### PR TITLE
Align commented out lines to prevent parsing error

### DIFF
--- a/search_github_files/spicepod.yaml
+++ b/search_github_files/spicepod.yaml
@@ -12,14 +12,14 @@ datasets:
       enabled: true
     columns:
       - name: content
-#        embeddings:
-#          - from: local_embedding_model
-#            row_id: path
-#            chunking:
-#              enabled: true
-#              target_chunk_size: 256
-#              overlap_size: 64
-#              file_format: md
+      #  embeddings:
+      #    - from: local_embedding_model
+      #      row_id: path
+      #      chunking:
+      #        enabled: true
+      #        target_chunk_size: 256
+      #        overlap_size: 64
+      #        file_format: md
 
 embeddings:
   - name: local_embedding_model

--- a/search_github_files/spicepod.yaml
+++ b/search_github_files/spicepod.yaml
@@ -12,14 +12,14 @@ datasets:
       enabled: true
     columns:
       - name: content
-        # embeddings:
-        #   - from: local_embedding_model
-        #     row_id: path
-        #     chunking:
-        #       enabled: true
-        #       target_chunk_size: 256
-        #       overlap_size: 64
-        #       file_format: md
+#        embeddings:
+#          - from: local_embedding_model
+#            row_id: path
+#            chunking:
+#              enabled: true
+#              target_chunk_size: 256
+#              overlap_size: 64
+#              file_format: md
 
 embeddings:
   - name: local_embedding_model


### PR DESCRIPTION
## 🗣 Description

In search_github_files cookbook, `embeddings` are commented out.
When user uncomment those [as guided in cookbook](https://github.com/spiceai/cookbook/tree/trunk/search_github_files#utilizing-vector-based-search) and run, parsing error arise as below.
```
WARN spiced: Unable to load spicepod .../cookbook/search_github_files: Unable to parse spicepod.yaml: mapping values are not allowed in this context at line 15 column 21
```

This PR aligns the lines as intended.