### PR TITLE
Cookbook fixes from v2.0-rc.5 validation

### DIFF
--- a/catalogs/ducklake/README.md
+++ b/catalogs/ducklake/README.md
@@ -10,6 +10,7 @@ The DuckLake Catalog Connector enables Spice to automatically discover and query
   ```bash
   curl https://install.duckdb.org | sh
   ```
+  Older DuckDB CLI versions create the catalog at metadata version `0.3`, which Spice rejects at runtime with `DuckLake catalog version mismatch: catalog version is 0.3, but the extension requires version 1.0`. Verify the installed version with `duckdb --version` before running Step 2.
 - Spice v2.0 or later is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 
 ## Step 1. Create a new directory and initialize a Spicepod

--- a/dynamodb/streams/README.md
+++ b/dynamodb/streams/README.md
@@ -67,9 +67,8 @@ You should see the dataset initialize and begin streaming:
 
 ```bash
 INFO runtime::init::dataset: Dataset orders_stream registered (dynamodb:orders), acceleration (duckdb:file, changes), results cache enabled.
-INFO runtime::dataconnector::dynamodb: No existing checkpoint found for table orders_stream, starting from bootstrap
-INFO runtime::dataconnector::dynamodb: Bootstrapping DynamoDB table orders_stream, records=1
-INFO runtime::dataconnector::dynamodb: Bootstrapping DynamoDB table orders_stream complete, starting changes stream. Table will be marked as Ready once stream lag reaches < '1h'
+INFO runtime::dataconnector::dynamodb: No existing lag found for DynamoDB Streams table, starting initialization
+INFO runtime::dataconnector::dynamodb: DynamoDB Streams table initialization complete, starting to process changes from the Stream
 INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/mtls/README.md
+++ b/mtls/README.md
@@ -143,8 +143,8 @@ curl --cacert ca.pem https://localhost:8090/v1/sql -d 'SELECT 1'
 
 Expected output:
 
-```json
-{"message":"Valid client TLS certificate required"}
+```text
+client certificate required
 ```
 
 ### Rejected request (untrusted client certificate)

--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Data Accelerator
 
-Works with `v1.0+`
+Works with `v1.0+`. As of Spice `v2.0`, the PostgreSQL Data Accelerator is an [Enterprise feature](https://spiceai.org/docs/enterprise) and requires an enterprise build of `spiced`. Community builds will log `The accelerator engine postgres is not available` and refuse to load the dataset.
 
 Follow these steps to get started with PostgreSQL as a Data Accelerator.
 
@@ -94,6 +94,8 @@ name: postgres-demo
 datasets:
   - from: spice.ai/spiceai/quickstart/datasets/taxi_trips
     name: taxi_trips
+    params:
+      spiceai_region: us-east-1
     acceleration:
       enabled: true
       refresh_mode: full
@@ -107,6 +109,8 @@ datasets:
         pg_sslmode: disable
         pg_pass: ${env:PG_PASS}
 ```
+
+The `spiceai_region` parameter selects which Spice Cloud region to source the dataset from. Run `spice cloud regions` to list available regions.
 
 Save the changes to `spicepod.yaml`. The Spice runtime terminal will show that the dataset has been loaded:
 

--- a/postgres/accelerator/spicepod.yaml
+++ b/postgres/accelerator/spicepod.yaml
@@ -5,6 +5,8 @@ name: postgres-accelerator
 datasets:
   - from: spice.ai/spiceai/quickstart/datasets/taxi_trips
     name: taxi_trips
+    params:
+      spiceai_region: [Region]
     acceleration:
       enabled: true
       refresh_mode: full

--- a/search/README.md
+++ b/search/README.md
@@ -1,6 +1,6 @@
 # Hybrid Search & Real Time Indexing
 
-Works with `v1.0+`
+Works with `v1.0+`. The fusion-score column emitted by `rrf(...)` was renamed from `fused_score` (Spice `v1.x`) to `_fused_score` (Spice `v2.0+`). The examples below use the `v2.0+` name; replace `_fused_score` with `fused_score` if you are running a `v1.x` build.
 
 In today's hyper-connected digital ecosystem, social media represents an untapped goldmine of actionable intelligence for organizations. Beyond traditional metrics, these platforms offer unprecedented visibility into market dynamics, consumer sentiment trajectories, demographic clustering patterns, and emergent behavioral signals that can fundamentally transform go-to-market strategies and competitive positioning.
 
@@ -109,11 +109,11 @@ Combine exact text matching with semantic similarity for comprehensive results:
 
 ```sql
 -- Find posts about space travel using both exact text and semantic search
-select fused_score, text, created_at, langs
+select _fused_score, text, created_at, langs
 from rrf(
     text_search(bluesky_posts, 'space travel'),
     vector_search(bluesky_posts, 'space travel')
-) order by fused_score desc limit 10;
+) order by _fused_score desc limit 10;
 ```
 
 ### Weighted Ranking
@@ -122,18 +122,18 @@ Boost specific search strategies using `rank_weight` to prioritize different res
 
 ```sql
 -- Heavily prioritize semantic similarity over exact text matches
-select fused_score, text, rkey
+select _fused_score, text, rkey
 from rrf(
     text_search(bluesky_posts, 'artificial intelligence', rank_weight => 50.0),
     vector_search(bluesky_posts, 'AI machine learning', rank_weight => 200.0)
-) order by fused_score desc limit 15;
+) order by _fused_score desc limit 15;
 
 -- Prioritize exact mentions while including semantic results
-select fused_score, text, created_at
+select _fused_score, text, created_at
 from rrf(
     text_search(bluesky_posts, 'climate change', rank_weight => 300.0),
     vector_search(bluesky_posts, 'environmental sustainability', rank_weight => 100.0)
-) order by fused_score desc limit 20;
+) order by _fused_score desc limit 20;
 ```
 
 ### Recency-Boosted Search
@@ -142,7 +142,7 @@ Use temporal information to surface recent content with exponential or linear de
 
 ```sql
 -- Recent posts get higher scores with exponential decay
-select fused_score, text, created_at, rkey
+select _fused_score, text, created_at, rkey
 from rrf(
     text_search(bluesky_posts, 'breaking news'),
     vector_search(bluesky_posts, 'latest updates'),
@@ -150,17 +150,17 @@ from rrf(
     recency_decay => 'exponential',
     decay_constant => 0.05,
     decay_scale_secs => 3600  -- 1 hour scale
-) order by fused_score desc limit 10;
+) order by _fused_score desc limit 10;
 
 -- Linear decay for trending topics over the last day
-select fused_score, text, created_at
+select _fused_score, text, created_at
 from rrf(
     text_search(bluesky_posts, 'trending now'),
     vector_search(bluesky_posts, 'viral popular'),
     time_column => 'created_at',
     recency_decay => 'linear',
     decay_window_secs => 86400  -- 24 hours
-) order by fused_score desc limit 15;
+) order by _fused_score desc limit 15;
 ```
 
 ### Advanced Parameter Tuning
@@ -169,20 +169,20 @@ Fine-tune the RRF algorithm using the smoothing parameter `k`:
 
 ```sql
 -- Lower k value for more aggressive ranking differences
-select fused_score, text, langs
+select _fused_score, text, langs
 from rrf(
     text_search(bluesky_posts, 'technology innovation'),
     vector_search(bluesky_posts, 'tech startups'),
     k => 20.0  -- More aggressive than default 60.0
-) order by fused_score desc limit 12;
+) order by _fused_score desc limit 12;
 
 -- Higher k for smoother score distribution
-select fused_score, text, created_at
+select _fused_score, text, created_at
 from rrf(
     text_search(bluesky_posts, 'social media'),
     vector_search(bluesky_posts, 'online platforms'),
     k => 120.0  -- Smoother than default 60.0
-) order by fused_score desc limit 10;
+) order by _fused_score desc limit 10;
 ```
 
 ### Multi-Language and Content Analysis
@@ -191,7 +191,7 @@ Combine vector search queries across languages for similar concepts:
 
 ```sql
 -- Find posts about "breaking news" with semantic query in Spanish, but keyword match in English
-select fused_score, text, langs, created_at
+select _fused_score, text, langs, created_at
 from rrf(
     vector_search(bluesky_posts, 'ultimas noticias', rank_weight => 100),
     text_search(bluesky_posts, 'news'),
@@ -199,10 +199,10 @@ from rrf(
     recency_decay => 'exponential',
     decay_constant => 0.05,
     decay_scale_secs => 3600  -- 1 h
-) where trim(text) != '' order by fused_score desc limit 15;
+) where trim(text) != '' order by _fused_score desc limit 15;
 
 -- Find posts about breaking news using two semantic queries in Spanish, but filter results for English
-select fused_score, text, langs, created_at
+select _fused_score, text, langs, created_at
 from rrf(
     vector_search(bluesky_posts, 'ultimas noticias'),
     vector_search(bluesky_posts, 'noticias de ultima hora'),
@@ -210,7 +210,7 @@ from rrf(
     recency_decay => 'exponential',
     decay_constant => 0.05,
     decay_scale_secs => 3600  -- 1 h
-) where langs like '%en%' and trim(text) != '' order by fused_score desc limit 15;
+) where langs like '%en%' and trim(text) != '' order by _fused_score desc limit 15;
 ```
 
 ## Step 4. Enable agentic support

--- a/snowflake/dml/README.md
+++ b/snowflake/dml/README.md
@@ -32,6 +32,26 @@ CREATE TABLE IF NOT EXISTS TV_SHOWS (
 );
 ```
 
+> **No worksheet UI access?** You can run the same DDL from the command line using [`snowflake-connector-python`](https://pypi.org/project/snowflake-connector-python/). Note the account identifier must use the dash form (`<org>-<account>`) for this driver, even though the Spice connector accepts the dot form (`<org>.<account>`):
+>
+> ```bash
+> pip install snowflake-connector-python
+> python -c "
+> import snowflake.connector
+> ddl = '''
+> CREATE DATABASE IF NOT EXISTS SPICE_DEMO;
+> CREATE TABLE IF NOT EXISTS SPICE_DEMO.PUBLIC.TV_SHOWS (
+>     id INTEGER NOT NULL, name VARCHAR(255), type VARCHAR(100),
+>     language VARCHAR(100), status VARCHAR(100), runtime INTEGER,
+>     premiered DATE, ended DATE, rating_average FLOAT, PRIMARY KEY (id)
+> );
+> '''
+> with snowflake.connector.connect(account='<org>-<account>', user='<username>', password='<password>') as cn:
+>     for stmt in filter(None, (s.strip() for s in ddl.split(';'))):
+>         cn.cursor().execute(stmt)
+> "
+> ```
+
 ## Step 2. Configure Snowflake credentials
 
 ```bash

--- a/tls/README.md
+++ b/tls/README.md
@@ -109,6 +109,14 @@ sudo chmod 600 postgres.key
 sudo chcon -Rt svirt_sandbox_file_t postgres.key
 ```
 
+## macOS: Tighten key file permissions
+
+`openssl ecparam -genkey` writes `postgres.key` as `0644` by default. Postgres 18 refuses to start with `FATAL: private key file "/var/lib/postgresql/postgres.key" has group or world access`. Tighten the mode before starting the container; Docker Desktop will bind-mount the file into the container with the same permissions:
+
+```bash
+chmod 600 postgres.key
+```
+
 ### Start `postgres`
 
 Start a `postgres` instance with TLS enabled using Docker compose.


### PR DESCRIPTION
## Summary

Two-commit cleanup of cookbook recipes against the v2.0-rc.5 build:

- **PostgreSQL Accelerator** (`postgres/accelerator/`)
  - Note up front that the engine is an Enterprise feature in Spice v2.0; community builds reject `engine: postgres` at dataset init.
  - Add the now-required `spiceai_region` connector parameter to the Step 5 yaml snippet and to the bundled `spicepod.yaml` template. Without it the runtime fails with `Missing required parameter: region`.
- **Hybrid Search** (`search/`) — rename `fused_score` to `_fused_score` in every example so they match the v2.0 RRF UDTF output. Adds a callout near the top pointing v1.x users at the legacy column name.
- **TLS** (`tls/`) — add a macOS-specific `chmod 600 postgres.key` section. Without it, Postgres 18 refuses to start with `FATAL: private key file ... has group or world access`.
- **DynamoDB Streams** (`dynamodb/streams/`) — refresh the bootstrap log sample to match the current runtime log lines.
- **mTLS** (`mtls/`) — fix the no-client-cert response sample; the runtime returns plain text `client certificate required`, not JSON.
- **DuckLake** (`catalogs/ducklake/`) — spell out the failure mode when DuckDB CLI is older than v1.5.2 (catalog metadata version `0.3` vs required `1.0`).
- **Snowflake DML** (`snowflake/dml/`) — add a `snowflake-connector-python` one-liner as an alternate to the worksheet UI for Step 1, including the dash-vs-dot account-identifier gotcha.

## Test plan

- [x] `postgres/accelerator/` — exercised end-to-end on rc.5: `spice run` registers `taxi_trips` with `acceleration (postgres, 10s refresh)`, loads 2,964,624 rows in 62s, README sample queries succeed in both `spice sql` and direct `psql`.
- [ ] `search/` — column rename verified against the rc.5 build; full recipe blocked on spiceai/spiceai#10951 (needs `join_key` workaround).
- [ ] `tls/`, `mtls/`, `dynamodb/streams/`, `catalogs/ducklake/`, `snowflake/dml/` — README-only text changes; no behavior change to validate.