### PR TITLE
Run cookbook recipe sequentially in spiceQA workflow

### DIFF
--- a/.github/workflows/spice-qa.yml
+++ b/.github/workflows/spice-qa.yml
@@ -15,9 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     strategy:
+      fail-fast: false
+      max-parallel: 1
       matrix:
         recipe_name:
           - 'File Data Connector'
+          - 'Dremio Data Connector'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## 🗣 Description

Add `Dremio Data Connector` cookbook recipe to SpiceQA, run multiple cookbook recipes sequentially and upload result as artifact.

View successful run from: https://github.com/spiceai/cookbook/actions/runs/14871821320

## 🔨 Related Issues

- Part of: https://github.com/spiceai/cookbook/issues/109

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
