### PR TITLE
Fix caching/accelerator recipe: correct cache column to _fetched_at

### DIFF
--- a/caching/accelerator/README.md
+++ b/caching/accelerator/README.md
@@ -74,7 +74,7 @@ spice sql
 Run a query to fetch the current time through the cache:
 
 ```sql
-SELECT request_path, content, fetched_at FROM time WHERE request_path = '/time';
+SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time';
 ```
 
 ## Understanding the Configuration
@@ -116,7 +116,7 @@ datasets:
 1. **First Query (Cache Miss)**: Run the query - it will take ~1 second (the server's default delay)
 
    ```sql
-   SELECT request_path, content, fetched_at FROM time WHERE request_path = '/time';
+   SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time';
    ```
 
 2. **Immediate Repeat (Cache Hit)**: Run the same query again - it returns instantly from cache
@@ -140,12 +140,12 @@ Query different paths to create separate cache entries:
 
 ```sql
 -- These create separate cache entries
-SELECT request_path, content, fetched_at FROM time WHERE request_path = '/time/1';
-SELECT request_path, content, fetched_at FROM time WHERE request_path = '/time/2';
-SELECT request_path, content, fetched_at FROM time WHERE request_path = '/time/3';
+SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time/1';
+SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time/2';
+SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time/3';
 
 -- View all cached entries
-SELECT request_path, content, fetched_at FROM time ORDER BY fetched_at DESC;
+SELECT request_path, content, _fetched_at FROM time ORDER BY _fetched_at DESC;
 ```
 
 ### Testing Response Delays
@@ -167,7 +167,7 @@ The caching accelerator automatically adds metadata fields to cached data:
 | `request_query` | String    | Query parameters from the request |
 | `request_body`  | String    | Request body (for POST requests)  |
 | `content`       | String    | The response content              |
-| `fetched_at`    | Timestamp | When the data was fetched         |
+| `_fetched_at`    | Timestamp | When the data was fetched         |
 
 ## Use Cases
 

--- a/caching/accelerator/README.md
+++ b/caching/accelerator/README.md
@@ -77,6 +77,8 @@ Run a query to fetch the current time through the cache:
 SELECT request_path, content, _fetched_at FROM time WHERE request_path = '/time';
 ```
 
+> **Version note:** The fetch-timestamp column is named `_fetched_at` (leading underscore) on Spice `v2.0+`. On `v1.x` it is `fetched_at` (no underscore) — use that name if you are running a `v1.x` release.
+
 ## Understanding the Configuration
 
 The `spicepod.yaml` configures the caching accelerator:
@@ -167,7 +169,7 @@ The caching accelerator automatically adds metadata fields to cached data:
 | `request_query` | String    | Query parameters from the request |
 | `request_body`  | String    | Request body (for POST requests)  |
 | `content`       | String    | The response content              |
-| `_fetched_at`    | Timestamp | When the data was fetched         |
+| `_fetched_at`   | Timestamp | When the data was fetched (named `fetched_at` on Spice `v1.x`) |
 
 ## Use Cases
 


### PR DESCRIPTION
## What the recipe says

The `caching/accelerator` README (advertised `Works with v1.10+`) queries a `fetched_at` column on the cached `time` dataset and documents it in the Cache Schema table.

## What the code does — and the v1 ↔ v2 difference

The HTTP connector's fetch-timestamp column was **renamed between major versions**:

- **v1.11.6**: column is `fetched_at` (`git show v1.11.6:crates/data_components/src/http/provider.rs`).
- **v2.0.0** (current stable): column is `_fetched_at`, and the caching layer keys off that exact name — `crates/runtime/src/accelerated_table/caching.rs`: `pub const CACHE_REFRESHED_AT_COLUMN: &str = "_fetched_at";`.

So on the current stable runtime (v2.0.0) every query selecting/ordering by `fetched_at` fails with a column-not-found error.

## What changed

- Updated the SQL queries and the Cache Schema table to the **v2.0** column name `_fetched_at` (the cookbook's primary target / current stable).
- Added an explicit **v1/v2 version note** at the first query and in the schema table so readers on a `v1.x` release know to use `fetched_at` instead — keeping the recipe correct for both major versions it advertises.

Verified against `spiceai/spiceai` tags **v2.0.0** and **v1.11.6**.