### PR TITLE
Spark cookbook configuration fix

### DIFF
--- a/spark/spark-3.5/spark/spark-defaults.conf
+++ b/spark/spark-3.5/spark/spark-defaults.conf
@@ -20,8 +20,7 @@
 
 spark.sql.catalogImplementation     hive
 spark.sql.warehouse.dir             /home/spark/warehouse
-spark.sql.catalogImplementation     in-memory
-spark.sql.defaultCatalog           spark_catalog
+spark.sql.defaultCatalog            spark_catalog
 spark.connect.grpc.binding.port     15002
 spark.connect.grpc.arrow.enabled    true
 spark.connect.grpc.binding.address  0.0.0.0

--- a/spark/spark-4/spark/spark-defaults.conf
+++ b/spark/spark-4/spark/spark-defaults.conf
@@ -20,8 +20,7 @@
 
 spark.sql.catalogImplementation     hive
 spark.sql.warehouse.dir             /home/spark/warehouse
-spark.sql.catalogImplementation     in-memory
-spark.sql.defaultCatalog           spark_catalog
+spark.sql.defaultCatalog            spark_catalog
 spark.connect.grpc.binding.port     15002
 spark.connect.grpc.arrow.enabled    true
 spark.connect.grpc.binding.address  0.0.0.0


### PR DESCRIPTION
## 🗣 Description

See diff: looks like Spark was confused as to which catalog to use. Removing `in-memory` fixes the issues with empty catalog on read.
