### PR TITLE
Fix openai-responses-api recipe: remove non-existent 'spice chat --responses' flag

### DIFF
--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -48,7 +48,7 @@ spice run
 In a separate terminal, start a chat session against the Spice runtime with the Responses API enabled:
 
 ```
-spice chat --responses
+spice chat
 ```
 
 Ask the model to retrieve today's news via web search, one of OpenAI's hosted tools.


### PR DESCRIPTION
## What the recipe said
> ```
> spice chat --responses
> ```

## What the code does
`spice chat` has no `--responses` flag. `ChatArgs` (spiceai `bin/spice/src/commands/chat.rs`) defines only `--model`, `--temperature`, `--endpoint`, `--headers`, and `--output`. Running `spice chat --responses` fails with an unknown-flag error.

The Responses API is enabled at the **model** level via `responses_api: enabled` in this recipe's `spicepod.yaml`, so plain `spice chat` already talks to the Responses-enabled model.

## Change
Drop the non-existent `--responses` flag.

**Severity: critical** — the documented command errors out.

Verified against `spiceai/spiceai` `origin/trunk` (v2.0.0-rc.5 line).
