### PR TITLE
Fix dynamodb/streams recipe: make the update step a real update and fix output

### DIFF
--- a/dynamodb/streams/README.md
+++ b/dynamodb/streams/README.md
@@ -94,13 +94,13 @@ You should see the new record:
 
 ---
 
-## Step 8. Update a Record and See the Change
+## Step 7. Update a Record and See the Change
 
-Update the order status:
+Update the order status to `shipped`. Re-running `put-item` with the same `id` overwrites the existing item:
 
 ```bash
 aws dynamodb put-item --table-name orders --item \
-  '{"id": {"S": "order-002"}, "customer": {"S": "Bob"}, "amount": {"N": "149.99"}, "status": {"S": "pending"}}' \
+  '{"id": {"S": "order-001"}, "customer": {"S": "Alice"}, "amount": {"N": "99.99"}, "status": {"S": "shipped"}}' \
   --region $AWS_REGION
 ```
 
@@ -113,17 +113,16 @@ SELECT * FROM orders_stream;
 The status should now be updated:
 
 ```console
-+-----------+----------+---------+---------+
-| id        | customer | amount  | status  |
-+-----------+----------+---------+---------+
-| order-001 | Alice    | 99.99   | pending |
-| order-002 | Bob      | 199.99  | pending |
-+-----------+----------+---------+---------+
++-----------+----------+--------+---------+
+| id        | customer | amount | status  |
++-----------+----------+--------+---------+
+| order-001 | Alice    | 99.99  | shipped |
++-----------+----------+--------+---------+
 ```
 
 ---
 
-## Step 9. Cleanup
+## Step 8. Cleanup
 
 To delete the DynamoDB table:
 


### PR DESCRIPTION
The "Update a Record and See the Change" step had three problems:

1. **Mislabeled as an update.** The step's title and prose say "update the order status," but the `put-item` wrote a brand-new item (`order-002`, Bob) instead of updating the existing `order-001`.
2. **Output didn't match input.** The `put-item` wrote `"amount": 149.99`, but the expected-output table showed `order-002 | Bob | 199.99`.
3. **Step numbering skipped Step 7** (jumped 6 → 8 → 9).

## Change
Rewrote the step as a genuine update of `order-001` (status → `shipped`, via a `put-item` overwrite with the same `id`), corrected the output table to match, and renumbered the steps (6 → 7 → 8).

**Severity: high** — the step demonstrates the wrong operation and shows output that contradicts its own command.
