### PR TITLE
fix(spark-3.5): restore runnable Spark 3 cookbook by pinning valid artifact source and version

### DIFF
--- a/spark/spark-3.5/spark/Dockerfile
+++ b/spark/spark-3.5/spark/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 
 WORKDIR ${SPARK_HOME}
 
-ENV SPARK_VERSION=3.5.7
+ENV SPARK_VERSION=3.5.6
 
 RUN mkdir -p /home/spark/data \
     /home/spark/notebooks \
@@ -51,11 +51,11 @@ COPY ipython/startup/*.py /root/.ipython/profile_default/startup/
 
 # Download spark
 RUN cd ${SPARK_HOME} \
-    && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+    && curl https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
     && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
     && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 
-ENV SPARK_VERSION=3.5.7
+ENV SPARK_VERSION=3.5.6
 RUN cd ${SPARK_HOME} && \
     wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.12/${SPARK_VERSION}/spark-connect_2.12-${SPARK_VERSION}.jar -P jars/ && \
     wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect-client-jvm_2.12/${SPARK_VERSION}/spark-connect-client-jvm_2.12-${SPARK_VERSION}.jar -P jars/ && \


### PR DESCRIPTION
Problem
- Spark 3.5 cookbook image build failed when extracting Spark tarball.
- Dockerfile referenced Spark 3.5.7 from dlcdn.apache.org, which returned a 404 HTML page instead of a .tgz.
- Build error manifested as: gzip: stdin: not in gzip format.

Root cause
- Spark 3.5.x artifacts are not available at dlcdn.apache.org path used in the Dockerfile.
- Version in Dockerfile (3.5.7) also diverged from README expectations (3.5.6).

Changes
- Updated spark/spark-3.5/spark/Dockerfile:
  - Set SPARK_VERSION to 3.5.6 in both declarations.
  - Switched Spark binary download URL to archive.apache.org: https://archive.apache.org/dist/spark/spark-/spark--bin-hadoop3.tgz

Validation
- Rebuilt and started spark/spark-3.5 compose stack successfully.
- Verified Spark logs show version 3.5.6 and successful service startup.
- Started Spice runtime against cookbook/spark spicepod.
- Confirmed nyc_taxis dataset registered and queried successfully (show tables + SELECT ... LIMIT 5).

Impact
- Spark 3.5 cookbook is runnable again and aligned with README version expectations.
