### PR TITLE
Fix websearch recipe: note Perplexity/websearch removal in v2.0

### DIFF
--- a/websearch/README.md
+++ b/websearch/README.md
@@ -1,6 +1,8 @@
 # Web Search Using Perplexity
 
-Works with `v1.0+`
+Deprecated in `v2.0+`. Works with `v1.0+`
+
+> **Note:** This recipe relies on the built-in `websearch` tool with the Perplexity engine. Perplexity support — both the model provider and the `websearch` tool — was removed in Spice `v2.0`, so this recipe only runs against `v1.x` releases (e.g. the current stable `v1.11.6`).
 
 This recipe demonstrates how to configure and use Perplexity web search within Spice AI.
 


### PR DESCRIPTION
## What the recipe said

The `websearch` recipe was labeled `Works with \`v1.0+\`` and configures a built-in web search tool using the Perplexity engine:

```yaml
tools:
  - name: the_internet
    from: websearch
    params:
      engine: perplexity
      perplexity_auth_token: ${ secrets:SPICE_PERPLEXITY_AUTH_TOKEN }
```

## What the code does

Perplexity support was **fully removed in Spice v2.0** — both the model provider and the built-in `websearch` tool that depended on it:

- v1.11.6 (current stable) ships the tool at `crates/runtime/src/tools/builtin/web_search/{mod,tool,perplexity}.rs`, registered as `"websearch"` in `crates/runtime/src/tools/builtin/catalog.rs`.
- On `trunk` (v2.0), that entire `web_search/` directory and the `websearch` registration are gone — `crates/runtime/src/tools/builtin/` no longer contains a web-search tool, and there are **no** `perplexity` references anywhere in the crates.

The v2.0.0 release notes confirm: *"Perplexity Removed: Removed Perplexity model provider support."*

As a result, a reader on v2.0 (the line the cookbook targets) hits a hard failure: `engine: perplexity` and `from: websearch` no longer exist. The recipe still runs against v1.x.

## What changed

Added a `Deprecated in \`v2.0+\`` version note, matching the convention already used by the `evals` recipe (which was removed in v2.0 the same way), plus a short explanatory note so readers on v2.0 know why it won't run.

No functional/config change — the recipe remains valid for `v1.x` (e.g. current stable v1.11.6).

**Source ref:** `spiceai/spiceai` @ `trunk` (v2.0.0) — `crates/runtime/src/tools/builtin/` (no `web_search`); compared against tag `v1.11.6` where `crates/runtime/src/tools/builtin/web_search/perplexity.rs` exists.