### PR TITLE
Pin to Python 3.13 for Iceberg catalog cookbook

### DIFF
--- a/catalogs/iceberg/iceberg-init/pyproject.toml
+++ b/catalogs/iceberg/iceberg-init/pyproject.toml
@@ -3,7 +3,7 @@ name = "iceberg-init"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 dependencies = [
     "pyarrow==20.0.0",
     "pyiceberg==0.9.1",

--- a/catalogs/iceberg/iceberg-init/uv.lock
+++ b/catalogs/iceberg/iceberg-init/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13"
+requires-python = ">=3.13,<3.14"
 
 [[package]]
 name = "annotated-types"


### PR DESCRIPTION
## 🗣 Description

Python 3.14 was just released, and the binary wheels for Arrow haven't been published yet. Once they are we can relax this restriction