### PR TITLE
Improve SpiceQA output reliability

### DIFF
--- a/.github/actions/parse-llm-test-result/action.yml
+++ b/.github/actions/parse-llm-test-result/action.yml
@@ -1,0 +1,176 @@
+name: 'Parse LLM Test Result'
+description: 'Parses LLM output to determine test pass/fail status with robust pattern matching'
+
+inputs:
+  output_file:
+    description: 'Path to the file containing LLM output'
+    required: true
+  debug:
+    description: 'Enable debug output'
+    required: false
+    default: 'true'
+
+outputs:
+  result:
+    description: 'Test result: passed, failed, or error'
+    value: ${{ steps.parse.outputs.result }}
+  reason:
+    description: 'Reason for failure (if applicable)'
+    value: ${{ steps.parse.outputs.reason }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Parse test result
+      id: parse
+      shell: bash
+      env:
+        OUTPUT_FILE: ${{ inputs.output_file }}
+        DEBUG: ${{ inputs.debug }}
+      run: |
+        if [ ! -f "$OUTPUT_FILE" ]; then
+          echo "::error::Output file not found: $OUTPUT_FILE"
+          echo "result=error" >> $GITHUB_OUTPUT
+          echo "reason=Output file not found" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Get file size for sanity check
+        FILE_SIZE=$(wc -c < "$OUTPUT_FILE" | tr -d ' ')
+        if [ "$FILE_SIZE" -lt 10 ]; then
+          echo "::error::Output file is too small ($FILE_SIZE bytes) - likely empty or truncated"
+          echo "result=error" >> $GITHUB_OUTPUT
+          echo "reason=Output file too small or empty" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        # Normalize output for reliable matching (lowercase, remove extra whitespace)
+        NORMALIZED_OUTPUT=$(cat "$OUTPUT_FILE" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+
+        # Also get just the last 50 lines for focused matching (LLM typically puts result at end)
+        TAIL_OUTPUT=$(tail -50 "$OUTPUT_FILE" | tr '[:upper:]' '[:lower:]' | tr -s '[:space:]' ' ')
+
+        # === FAIL PATTERNS (check first - fail takes priority) ===
+        # These patterns indicate test failure
+        FAIL_PATTERNS=(
+          "test failed"
+          "tests failed"
+          "test failure"
+          "test unsuccessful"
+          "failed test"
+          "failure:"
+          "❌"
+        )
+
+        # === PASS PATTERNS ===
+        # These patterns indicate test success
+        PASS_PATTERNS=(
+          "test passed"
+          "tests passed"
+          "test successful"
+          "test succeeded"
+          "all tests pass"
+          "passed test"
+          "✅"
+        )
+
+        # === ERROR/INCONCLUSIVE PATTERNS ===
+        # These indicate the test couldn't complete properly
+        ERROR_PATTERNS=(
+          "could not complete"
+          "unable to determine"
+          "test inconclusive"
+          "timed out"
+          "timeout"
+        )
+
+        RESULT=""
+        REASON=""
+
+        # Check for explicit fail patterns in the tail (most relevant)
+        for pattern in "${FAIL_PATTERNS[@]}"; do
+          if echo "$TAIL_OUTPUT" | grep -qi "$pattern"; then
+            RESULT="failed"
+            # Try to extract the reason after "failed:" or similar
+            REASON=$(echo "$TAIL_OUTPUT" | grep -oi "failed[: ]*[^.]*" | tail -1 || echo "Test failed")
+            break
+          fi
+        done
+
+        # If no fail found, check for error patterns
+        if [ -z "$RESULT" ]; then
+          for pattern in "${ERROR_PATTERNS[@]}"; do
+            if echo "$TAIL_OUTPUT" | grep -qi "$pattern"; then
+              RESULT="error"
+              REASON="Test inconclusive or timed out"
+              break
+            fi
+          done
+        fi
+
+        # If no fail/error found, check for pass patterns
+        if [ -z "$RESULT" ]; then
+          for pattern in "${PASS_PATTERNS[@]}"; do
+            if echo "$TAIL_OUTPUT" | grep -qi "$pattern"; then
+              RESULT="passed"
+              REASON=""
+              break
+            fi
+          done
+        fi
+
+        # If still no result, check the full output as fallback
+        if [ -z "$RESULT" ]; then
+          for pattern in "${FAIL_PATTERNS[@]}"; do
+            if echo "$NORMALIZED_OUTPUT" | grep -qi "$pattern"; then
+              RESULT="failed"
+              REASON="Test failed (detected in full output)"
+              break
+            fi
+          done
+        fi
+
+        if [ -z "$RESULT" ]; then
+          for pattern in "${PASS_PATTERNS[@]}"; do
+            if echo "$NORMALIZED_OUTPUT" | grep -qi "$pattern"; then
+              RESULT="passed"
+              REASON=""
+              break
+            fi
+          done
+        fi
+
+        # Default to error if we couldn't determine result
+        if [ -z "$RESULT" ]; then
+          RESULT="error"
+          REASON="Could not determine test result from LLM output"
+        fi
+
+        # Output results
+        echo "result=$RESULT" >> $GITHUB_OUTPUT
+        echo "reason=$REASON" >> $GITHUB_OUTPUT
+
+        # Debug output
+        if [ "$DEBUG" = "true" ]; then
+          echo "--- Parse LLM Test Result Debug ---"
+          echo "File size: $FILE_SIZE bytes"
+          echo "Result: $RESULT"
+          echo "Reason: $REASON"
+          echo ""
+          echo "--- Last 20 lines with pass/fail keywords ---"
+          tail -20 "$OUTPUT_FILE" | grep -iE "(pass|fail|success|error|test|complete)" || echo "(no keywords found)"
+          echo "-----------------------------------"
+        fi
+
+        # Set appropriate notice/warning
+        case "$RESULT" in
+          passed)
+            echo "::notice::Test result: PASSED"
+            ;;
+          failed)
+            echo "::error::Test result: FAILED - $REASON"
+            ;;
+          error)
+            echo "::warning::Test result: ERROR - $REASON"
+            ;;
+        esac

--- a/.github/workflows/codex-test-reusable.yml
+++ b/.github/workflows/codex-test-reusable.yml
@@ -115,12 +115,18 @@ jobs:
           IMPORTANT:
           - If external credentials/services are unavailable, note it and skip ONLY that specific step
           - Timeout is ${{ inputs.timeout_minutes }} minutes
-          - End with exactly '✅ TEST PASSED' if ALL documented steps work, or '❌ TEST FAILED: <reason>' if ANY step fails
+
+          FINAL OUTPUT REQUIREMENT (CRITICAL):
+          At the very end of your response, you MUST output EXACTLY ONE of these two lines (copy verbatim):
+          - If all documented steps worked: TEST PASSED
+          - If any step failed: TEST FAILED: <describe what failed>
+          
+          This final line determines whether the CI pipeline passes or fails. Do not add extra formatting or emojis.
           PROMPT_EOF
           echo "file=/tmp/prompt.txt" >> $GITHUB_OUTPUT
 
       - name: Run Codex CLI test
-        id: codex_test
+        id: codex_run
         working-directory: ${{ inputs.recipe_path }}
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
@@ -131,14 +137,12 @@ jobs:
                 "$(cat ${{ steps.prompt.outputs.file }})" \
                 2>&1 | tee "${{ env.OUTPUT_FILE }}"
 
-          # Check if codex produced valid output with a test result
-          if grep -q "✅ TEST PASSED" "${{ env.OUTPUT_FILE }}"; then
-            echo "result=passed" >> $GITHUB_OUTPUT
-          elif grep -q "❌ TEST FAILED" "${{ env.OUTPUT_FILE }}"; then
-            echo "result=failed" >> $GITHUB_OUTPUT
-          else
-            echo "result=error" >> $GITHUB_OUTPUT
-          fi
+      - name: Parse test result
+        id: codex_test
+        uses: ./.github/actions/parse-llm-test-result
+        with:
+          output_file: ${{ env.OUTPUT_FILE }}
+          debug: 'true'
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
@@ -151,9 +155,14 @@ jobs:
       - name: Display test output on failure
         if: ${{ steps.codex_test.outputs.result != 'passed' }}
         run: |
-          echo "::error::Test failed for ${{ inputs.recipe_name }}"
+          echo "::error::Test failed for ${{ inputs.recipe_name }}: ${{ steps.codex_test.outputs.reason }}"
+          echo ""
+          echo "=== Full Test Output ==="
           cat "${{ env.OUTPUT_FILE }}" || echo "No log file found"
 
       - name: Fail workflow if test failed
         if: ${{ steps.codex_test.outputs.result != 'passed' }}
-        run: exit 1
+        run: |
+          echo "Test result: ${{ steps.codex_test.outputs.result }}"
+          echo "Reason: ${{ steps.codex_test.outputs.reason }}"
+          exit 1

--- a/.github/workflows/codex-test-reusable.yml
+++ b/.github/workflows/codex-test-reusable.yml
@@ -120,7 +120,7 @@ jobs:
           At the very end of your response, you MUST output EXACTLY ONE of these two lines (copy verbatim):
           - If all documented steps worked: TEST PASSED
           - If any step failed: TEST FAILED: <describe what failed>
-          
+
           This final line determines whether the CI pipeline passes or fails. Do not add extra formatting or emojis.
           PROMPT_EOF
           echo "file=/tmp/prompt.txt" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request introduces a more robust and maintainable approach for parsing LLM test results in the CI pipeline. The main improvement is the addition of a dedicated GitHub Action for parsing test output, replacing brittle inline shell scripts and emoji-based matching. The workflow is updated to require standardized final output lines from the LLM and to provide clearer error reporting and debugging information.

**LLM Test Result Parsing Improvements:**

* Added a new composite GitHub Action `parse-llm-test-result` that parses LLM output files using robust pattern matching for pass, fail, and error states, with debug output and detailed failure reasons. (`.github/actions/parse-llm-test-result/action.yml`)
* Updated the workflow to use the new parsing action, replacing the previous inline shell logic that relied on emoji-based matching. (`.github/workflows/codex-test-reusable.yml`)

**LLM Output Standardization:**

* Changed the LLM prompt requirements so that the final output must be a single standardized line: either `TEST PASSED` or `TEST FAILED: <reason>`, removing emojis and extra formatting for reliable parsing. (`.github/workflows/codex-test-reusable.yml`)

**Error Reporting and Debugging:**

* Enhanced error reporting to include the failure reason from the parsing action and to display the full test output on failure for easier debugging. (`.github/workflows/codex-test-reusable.yml`)