### PR TITLE
Fix llm-judge recipe: mark deprecated in v2.0 (eval subsystem removed)

### DIFF
--- a/llm-judge/README.md
+++ b/llm-judge/README.md
@@ -1,6 +1,8 @@
 # LLM as a Judge
 
-Works with `v1.0+`
+Deprecated in `v2.0+`. Works with `v1.0+`
+
+> **Note:** The evaluation subsystem this recipe relies on — the `spice eval` command, the `evals:` / `scorers:` spicepod config, the `eval.results` table, and `eval_run` traces — was removed in Spice `v2.0.0`. Run this recipe with a Spice `v1.x` release.
 
 Spice can be used to run language models (LLM) but also to evaluate their performance on specific tasks. Sometimes it's useful to use another language model to judge the performance of another LLM. This is often called an [LLM judge](https://spiceai.org/docs/features/large-language-models/evals#llm-judge).
 


### PR DESCRIPTION
## What the recipe says

The `llm-judge` README is headed `Works with `v1.0+`` and walks the reader through:

- `spice eval tpch_nsql --model sql-analyst`
- `spice trace eval_run`
- `SELECT ... FROM eval.results WHERE scorer = 'match'`
- an `evals:` / `scorers:` block in `spicepod.yml`

## What the code does

The entire evaluation subsystem was **removed in Spice `v2.0.0`**:

- There is no `eval` subcommand — `bin/spice/src/commands/` has no `eval.rs`, and `eval` is not in the CLI subcommand list.
- The `/v1/evals` HTTP route is gone (no `evals` route in `crates/runtime/src/http/routes.rs`).
- `eval_run` / `eval_step` / `eval_scoring` spans no longer exist anywhere in `crates/`.
- `SpicepodDefinition` has no `evals` field, so the `evals:` block is silently ignored, and the `eval.results` table is never created.

So on current stable (v2.0.0) the recipe's steps fail: `spice eval` is an unknown command and the `eval.results` query errors.

## What changed

Mirrored the treatment already applied to the sibling `evals/` recipe in #397: changed the header to `Deprecated in `v2.0+`. Works with `v1.0+`` and added a short note listing exactly which pieces (`spice eval`, `evals:`/`scorers:` config, `eval.results`, `eval_run` traces) were removed in v2.0, pointing readers to a v1.x release. No functional content changed; the recipe still documents the v1.x workflow.

Verified against `spiceai/spiceai` at tag **v2.0.0** (current stable).