### PR TITLE
Fix mysql/rds-aurora recipe: correct CloudFormation template filename

### DIFF
--- a/mysql/rds-aurora/README.md
+++ b/mysql/rds-aurora/README.md
@@ -16,7 +16,7 @@ Follow these steps to get started with federated SQL query against AWS RDS Auror
 ```bash
 aws cloudformation create-stack \
   --stack-name aurora-cookbook \
-  --template-body file://cloudformation.yaml
+  --template-body file://aurora-test-cluster.yaml
 ```
 
 **Step 2.** Navigate to your AWS RDS Aurora instance in the AWS Management Console.


### PR DESCRIPTION
## What the recipe said
Step 1 deploys the Aurora cluster with `--template-body file://cloudformation.yaml`.

## What's actually shipped
The recipe ships the CloudFormation template as **`aurora-test-cluster.yaml`** — there is no `cloudformation.yaml` in `mysql/rds-aurora/`. So Step 1 fails immediately with a "file not found" error for anyone following the README verbatim.

## Change
Point `--template-body` at the shipped filename (`file://aurora-test-cluster.yaml`).

**Severity: critical** — the first step of the recipe cannot succeed as written.
