### PR TITLE
Add Fedora equivalents for install instructions

### DIFF
--- a/odbc/README.md
+++ b/odbc/README.md
@@ -20,6 +20,12 @@ On Unix, this requires cloning and compiling the SQLite ODBC driver project. Fir
 sudo apt-get install unixodbc odbcinst sqlite3 libsqlite3-dev
 ```
 
+On Fedora, install the equivalent dependencies:
+
+```bash
+sudo dnf install unixODBC unixODBC-devel sqlite sqlite-devel
+```
+
 Then, clone and compile the SQLite ODBC driver:
 
 ```bash

--- a/text-to-sql/README.md
+++ b/text-to-sql/README.md
@@ -37,7 +37,8 @@ SPICE_OPENAI_API_KEY=your_openai_api_key_here
 
 - **Install `jq`** (for pretty-printing JSON):
   - macOS: `brew install jq`
-  - Linux: `sudo apt-get install jq`
+  - Ubuntu/Debian: `sudo apt-get install jq`
+  - Fedora: `sudo dnf install jq`
   - Other platforms: [jqlang.github.io/jq/download](https://jqlang.github.io/jq/download/)
 
 ## Background

--- a/tls/README.md
+++ b/tls/README.md
@@ -9,6 +9,7 @@ First a CA (Certificate Authority) will be created with OpenSSL. Then, certifica
 - OpenSSL
   - macOS: `brew install openssl`
   - Ubuntu: `sudo apt-get install openssl`
+  - Fedora: `sudo dnf install openssl`
   - Windows: [Download OpenSSL](https://slproweb.com/products/Win32OpenSSL.html)
 - Spice.ai runtime
   - [Install Spice.ai](https://docs.spiceai.org/installation)
@@ -86,6 +87,16 @@ Set the owner to the UID `999` and GID `999`, which [match the UID and GID of th
 ```bash
 sudo chown 999:999 postgres.key
 sudo chmod 600 postgres.key
+```
+
+## Fedora: Change key file owner, permissions, and SELinux context
+
+On Fedora, update permissions and SELinux context so the `postgres` Docker instance can read the key.
+
+```bash
+sudo chown 999:999 postgres.key
+sudo chmod 600 postgres.key
+sudo chcon -Rt svirt_sandbox_file_t postgres.key
 ```
 
 ### Start `postgres`


### PR DESCRIPTION
## Summary
- add Fedora dnf install guidance alongside Ubuntu instructions in TLS doc
- add Fedora install steps for jq in text-to-sql recipe
- add Fedora build dependencies for SQLite ODBC in ODBC connector guide
