### PR TITLE
Fix oracle recipe: correct version floor to v1.5.0+

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -1,6 +1,6 @@
 # Oracle Data Connector
 
-Works with `v1.0+`
+Works with `v1.5.0+`
 
 This cookbook demonstrates how to use Spice.ai to connect to and accelerate data from an Oracle database.
 


### PR DESCRIPTION
## What the recipe says

`oracle/README.md` line 3 declares the recipe "Works with `v1.0+`".

## What the code does

The Oracle Data Connector did not exist in v1.0–v1.4. It was introduced in **v1.5.0**, promoted to Alpha in [spiceai/spiceai#6503](https://github.com/spiceai/spiceai/pull/6503).

Source ref: `spiceai/spiceai` at `v2.0.0` — `docs/release_notes/v1.5/v1.5.0.md` ("**Oracle Data Connector**: Use `from: oracle:` …", and the changelog line promoting it to Alpha in #6503). No mention of Oracle appears in any v1.0–v1.4 release notes.

## What changed

Updated the version floor from `v1.0+` to `v1.5.0+` so a reader on an older release isn't told the recipe works when the `oracle:` connector isn't present. The recipe is otherwise accurate against current stable (v2.0.0): all five params (`oracle_host`, `oracle_port`, `oracle_username`, `oracle_password`, `oracle_service_name`) match the connector's `ParameterSpec` list.