### PR TITLE
Update go client sdk cookbook

### DIFF
--- a/client-sdk/gospice-sdk-sample/README.md
+++ b/client-sdk/gospice-sdk-sample/README.md
@@ -31,13 +31,13 @@ Output:
 ## Run sample application
 
 ```shell
-go run .
+go run main.go
 ```
 
 Results:
 
 ```shell
-go run .
+go run main.go
 VendorID: 2
 tpep_pickup_datetime: 1705115889000000
 fare_amount: 11.4


### PR DESCRIPTION
## 🗣 Description

Go cookbook now includes a second file that has main() for querying against the spice cloud instance (main_cloud.go) and `go run .` will fail due to redeclaration of main function. Update the command so it runs the main.go against local spice instance.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
