### PR TITLE
Fix cdc-debezium recipe: README spicepod block must use SASL to match the broker

### DIFF
--- a/cdc-debezium/README.md
+++ b/cdc-debezium/README.md
@@ -39,7 +39,7 @@ curl -i -X POST -H "Accept:application/json" -H  "Content-Type:application/json"
 
 Now the Debezium connector is registered and will start capturing changes from the `customer_addresses` table in the Postgres database. Open http://<localhost:8080/topics> and see the topic `cdc.public.customer_addresses` created.
 
-This spicepod.yaml shows the config needed to configure Spice to connect to the Kafka topic and consume the Debezium changes:
+This spicepod.yaml shows the config needed to configure Spice to connect to the Kafka topic and consume the Debezium changes. The Redpanda broker started by `docker compose` has SASL authentication enabled, so the connection uses `SASL_PLAINTEXT` with the `SCRAM-SHA-256` mechanism; the `KAFKA_USERNAME` and `KAFKA_PASSWORD` secrets are provided in `cdc-debezium/.env`:
 
 ```yaml
 version: v1
@@ -53,7 +53,10 @@ datasets:
       debezium_transport: kafka
       debezium_message_format: json
       kafka_bootstrap_servers: localhost:19092
-      kafka_security_protocol: PLAINTEXT
+      kafka_security_protocol: SASL_PLAINTEXT
+      kafka_sasl_mechanism: SCRAM-SHA-256
+      kafka_sasl_username: ${secrets:KAFKA_USERNAME}
+      kafka_sasl_password: ${secrets:KAFKA_PASSWORD}
     acceleration:
       enabled: true
       engine: sqlite


### PR DESCRIPTION
## What the recipe says

The `cdc-debezium` README presents the spicepod config "needed to configure Spice to connect to the Kafka topic" with a plaintext Kafka connection and no authentication:

```yaml
      kafka_bootstrap_servers: localhost:19092
      kafka_security_protocol: PLAINTEXT
```

## What the code / recipe actually requires

The Redpanda broker started by the recipe's own `docker compose` stack has **SASL authentication enabled**:

- `cdc-debezium/compose.yaml` — `--set redpanda.enable_sasl=true` and `--set redpanda.superusers=['admin']`; the Kafka Connect service uses `CONNECT_SECURITY_PROTOCOL: SASL_PLAINTEXT`.

A `PLAINTEXT` connection to that broker is rejected. Accordingly, the recipe's **shipped** `cdc-debezium/spicepod.yaml` (what `spice run` actually loads) correctly uses:

```yaml
      kafka_security_protocol: SASL_PLAINTEXT
      kafka_sasl_mechanism: SCRAM-SHA-256
      kafka_sasl_username: ${secrets:KAFKA_USERNAME}
      kafka_sasl_password: ${secrets:KAFKA_PASSWORD}
```

with `KAFKA_USERNAME=admin` / `KAFKA_PASSWORD=admin123` supplied in `cdc-debezium/.env`. All four `kafka_*` params are valid runtime params for the debezium/kafka connector (`crates/runtime/src/dataconnector/debezium.rs`, `.../kafka.rs`).

So the README's explanatory block misrepresents the configuration: a reader who builds their own spicepod from it (rather than relying on the shipped file) cannot connect.

## What changed

Updated the README's spicepod block to match the shipped `spicepod.yaml` (SASL_PLAINTEXT + SCRAM-SHA-256 + credential secrets), and added a sentence explaining the broker requires SASL and where the credentials come from. No change to the shipped config or to the runnable flow.

Verified against `spiceai/spiceai` at tag **v2.0.0** (current stable).