### PR TITLE
Fix imap recipe: correct version floor to v1.1.0+

### DIFF
--- a/imap/README.md
+++ b/imap/README.md
@@ -1,6 +1,6 @@
 # IMAP Data Connector
 
-Works with `v1.0+`
+Works with `v1.1.0+`
 
 Follow these steps to get started with the IMAP Data Connector, connecting to an IMAP server with a plain username and password.
 


### PR DESCRIPTION
## What the recipe says

`imap/README.md` line 3 declares the recipe "Works with `v1.0+`".

## What the code does

The IMAP Data Connector did not exist in v1.0. It was introduced in **v1.1.0**.

Source ref: `spiceai/spiceai` at `v2.0.0` — `docs/release_notes/v1.1/v1.1.0.md` adds the IMAP Data Connector. No IMAP connector appears in any v1.0 release notes.

## What changed

Updated the version floor from `v1.0+` to `v1.1.0+`. The recipe is otherwise accurate against current stable (v2.0.0): the `imap_host` / `imap_password` params and the message schema columns match the connector implementation.