### PR TITLE
Searching GitHub Files: Remove open_telemetry arg (deprecated)

### DIFF
--- a/search_github_files/README.md
+++ b/search_github_files/README.md
@@ -186,7 +186,7 @@ Spiced can perform vector search on table that already have the required embeddi
 
 ```shell
 cd child/
-spiced --http 127.0.0.1:8091 --flight 127.0.0.1:50061 --open_telemetry 127.0.0.1:50062
+spiced --http 127.0.0.1:8091 --flight 127.0.0.1:50061
 ```
 
 2. Rerun the search, this time against the child `spiced` (port `8091`)


### PR DESCRIPTION
## 🗣 Description

`open_telemetry` is deprecated and has no effect

>2026-05-20T10:57:14.699740Z  WARN spiced: `--open_telemetry` is deprecated and has no effect; it will be removed in a future version

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
