### PR TITLE
Fix models/openai recipe: correct /v1/search score field to _score

### DIFF
--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -136,7 +136,7 @@ Result
       "matches": {
         "content": "# Metrics Naming\n\n## TL;DR\n\n**Metric Naming Guide**: Prioritize Developer Experience (DX) with intuitive, ..."
       },
-      "score": 0.7941223368131454,
+      "_score": 0.7941223368131454,
       "dataset": "spiceai.docs",
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/dev/metrics.md"
@@ -146,7 +146,7 @@ Result
       "matches": {
         "content": "# Criteria Definitions\n\n## RC\n\nAcronym for \"Release Candidate\". Identifies a version that is eligible for ..."
       },
-      "score": 0.7145749783070606,
+      "_score": 0.7145749783070606,
       "dataset": "spiceai.docs",
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/criteria/definitions.md"

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -157,6 +157,8 @@ Result
 }
 ```
 
+> **Version note:** The relevance score is returned in the `_score` field (leading underscore) on Spice `v2.0+`. On `v1.x` it was returned as `score` (no underscore).
+
 ## Utilizing a natural language query
 
 Use `spice chat` CLI command to query information using natural language


### PR DESCRIPTION
## What the recipe says

The README shows the `/v1/search` JSON response with a `"score"` field.

## What the code does — and the v1 ↔ v2 difference

The search relevance score field was **renamed in the v2.0 breaking-changes pass** (`spiceai/spiceai` #9233, "v2.0 breaking changes"):

- **v1.11.6**: serialized as `score` (`git show v1.11.6:crates/runtime/src/search/types.rs`).
- **v2.0.0** (current stable): the `Match` struct uses `#[serde(rename = "_score")]`, so the field serializes as `_score`. The endpoint's own OpenAPI example in `crates/runtime/src/http/v1/search.rs` uses `_score`.

So on the current stable runtime a reader running the documented `curl` gets `_score`, not `score`.

## What changed

- Updated the `/v1/search` JSON response examples to the **v2.0** field name `_score` (the cookbook's primary target / current stable).
- Added an explicit **v1/v2 version note** so readers on a `v1.x` release know the field is `score` there.

(The `spice search` CLI table's `Score` column header is a separate presentation layer and is unchanged.)

Verified against `spiceai/spiceai` tags **v2.0.0** and **v1.11.6**.