### PR TITLE
Update gospice recipe to use v8.0.1

### DIFF
--- a/client-sdk/gospice-sdk-sample/README.md
+++ b/client-sdk/gospice-sdk-sample/README.md
@@ -44,35 +44,22 @@ go run main.go
 Results:
 
 ```shell
-go run main.go
-VendorID: 2
-tpep_pickup_datetime: 1705115889000000
-fare_amount: 11.4
-VendorID: 2
-tpep_pickup_datetime: 1705117978000000
-fare_amount: 13.5
-VendorID: 2
-tpep_pickup_datetime: 1705116362000000
-fare_amount: 11.4
-VendorID: 2
-tpep_pickup_datetime: 1705118024000000
-fare_amount: 27.5
-VendorID: 2
-tpep_pickup_datetime: 1705114708000000
-fare_amount: 18.4
-VendorID: 2
-tpep_pickup_datetime: 1705118064000000
-fare_amount: 14.2
-VendorID: 2
-tpep_pickup_datetime: 1705115215000000
-fare_amount: 88.1
-VendorID: 2
-tpep_pickup_datetime: 1705116146000000
-fare_amount: 10
-VendorID: 2
-tpep_pickup_datetime: 1705116079000000
-fare_amount: 28.9
-VendorID: 1
-tpep_pickup_datetime: 1705115615000000
-fare_amount: 35.2
+=== Using Sql ===
+VendorID: 2, tpep_pickup_datetime: 1706465757000000, fare_amount: 15.6
+VendorID: 2, tpep_pickup_datetime: 1706466833000000, fare_amount: 14.2
+VendorID: 2, tpep_pickup_datetime: 1706465786000000, fare_amount: 7.9
+VendorID: 1, tpep_pickup_datetime: 1706464867000000, fare_amount: 14.2
+VendorID: 1, tpep_pickup_datetime: 1706466244000000, fare_amount: 15.6
+VendorID: 1, tpep_pickup_datetime: 1706467652000000, fare_amount: 33.1
+VendorID: 1, tpep_pickup_datetime: 1706465767000000, fare_amount: 7.2
+VendorID: 1, tpep_pickup_datetime: 1706466975000000, fare_amount: 46.4
+VendorID: 1, tpep_pickup_datetime: 1706464846000000, fare_amount: 17
+VendorID: 1, tpep_pickup_datetime: 1706467147000000, fare_amount: 9.3
+
+=== Using SqlWithParams ===
+VendorID: 2, tpep_pickup_datetime: 1706252166000000, fare_amount: 19.1
+VendorID: 2, tpep_pickup_datetime: 1706251687000000, fare_amount: 70
+VendorID: 1, tpep_pickup_datetime: 1706250595000000, fare_amount: 20.5
+VendorID: 1, tpep_pickup_datetime: 1706250222000000, fare_amount: 10.7
+VendorID: 2, tpep_pickup_datetime: 1706249286000000, fare_amount: 70
 ```

--- a/client-sdk/gospice-sdk-sample/go.mod
+++ b/client-sdk/gospice-sdk-sample/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	github.com/apache/arrow-go/v18 v18.4.1
-	github.com/spiceai/gospice/v8 v8.0.0
+	github.com/spiceai/gospice/v8 v8.0.1
 )
 
 require (

--- a/client-sdk/gospice-sdk-sample/go.sum
+++ b/client-sdk/gospice-sdk-sample/go.sum
@@ -59,8 +59,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
-github.com/spiceai/gospice/v8 v8.0.0 h1:aKUfdEvvzZ6yVXxCOlQA774QhiPcjY3VnOAAXXAANRI=
-github.com/spiceai/gospice/v8 v8.0.0/go.mod h1:OAEO1UpEk4BLyyz8q8/HKi90Rn6O1/oRx1Yaf4bPWBc=
+github.com/spiceai/gospice/v8 v8.0.1 h1:baLvjfs7hoTiYqHCT+bMfWPcD5DsWiCwt5nRJhRlRKA=
+github.com/spiceai/gospice/v8 v8.0.1/go.mod h1:OAEO1UpEk4BLyyz8q8/HKi90Rn6O1/oRx1Yaf4bPWBc=
 github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/client-sdk/gospice-sdk-sample/main.go
+++ b/client-sdk/gospice-sdk-sample/main.go
@@ -12,8 +12,18 @@ func main() {
 	spice := gospice.NewSpiceClient()
 	defer spice.Close()
 
-	spice.Init()
+	if err := spice.Init(); err != nil {
+		panic(fmt.Errorf("error initializing: %w", err))
+	}
 
+	fmt.Println("=== Using Sql ===")
+	queryWithSql(spice)
+
+	fmt.Println("\n=== Using SqlWithParams ===")
+	queryWithSqlParams(spice, 5)
+}
+
+func queryWithSql(spice *gospice.SpiceClient) {
 	reader, err := spice.Sql(
 		context.Background(),
 		"SELECT \"VendorID\", \"tpep_pickup_datetime\", \"fare_amount\" FROM taxi_trips LIMIT 10",
@@ -39,9 +49,53 @@ func main() {
 		numRows := int(record.NumRows())
 
 		for i := 0; i < numRows; i++ {
-			fmt.Printf("VendorID: %v\n", col0.(*array.Int32).Value(i))
-			fmt.Printf("tpep_pickup_datetime: %v\n", col1.(*array.Timestamp).Value(i))
-			fmt.Printf("fare_amount: %v\n", col2.(*array.Float64).Value(i))
+			fmt.Printf("VendorID: %v, tpep_pickup_datetime: %v, fare_amount: %v\n",
+				col0.(*array.Int32).Value(i),
+				col1.(*array.Timestamp).Value(i),
+				col2.(*array.Float64).Value(i))
 		}
+	}
+
+	if err := reader.Err(); err != nil {
+		panic(fmt.Errorf("error reading: %w", err))
+	}
+}
+
+func queryWithSqlParams(spice *gospice.SpiceClient, limit int) {
+	reader, err := spice.SqlWithParams(
+		context.Background(),
+		"SELECT \"VendorID\", \"tpep_pickup_datetime\", \"fare_amount\" FROM taxi_trips LIMIT ?",
+		limit,
+	)
+	if err != nil {
+		panic(fmt.Errorf("error querying: %w", err))
+	}
+	defer reader.Release()
+
+	for reader.Next() {
+		record := reader.Record()
+		defer record.Release()
+
+		col0 := record.Column(0)
+		defer col0.Release()
+
+		col1 := record.Column(1)
+		defer col1.Release()
+
+		col2 := record.Column(2)
+		defer col2.Release()
+
+		numRows := int(record.NumRows())
+
+		for i := 0; i < numRows; i++ {
+			fmt.Printf("VendorID: %v, tpep_pickup_datetime: %v, fare_amount: %v\n",
+				col0.(*array.Int32).Value(i),
+				col1.(*array.Timestamp).Value(i),
+				col2.(*array.Float64).Value(i))
+		}
+	}
+
+	if err := reader.Err(); err != nil {
+		panic(fmt.Errorf("error reading: %w", err))
 	}
 }


### PR DESCRIPTION
## 🗣 Description

This pull request updates the sample Go client to demonstrate both SQL and parameterized SQL queries with improved error handling and output formatting. The main changes include upgrading the `gospice` dependency, restructuring the main function to clearly separate query types, and refactoring output for clarity.

**Dependency update:**

* Upgraded the `github.com/spiceai/gospice/v8` dependency from version `8.0.0` to `8.0.1` in `go.mod`.

**Code improvements and refactoring:**

* Enhanced error handling in the `main` function by checking the result of `spice.Init()` and panicking with a descriptive error if initialization fails.
* Refactored query logic into two separate functions: `queryWithSql` and `queryWithSqlParams`, making the code easier to read and maintain. [[1]](diffhunk://#diff-c2b91e12fa893fea3df15a09ab5f4afe6e83c5b7c1c0a620053d32b914d49ae0L15-R26) [[2]](diffhunk://#diff-c2b91e12fa893fea3df15a09ab5f4afe6e83c5b7c1c0a620053d32b914d49ae0L42-R99)
* Improved output formatting by printing all relevant fields on a single line for each record, and clearly labeling results from each query type. [[1]](diffhunk://#diff-c2b91e12fa893fea3df15a09ab5f4afe6e83c5b7c1c0a620053d32b914d49ae0L42-R99) [[2]](diffhunk://#diff-79f47919d81508a2d2a3ffc4f33aa40558f05d9dd742985de0372dd0c5c9fae5L47-R64)

**Documentation update:**

* Updated the example output in `README.md` to reflect the new output format and the addition of results from both SQL and parameterized SQL queries.
