### PR TITLE
Debezium CDC and SASL/SCRAM: update mysql connection string

### DIFF
--- a/cdc-debezium/sasl-scram/README.md
+++ b/cdc-debezium/sasl-scram/README.md
@@ -102,7 +102,7 @@ Now let's make some changes to the MySQL database and observe that Spice consume
 Stop the Spice SQL REPL or open a third terminal and connect to the MySQL database with `mysql`:
 
 ```bash
-mysql -h localhost -u root -p inventory -P 3306
+mysql -h 127.0.0.1 -u root -pdebezium inventory -P 3306
 ```
 
 ```sql


### PR DESCRIPTION
## 🗣 Description

- Password is `debezium`. 
- For some reason `localhost` does not work (`ERROR 2002 (HY000): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)`), only `127.0.0.1`

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
