### PR TITLE
Fix vectors/s3 recipe: align AWS credential env var names

### DIFF
--- a/vectors/s3/.env
+++ b/vectors/s3/.env
@@ -1,4 +1,5 @@
 GITHUB_TOKEN="<your_github_token>"
 SPICE_OPENAI_API_KEY="<an-OPENAI-API-key>"
+AWS_ACCESS_KEY_ID="<AWS...>"
 AWS_SECRET_ACCESS_KEY="<AWS...>"
 AWS_SESSION_TOKEN="<AWS...only if you need it>"

--- a/vectors/s3/README.md
+++ b/vectors/s3/README.md
@@ -10,7 +10,7 @@ Spice.ai integrates Amazon S3 Vectors, launched in public preview at AWS Summit 
 - Create `.env` file with:
   - `GITHUB_TOKEN`: GitHub personal access token ([guide](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic)).
   - `SPICE_OPENAI_API_KEY`: OpenAI API key.
-  - `S3_VECTORS_AWS_ACCESS_KEY_ID`, `S3_VECTORS_AWS_SECRET_ACCESS_KEY` (and `S3_VECTORS_AWS_SESSION_TOKEN` if using temporary credentials): AWS credentials for S3 Vectors access. For alternatives, see [S3 Vectors documentation](https://spiceai.org/docs/components/vectors/s3_vectors).
+  - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` (and `AWS_SESSION_TOKEN` if using temporary credentials): AWS credentials for S3 Vectors access. For alternatives, see [S3 Vectors documentation](https://spiceai.org/docs/components/vectors/s3_vectors).
 - AWS account with an S3 Vectors-enabled bucket (e.g., `spiceai-cookbook` in `us-east-2`).
 
 ## Configuration


### PR DESCRIPTION
## The mismatch
- `spicepod.yaml` resolves the S3 Vectors credentials from `${secrets:AWS_ACCESS_KEY_ID}`, `${secrets:AWS_SECRET_ACCESS_KEY}`, `${secrets:AWS_SESSION_TOKEN}`.
- The README told readers to set `S3_VECTORS_AWS_ACCESS_KEY_ID` / `S3_VECTORS_AWS_SECRET_ACCESS_KEY` / `S3_VECTORS_AWS_SESSION_TOKEN` — names that match neither the spicepod nor the bundled `.env`.
- The committed `.env` was also missing `AWS_ACCESS_KEY_ID` entirely (it listed only the secret key and session token).

With the documented names, the secrets never resolve and S3 Vectors authentication fails.

## Change
Aligned the README prose on the `AWS_*` names the spicepod actually reads, and added the missing `AWS_ACCESS_KEY_ID` entry to `.env`. README, `.env`, and `spicepod.yaml` now agree.
