### PR TITLE
MySQL Data Connector: add Spice run example output

### DIFF
--- a/mysql/connector/README.md
+++ b/mysql/connector/README.md
@@ -173,6 +173,19 @@ echo "MYSQL_PASS=<password>" > .env
 spice run
 ```
 
+Confirm in the terminal output the `sample_data` dataset has been loaded:
+
+```bash
+2025/01/13 11:52:51 INFO Spice.ai runtime starting...
+2025-01-13T19:52:51.473621Z  INFO runtime::init::dataset: Initializing dataset sample_data
+2025-01-13T19:52:51.474059Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
+2025-01-13T19:52:51.474795Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2025-01-13T19:52:51.474869Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2025-01-13T19:52:51.481201Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
+2025-01-13T19:52:51.491591Z  INFO runtime::init::dataset: Dataset sample_data registered (mysql:spice_demo.sample_data).
+2025-01-13T19:52:51.673260Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
+```
+
 Follow the [getting started guide](https://docs.spiceai.org/getting-started) to get started with the Spice.ai runtime.
 
 See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options.


### PR DESCRIPTION
## 🗣 Description

Add example output when starting Spice to confirm the dataset has been loaded

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
