### PR TITLE
Fix spice qa workflow to run timmy e2e and upload artifact

### DIFF
--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           curl https://install.spiceai.org | /bin/bash
-          echo "/home/runner/.spice/bin" >> $GITHUB_PATH
+          echo "~/.spice/bin" >> $GITHUB_PATH
 
       - name: Verify Spice Installation
         shell: bash

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -65,5 +65,5 @@ jobs:
       - name: Upload response file
         uses: actions/upload-artifact@v4
         with:
-          name: api-response-${recipe_file_path}
-          path: api_responses/${recipe_file_path}.json
+          name: api-response-${{ env.RECIPE_FILE_PATH }}
+          path: api_responses/${{ env.RECIPE_FILE_PATH }}.log

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -34,10 +34,16 @@ jobs:
         run: |
           curl https://install.spiceai.org | /bin/bash
           echo "/home/runner/.spice/bin" >> $GITHUB_PATH
+
       - name: Verify Spice Installation
         shell: bash
         run: |
           spice version
+
+      - name: Install Spice Runtime
+        shell: bash
+        run: |
+          spice install
 
       - name: Call Spice AI Completion API
         shell: bash

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -32,16 +32,10 @@ jobs:
           curl https://install.spiceai.org | /bin/bash
           echo "/home/runner/.spice/bin" >> $GITHUB_PATH
 
-      # - name: Install Spice Runtime
-      #   shell: bash
-      #   run: |
-      #     spice install
-
       - name: Verify Spice Installation
         shell: bash
         run: |
           spice version
-
 
       - name: Call Spice AI Completion API
         shell: bash
@@ -54,7 +48,7 @@ jobs:
 
           chat_input="Install Spice.ai OSS using the spiceai docs. Add it to the PATH. If it is already installed, run spice upgrade to upgrade it. Verify installation of version '${{ github.event.inputs.spice_version }}' by running the CLI command spice version. Use the '${{ matrix.recipe_name }}' Recipe to conduct testing. Ensure you execute all instructions in the recipe. Ensure you report on the spice sql query or spice chat results if the recipe includes them."
 
-          spice chat --http-endpoint https://data.spiceai.io --model timmy "$chat_input" > "$output_file" 2>&1
+          spice chat --cloud --http-endpoint https://data.spiceai.io --model timmy "$chat_input" > "$output_file" 2>&1
 
           # Output response for debugging
           echo "API Response saved to $output_file"

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -32,10 +32,10 @@ jobs:
           curl https://install.spiceai.org | /bin/bash
           echo "/home/runner/.spice/bin" >> $GITHUB_PATH
 
-      - name: Install Spice Runtime
-        shell: bash
-        run: |
-          spice install
+      # - name: Install Spice Runtime
+      #   shell: bash
+      #   run: |
+      #     spice install
 
       - name: Verify Spice Installation
         shell: bash

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -35,15 +35,16 @@ jobs:
           curl https://install.spiceai.org | /bin/bash
           echo "/home/runner/.spice/bin" >> $GITHUB_PATH
 
+      - name: Install Spice Runtime
+        shell: bash
+        run: |
+          spice install
+
       - name: Verify Spice Installation
         shell: bash
         run: |
           spice version
 
-      - name: Install Spice Runtime
-        shell: bash
-        run: |
-          spice install
 
       - name: Call Spice AI Completion API
         shell: bash

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Create output directory
         run: mkdir -p api_responses
 
-      - name: Install required tools
-        run: sudo apt-get update && sudo apt-get install -y expect
-
       - name: Install Spice
         shell: bash
         run: |

--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -26,47 +26,31 @@ jobs:
       - name: Create output directory
         run: mkdir -p api_responses
 
+      - name: Install required tools
+        run: sudo apt-get update && sudo apt-get install -y expect
+
+      - name: Install Spice
+        shell: bash
+        run: |
+          curl https://install.spiceai.org | /bin/bash
+          echo "/home/runner/.spice/bin" >> $GITHUB_PATH
+      - name: Verify Spice Installation
+        shell: bash
+        run: |
+          spice version
+
       - name: Call Spice AI Completion API
         shell: bash
         env:
-          SPICE_API_KEY: ${{ secrets.SPICE_API_KEY }}
+          SPICE_SPICEAI_API_KEY: ${{ secrets.SPICE_API_KEY }}
         run: |
           recipe_file_path="$(echo "${{ matrix.recipe_name }}" | tr '[:upper:]' '[:lower:]' | tr ' ' '_')"
-          output_file="api_responses/${recipe_file_path}.json"
+          echo "RECIPE_FILE_PATH=$recipe_file_path" >> $GITHUB_ENV
+          output_file="api_responses/${recipe_file_path}.log"
 
-          curl -s \
-            -H "Content-Type: application/json" \
-            -H "X-API-Key: $SPICE_API_KEY" \
-            -d '{
-              "model": "timmy",
-              "messages": [
-                {
-                  "role": "user",
-                  "content": "Install Spice.ai OSS using the spiceai docs. Add it to the PATH. If it is already installed, run spice upgrade to upgrade it. Verify installation of version ${{ github.event.inputs.spice_version }} by running the CLI command spice version. Use the ${{ toJson(matrix.recipe_name) }} Recipe to conduct testing. Ensure you execute all instructions in the recipe. Ensure you report on the spice sql query or spice chat results if the recipe includes them."
-                }
-              ],
-              "temperature": 0.1
-            }' \
-            https://data.spiceai.io/v1/chat/completions
+          chat_input="Install Spice.ai OSS using the spiceai docs. Add it to the PATH. If it is already installed, run spice upgrade to upgrade it. Verify installation of version '${{ github.event.inputs.spice_version }}' by running the CLI command spice version. Use the '${{ matrix.recipe_name }}' Recipe to conduct testing. Ensure you execute all instructions in the recipe. Ensure you report on the spice sql query or spice chat results if the recipe includes them."
 
-          # Call API
-          response=$(curl -s \
-            -H "Content-Type: application/json" \
-            -H "X-API-Key: $SPICE_API_KEY" \
-            -d '{
-              "model": "timmy",
-              "messages": [
-                {
-                  "role": "user",
-                  "content": "Install Spice.ai OSS using the spiceai docs. Add it to the PATH. If it is already installed, run spice upgrade to upgrade it. Verify installation of version ${{ github.event.inputs.spice_version }} by running the CLI command spice version. Use the ${{ toJson(matrix.recipe_name) }} Recipe to conduct testing. Ensure you execute all instructions in the recipe. Ensure you report on the spice sql query or spice chat results if the recipe includes them."
-                }
-              ],
-              "temperature": 0.1
-            }' \
-            https://data.spiceai.io/v1/chat/completions)
-
-          # Save the response to a file
-          echo "$response" > $output_file
+          spice chat --http-endpoint https://data.spiceai.io --model timmy "$chat_input" > "$output_file" 2>&1
 
           # Output response for debugging
           echo "API Response saved to $output_file"


### PR DESCRIPTION
## 🗣 Description

Enable spiceqa workflow to run e2e and upload artifact.

Use the `spice chat` cli command to get response from SCP timmy in spice qa workflow. Also fixed some bugs in passing down the environment vairables in the workflow.

Sample run can be seen from: https://github.com/spiceai/cookbook/actions/runs/14763261214

## 🔨 Related Issues

- Close: https://github.com/spiceai/cookbook/issues/114

## 🤔 Concerns

The matrix strategy will face the challenge of different recipes running in parallel within the same timmy sandbox, which will conflict with each other. Future recipes to be added should be running in a sequential manner, unless SCP supports different timmy sandboxes for different recipes.