### PR TITLE
Minor fixes for postgres/iceberg-hadoop/text-to-sql cookbooks

### DIFF
--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -11,10 +11,15 @@ This recipe uses the Spice Runtime to connect to a TPCH dataset, configured on a
 
 ## Step 1: Start the MinIO Server
 
+Clone the Spice samples repository and navigate to the iceberg-hadoop directory:
+```bash
+git clone https://github.com/spiceai/cookbook.git
+cd cookbook/catalogs/iceberg-hadoop
+```
+
 Use the provided Docker Compose file to start a MinIO server, which sets up with a TPCH dataset:
 
 ```bash
-cd catalogs/iceberg-hadoop
 docker compose up -d
 ```
 

--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -9,7 +9,7 @@ This recipe uses the Spice Runtime to connect to a TPCH dataset, configured on a
 - Docker is installed, to run the sample MinIO object store service with Hadoop catalog.
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 
-## Step 1: Start the MinIO Server
+## Step 1: Start the MinIO Server.
 
 Clone the Spice cookbook repository and navigate to the `iceberg-hadoop` directory:
 ```bash
@@ -23,7 +23,7 @@ Use the provided Docker Compose file to start a MinIO server, which sets up with
 docker compose up -d
 ```
 
-## Step 2: Start the Spice Runtime
+## Step 2: Start the Spice Runtime.
 
 Once Docker has finished starting, enter into the provided spicepod directory and start the Spice Runtime:
 
@@ -46,7 +46,7 @@ The Runtime should start and register the TPCH catalog. Example output:
 2025-08-07T02:51:44.453020Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
-## Step 3: Query the Hadoop Catalog
+## Step 3: Query the Hadoop Catalog.
 
 In a new terminal, run the Spice SQL REPL and execute an SQL command to read TPCH data from the Hadoop catalog:
 
@@ -72,7 +72,7 @@ Example output:
 +-------------+-------------+---------------------------------------------------------------------------------------------------------------------+
 ```
 
-## Step 4: Cleanup
+## Step 4: Cleanup.
 
 ```bash
 docker-compose down

--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -11,9 +11,9 @@ This recipe uses the Spice Runtime to connect to a TPCH dataset, configured on a
 
 ## Step 1: Start the MinIO Server
 
-Clone the Spice samples repository and navigate to the iceberg-hadoop directory:
+Clone the Spice cookbook repository and navigate to the iceberg-hadoop directory:
 ```bash
-git clone https://github.com/spiceai/cookbook.git
+git clone https://github.com/spiceai/cookbook.git # Skip if already cloned
 cd cookbook/catalogs/iceberg-hadoop
 ```
 

--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -71,3 +71,9 @@ Example output:
 | 4           | MIDDLE EAST |  foxes boost furiously along the carefully dogged tithes. slyly regular orbits according to the special epit        |
 +-------------+-------------+---------------------------------------------------------------------------------------------------------------------+
 ```
+
+## Step 4: Cleanup
+
+```bash
+docker-compose down
+```

--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -11,7 +11,7 @@ This recipe uses the Spice Runtime to connect to a TPCH dataset, configured on a
 
 ## Step 1: Start the MinIO Server
 
-Clone the Spice cookbook repository and navigate to the iceberg-hadoop directory:
+Clone the Spice cookbook repository and navigate to the `iceberg-hadoop` directory:
 ```bash
 git clone https://github.com/spiceai/cookbook.git # Skip if already cloned
 cd cookbook/catalogs/iceberg-hadoop

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -141,7 +141,7 @@ datasets:
 
 Ensure that the `pg_pass` connector parameter is only set when `pg_user` used in spicepod requires a password.
 
-## Step 4: Start the Spice runtime
+## Step 4: Start the Spice runtime.
 
 ```bash
 spice run

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -187,7 +187,6 @@ show tables;
 | table_catalog | table_schema | table_name   | table_type |
 +---------------+--------------+--------------+------------+
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 | spice         | public       | sample_data  | BASE TABLE |
 +---------------+--------------+--------------+------------+
 

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -13,9 +13,7 @@ psql --help
 
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 
-## Steps
-
-**Step 1.** Create a sample Postgres database and generate a testing table using stored procedure.
+## Step 1: Create a sample Postgres database and generate a testing table using stored procedure.
 
 - Start postgres server (note: this is an insecure postgres, only use for testing).
 
@@ -121,14 +119,16 @@ DROP PROCEDURE sample_data_gen();
 ```
 
 
-**Step 2.** Initialize a Spice app.
+## Step 2: Initialize a Spice app.
 
 ```bash
 spice init postgres-connector-demo
 cd postgres-connector-demo
 ```
 
-**Step 3.** Configure the dataset to connect to Postgres. Copy and paste the configuration below to `spicepod.yaml` in the Spice app.
+## Step 3: Configure the dataset to connect to Postgres. 
+
+Copy and paste the configuration below to `spicepod.yaml` in the Spice app.
 
 ```yaml
 version: v1
@@ -147,7 +147,7 @@ datasets:
 
 Ensure that the `pg_pass` connector parameter is only set when `pg_user` used in spicepod requires a password.
 
-**Step 4.** Start the Spice runtime
+## Step 4: Start the Spice runtime
 
 ```bash
 spice run
@@ -169,7 +169,7 @@ Follow the [getting started guide](https://docs.spiceai.org/getting-started) to 
 
 See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options.
 
-**Step 5.** Run queries against the dataset using the Spice SQL REPL.
+# Step 5: Run queries against the dataset using the Spice SQL REPL.
 
 In a new terminal, start the Spice SQL REPL
 
@@ -218,3 +218,9 @@ Time: 0.017579583 seconds. 10 rows.
 ```
 
 For more information on using `spice sql`, see the [CLI reference](https://docs.spiceai.org/cli/reference/sql).
+
+## Step 6: Cleanup
+
+```bash
+docker rm -f postgres
+```

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -4,13 +4,7 @@ This recipe will use a demo instance of Postgres with a dataset generated using 
 
 ## Pre-requisites
 
-- Install [PostgresSQL](https://www.postgresql.org/download/). Once downloaded and installed, run the following commands:
-
-```bash
-createdb --help
-psql --help
-```
-
+- [Docker](https://docs.docker.com/get-docker/) is installed
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 
 ## Step 1: Create a sample Postgres database and generate a testing table using stored procedure.

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -145,7 +145,7 @@ datasets:
       pg_user: postgres
 ```
 
-Ensure that the `pg_pass` connctor parameter is only set when `pg_user` used in spicepod requires a password.
+Ensure that the `pg_pass` connector parameter is only set when `pg_user` used in spicepod requires a password.
 
 **Step 4.** Start the Spice runtime
 

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -9,7 +9,7 @@ Ensure you have the Spice CLI installed. Follow the [Getting Started](https://do
 Clone the Spice samples repository and navigate to the `text-to-sql` directory:
 
 ```bash
-git clone https://github.com/spiceai/cookbook.git
+git clone https://github.com/spiceai/cookbook.git  # Skip if already cloned
 cd cookbook/text-to-sql
 ```
 

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -24,13 +24,13 @@ cd cookbook/text-to-sql
 
 Separate from using language models to interact with [runtime tools](https://spiceai.org/docs/components/tools), `spice` has a standalone text to SQL endpoint. This provides more granular control of how SQL generation is done, and is more robust to hallucination and misuse of tools.
 
-## Step 1: Start Spice
+## Step 1: Start Spice.
 
 ```bash
 spice run
 ```
 
-## Step 2: Call the dedicated text-to-sql endpoint
+## Step 2: Call the dedicated text-to-sql endpoint.
 
 ```shell
 curl -XPOST "http://localhost:8090/v1/nsql" \

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -4,9 +4,18 @@ This recipe will walk you through using Spice as a text to SQL interface.
 
 ## Prerequisites
 
-- Ensure you have the Spice CLI installed. Follow the [Getting Started](https://docs.spiceai.org/getting-started) if you haven't done so.
+Ensure you have the Spice CLI installed. Follow the [Getting Started](https://docs.spiceai.org/getting-started) if you haven't done so.
+
+Clone the Spice samples repository and navigate to the `text-to-sql` directory:
+
+```bash
+git clone https://github.com/spiceai/cookbook.git
+cd cookbook/text-to-sql
+```
+
 - Populate `.env`.
   - `SPICE_OPENAI_API_KEY`: A valid OpenAI API key (or equivalent).
+
 - Install `jq` from [here](https://jqlang.github.io/jq/download/)
   - Or `brew install jq` for MacOS.
   - Or `sudo apt-get install jq` for Linux.

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -5,7 +5,7 @@ This recipe will walk you through using Spice as a text to SQL interface.
 ## Prerequisites
 
 Ensure you have the Spice CLI installed. Follow the [Getting Started](https://docs.spiceai.org/getting-started) if you haven't done so.
-
+  
 Clone the Spice cookbook repository and navigate to the `text-to-sql` directory:
 
 ```bash
@@ -24,13 +24,13 @@ cd cookbook/text-to-sql
 
 Separate from using language models to interact with [runtime tools](https://spiceai.org/docs/components/tools), `spice` has a standalone text to SQL endpoint. This provides more granular control of how SQL generation is done, and is more robust to hallucination and misuse of tools.
 
-1. Start Spice
+## Step 1: Start Spice
 
 ```bash
 spice run
 ```
 
-2. Call the dedicated text-to-sql endpoint
+## Step 2: Call the dedicated text-to-sql endpoint
 
 ```shell
 curl -XPOST "http://localhost:8090/v1/nsql" \
@@ -59,7 +59,7 @@ Result:
 ]
 ```
 
-3. Inspect the tools used.
+## Step 3: Inspect the tools used.
 
 ```shell
 spice trace nsql --include-input --truncate=40

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -6,7 +6,7 @@ This recipe will walk you through using Spice as a text to SQL interface.
 
 Ensure you have the Spice CLI installed. Follow the [Getting Started](https://docs.spiceai.org/getting-started) if you haven't done so.
 
-Clone the Spice samples repository and navigate to the `text-to-sql` directory:
+Clone the Spice cookbook repository and navigate to the `text-to-sql` directory:
 
 ```bash
 git clone https://github.com/spiceai/cookbook.git  # Skip if already cloned


### PR DESCRIPTION
Postgres fixes:
* `connctor` -> `connector`
* Simplified Pre-requisites
* Removed `metrics` dataset from listed datasets as it is no longer displayed
* Used header for step-X sections
* * Added docker cleanup

Iceberg-hadoop catalog fix:
* Added command to clone cookbook repo
* Added docker cleanup

to-to-sql fix:
* Add command to clone cookbook repo
* Used header for step-X sections


