### PR TITLE
Add limit to GitHub dataset in Search GitHub files cookbook recipe

### DIFF
--- a/search_github_files/spicepod.yaml
+++ b/search_github_files/spicepod.yaml
@@ -27,6 +27,7 @@ datasets:
   #     github_token: ${secrets:GITHUB_TOKEN}
   #   acceleration:
   #     enabled: true
+  #     refresh_sql: SELECT * FROM doc.pulls LIMIT 300
   #   columns:
   #     - name: title
   #       full_text_search:


### PR DESCRIPTION
## 🗣 Description
- Limit the number of entries in the `doc.pulls` dataset in the Search GitHub Files cookbook recipe to 300
- Prevents rate limiting, loads significantly faster too

