### PR TITLE
Fix broken tool call links in text-to-sql README

### DIFF
--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -13,7 +13,7 @@ This recipe will walk you through using Spice as a text to SQL interface.
 
 ## Steps
 
-Separate from using language models to interact with [runtime tools](https://docs.spiceai.org/features/ai-gateway/runtime_tools), `spice` has a standalone text to SQL endpoint. This provides more granular control of how SQL generation is done, and is more robust to hallucination and misuse of tools.
+Separate from using language models to interact with [runtime tools](https://spiceai.org/docs/components/tools), `spice` has a standalone text to SQL endpoint. This provides more granular control of how SQL generation is done, and is more robust to hallucination and misuse of tools.
 
 1. Start Spice
 
@@ -155,7 +155,7 @@ Result:
 }
 ```
 
-From this, you can see that `spice` runs the following [tools](https://docs.spiceai.org/features/ai-gateway/runtime_tools) to help the model write contextual, correct SQL:
+From this, you can see that `spice` runs the following [tools](https://spiceai.org/docs/components/tools) to help the model write contextual, correct SQL:
 
 - `table_schema`: To show the table schema of each relevant table.
 - Sample data from the relevant table(s), both:


### PR DESCRIPTION
## 🗣 Description

Updated two broken links in `text-to-sql/README.md` that pointed to `https://docs.spiceai.org/features/ai-gateway/runtime_tools`, which no longer exists. They now link to `https://spiceai.org/docs/components/tools`. Let me know if there's a more appropriate URL.

The cookbooks are awesome!

## 🔨 Related Issues

None

## 🤔 Concerns

None
