### PR TITLE
Fix ai recipe: correct ai() batch limit and example_queries.sql column

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -240,7 +240,7 @@ LIMIT 10;
 
 ### Limits
 
-- Maximum batch size: 100 rows per query
+- Maximum batch size: 1000 rows per query
 - Maximum message size: 1 MB per message
 
 ### Error Handling

--- a/ai/WHEN_TO_USE.md
+++ b/ai/WHEN_TO_USE.md
@@ -319,7 +319,7 @@ execute("""
    - Use pre-computed results or caching
 
 2. **Processing millions of rows**
-   - 100 row batch limit
+   - 1000 row batch limit
    - Consider batch processing offline
 
 3. **Simple text operations**

--- a/ai/example_queries.sql
+++ b/ai/example_queries.sql
@@ -56,19 +56,19 @@ FROM taxi_zones;
 -- ==============================================
 
 -- 7. Analyze customer feedback
-SELECT 
-  id,
+SELECT
+  feedback_id,
   feedback,
   ai('Classify as positive, negative, or neutral: ' || feedback, 'gpt-4o-mini') as sentiment
 FROM customer_feedback;
 
 -- 8. Extract key points from feedback
-SELECT 
-  id,
+SELECT
+  feedback_id,
   feedback,
   ai('What is the main point in 3 words: ' || feedback, 'gpt-4o-mini') as key_point
 FROM customer_feedback
-WHERE id <= 3;
+WHERE feedback_id <= 3;
 
 
 -- ==============================================


### PR DESCRIPTION
Two accuracy fixes in the `ai/` recipe, verified against `spiceai/spiceai` `origin/trunk` (v2.0.0-rc.5 line).

## 1. `ai()` batch limit is 1000, not 100
`README.md` and `WHEN_TO_USE.md` stated the `ai()` UDF max batch size is **100 rows**. The runtime limit is `MAX_BATCH_SIZE = 1000` (`crates/runtime-datafusion-udfs/src/ai.rs:59`). The 1 MB per-message limit alongside it is correct (`MAX_MESSAGE_SIZE = 1_000_000`). Corrected 100 → 1000.

## 2. `example_queries.sql` selected a non-existent column
Queries #7 and #8 selected `id` (and filtered `WHERE id <= 3`) `FROM customer_feedback`, but the CSV header is `feedback_id` (`data/customer_feedback.csv`). The bundled queries fail for anyone who runs the file. Changed to `feedback_id`.

(The README inline query and `examples.sh` were already correct — only the bundled `.sql` had drifted.)
