### PR TITLE
Spark: prevent Spark Connect Server to take all available cores

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -66,7 +66,7 @@ cd cookbook/spark
   spark  | Spark services started! ✅
   ```
 
-2. Initialise a Spice app
+2. Initialize a Spice app
 
   ```shell
   spice init spark_demo

--- a/spark/spark-3.5/spark/spark-defaults.conf
+++ b/spark/spark-3.5/spark/spark-defaults.conf
@@ -28,6 +28,8 @@ spark.connect.grpc.binding.address  0.0.0.0
 spark.sql.hive.metastore.version    2.3.9
 spark.sql.hive.metastore.jars       builtin
 spark.driver.memory                 6g
+spark.executor.cores                4
+spark.cores.max                     8
 
 spark.hadoop.javax.jdo.option.ConnectionURL jdbc:derby:;databaseName=/home/spark/metastore/metastore_db;create=true
 spark.hadoop.javax.jdo.option.ConnectionDriverName org.apache.derby.jdbc.EmbeddedDriver

--- a/spark/spark-4/spark/spark-defaults.conf
+++ b/spark/spark-4/spark/spark-defaults.conf
@@ -28,6 +28,8 @@ spark.connect.grpc.binding.address  0.0.0.0
 spark.sql.hive.metastore.version    2.3.10
 spark.sql.hive.metastore.jars       builtin
 spark.driver.memory                 6g
+spark.executor.cores                4
+spark.cores.max                     8
 
 spark.hadoop.javax.jdo.option.ConnectionURL jdbc:derby:;databaseName=/home/spark/metastore/metastore_db;create=true
 spark.hadoop.javax.jdo.option.ConnectionDriverName org.apache.derby.jdbc.EmbeddedDriver


### PR DESCRIPTION
## 🗣 Description

Ensure there are available cores to process NYC Taxi Data by preventing the Spark Connect Server from occupying all available cores, ensuring that NYC Taxi Data can complete successfully.

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
