### PR TITLE
Improve python ADBC cookbook

### DIFF
--- a/clients/adbc/main.py
+++ b/clients/adbc/main.py
@@ -3,6 +3,7 @@ from adbc_driver_flightsql.dbapi import connect
 
 with connect(
     "grpc://127.0.0.1:50051",
+     autocommit=True,
 ) as conn:
     with conn.cursor() as cur:
         cur.execute("""


### PR DESCRIPTION
## 🗣 Description

Fix the python script so that it doesn't give the following warning:
```python
/Users/qianqian/cookbook/clients/adbc/.venv/lib/python3.11/site-packages/adbc_driver_manager/dbapi.py:320: Warning: Cannot disable autocommit; conn will not be DB-API 2.0 compliant
  warnings.warn(
pyarrow.Table
AccountId: string
ServiceId: string
AddOnSid: string
AddOnTypeSid: string
AddOnJson: string
DateCreated: timestamp[s]
DateUpdated: timestamp[s]
----
AccountId: [["account123","account789","account456"]]
ServiceId: [["service789","service789","service789"]]
AddOnSid: [["addon3","addon7","addon10"]]
AddOnTypeSid: [["type123","type123","type789"]]
AddOnJson: [["{\feature\":\"voice_integration\"}"","{\feature\":\"voice_integration\"}"","{\feature\":\"mms_support\"}""]]
DateCreated: [[2025-04-03 15:45:00,2025-04-07 11:30:00,2025-04-10 09:45:00]]
DateUpdated: [[2025-04-03 15:45:00,2025-04-07 11:30:00,2025-04-10 09:45:00]]
```

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
