### PR TITLE
Improve clarity on which terminal to run spice runtime for dremio data conenctor recipe

### DIFF
--- a/dremio/README.md
+++ b/dremio/README.md
@@ -1,4 +1,3 @@
-
 # Dremio Data Connector
 
 The Dremio recipe uses a publicly accessible demo instance of Dremio loaded with sample datasets. Thus, setting up your own Dremio instance is not required to complete the recipe, but the same steps can be used to connect to any Dremio instance.
@@ -16,7 +15,7 @@ cd dremio-demo
 spice login dremio -u demo -p demo1234
 ```
 
-**Step 3.** Start the runtime.
+**Step 3.** In the same terminal window, start the runtime.
 
 ```bash
 spice run
@@ -102,6 +101,7 @@ Now query `taxi_trips`:
 ```sql
 select avg(total_amount), avg(tip_amount), count(1), passenger_count from taxi_trips group by passenger_count order by passenger_count asc;
 ```
+
 ```sql
 +------------------------------+----------------------------+-----------------+-----------------+
 | avg(taxi_trips.total_amount) | avg(taxi_trips.tip_amount) | count(Int64(1)) | passenger_count |
@@ -119,4 +119,4 @@ Time: 0.03241875 seconds. 7 rows.
 ```
 
 **Next Steps**
-This recipe accelerates query performance using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).  Experiment with different acceleration options by editing the dataset.yaml file or removing acceleration altogether to have the Spice runtime federate the query to Dremio directly.
+This recipe accelerates query performance using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators). Experiment with different acceleration options by editing the dataset.yaml file or removing acceleration altogether to have the Spice runtime federate the query to Dremio directly.


### PR DESCRIPTION
## 🗣 Description

Improve clarity on which terminal to run spice runtime for dremio data conenctor recipe

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
