### PR TITLE
Change the Grafana datasource cookbook to use local Spice

### DIFF
--- a/grafana-datasource/README.md
+++ b/grafana-datasource/README.md
@@ -6,6 +6,8 @@ This recipe will show how to configure a Grafana dashboard to use Spice as the d
 
 This recipe requires [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) to be installed.
 
+Install [`spice`](https://docs.spiceai.org/getting-started) locally so you can run the Spice runtime on your machine.
+
 ## Running the recipe
 
 Clone the `spiceai/cookbook` repository and navigate to the `grafana-datasource` directory:
@@ -15,11 +17,17 @@ git clone https://github.com/spiceai/cookbook.git
 cd cookbook/grafana-datasource
 ```
 
-Run the following command to start the components in the Docker Compose file:
+In one terminal, run the Spice runtime locally from this directory:
+
+```bash
+spice run
+```
+
+Spice will load the datasets defined in `spicepod.yaml` and listen on `localhost:8090`.
+
+Open a second terminal and run the following command to start Grafana in Docker:
 
 `make`
-
-This will start the Spice runtime and Grafana server. The Spice runtime will load two datasets based on the parquet file in S3.
 
 ### Setup with Infinity Grafana plugin
 
@@ -36,7 +44,7 @@ This will start the Spice runtime and Grafana server. The Spice runtime will loa
    ![screenshot](./img/grafana-datasource-8.png)
 
 1. Click on "Build a dashboard" and add a new visualization. Select "Infinity" from the list of data sources.
- - Change "Method" to "POST" and "URL" to `http://spice:8090/v1/sql`.
+ - Change "Method" to "POST" and "URL" to `http://localhost:8090/v1/sql`.
  - Add SQL query in body, using "Raw" mode:
 
    ```sql
@@ -48,6 +56,8 @@ This will start the Spice runtime and Grafana server. The Spice runtime will loa
 ![screenshot](./img/grafana-datasource-9.png)
 
 ## Clean up
+
+Press `Ctrl+C` in the terminal running `spice run` to stop the Spice runtime.
 
 To stop and remove the Docker containers/volumes that were created, run:
 

--- a/grafana-datasource/compose.yaml
+++ b/grafana-datasource/compose.yaml
@@ -1,17 +1,5 @@
 services:
-  spice:
-    image: spiceai/spiceai
-    container_name: spice
-    ports:
-      - "8090:8090"
-      - "50051:50051"
-    working_dir: /app
-    volumes:
-      - ./spicepod.yaml:/app/spicepod.yaml
-    command: ["--http", "0.0.0.0:8090", "--flight", "0.0.0.0:50051"]
-
   grafana:
     image: grafana/grafana-enterprise
     container_name: grafana
-    ports:
-      - "3000:3000"
+    network_mode: host


### PR DESCRIPTION
## 🗣 Description

Reworks the Grafana Datasource cookbook so that the user runs Spice locally and the Grafana connects to that running Spice instance intead of pulling from the last Docker image
