### PR TITLE
Fix openai-responses-api recipe: remove non-existent 'spice chat --responses' flag

### DIFF
--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -45,10 +45,10 @@ spice run
 
 ## Using OpenAI-hosted tools
 
-In a separate terminal, start a chat session against the Spice runtime with the Responses API enabled:
+In a separate terminal, start a chat session against the Spice runtime. The Responses API is enabled by the model's `responses_api: enabled` param in `spicepod.yaml`, so no extra flag is needed:
 
 ```
-spice chat --responses
+spice chat --model gpt-4o-responses
 ```
 
 Ask the model to retrieve today's news via web search, one of OpenAI's hosted tools.


### PR DESCRIPTION
## What the recipe says

The `openai-responses-api` README starts the chat session with:

```
spice chat --responses
```

## What the code does

`spice chat` has no `--responses` flag. `ChatArgs` (`bin/spice/src/commands/chat.rs`) defines only `--model`, `--temperature`, `--endpoint`, `--headers`, and `-o/--output` (plus a hidden `--direct-prompt`). clap rejects the unknown `--responses` flag, so the command fails.

The Responses API is instead enabled at the **model** level via the `responses_api: enabled` param — which this recipe's `spicepod.yaml` already sets on the `gpt-4o-responses` model. No CLI flag is involved.

## What changed

Replaced `spice chat --responses` with `spice chat --model gpt-4o-responses` and added a one-line note that the Responses API is enabled by the model's `responses_api: enabled` param. Using `--model` makes the model selection explicit and copy-pasteable.

Verified against `spiceai/spiceai` at tag **v2.0.0** (current stable).