### PR TITLE
Fix azure_openai recipe: correct /v1/search score field to _score

### DIFF
--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -168,6 +168,8 @@ Result:
 }
 ```
 
+> **Version note:** The relevance score is returned in the `_score` field (leading underscore) on Spice `v2.0+`. On `v1.x` it was returned as `score` (no underscore).
+
 Vector-based search could also be performed using `spice search` CLI command:
 
 ```shell

--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -147,7 +147,7 @@ Result:
       "primary_key": {
         "path": "docs/dev/metrics.md"
       },
-      "score": 0.7269563689871208,
+      "_score": 0.7269563689871208,
       "dataset": "spiceai.files"
     },
     {
@@ -160,7 +160,7 @@ Result:
       "primary_key": {
         "path": "docs/criteria/definitions.md"
       },
-      "score": 0.6737559856782607,
+      "_score": 0.6737559856782607,
       "dataset": "spiceai.files"
     }
   ],


### PR DESCRIPTION
## What the recipe says

The README shows the `/v1/search` JSON response with a `"score"` field.

## What the code does — and the v1 ↔ v2 difference

The search relevance score field was **renamed in the v2.0 breaking-changes pass** (`spiceai/spiceai` #9233, "v2.0 breaking changes"):

- **v1.11.6**: serialized as `score` (`git show v1.11.6:crates/runtime/src/search/types.rs`).
- **v2.0.0** (current stable): the `Match` struct uses `#[serde(rename = "_score")]`, so the field serializes as `_score`. The endpoint's own OpenAPI example in `crates/runtime/src/http/v1/search.rs` uses `_score`.

So on the current stable runtime a reader running the documented `curl` gets `_score`, not `score`.

## What changed

- Updated the `/v1/search` JSON response examples to the **v2.0** field name `_score` (the cookbook's primary target / current stable).
- Added an explicit **v1/v2 version note** so readers on a `v1.x` release know the field is `score` there.

(The `spice search` CLI table's `Score` column header is a separate presentation layer and is unchanged.)

Verified against `spiceai/spiceai` tags **v2.0.0** and **v1.11.6**.