### PR TITLE
Fix glue recipe: correct version floor to v1.4.0+

### DIFF
--- a/glue/README.md
+++ b/glue/README.md
@@ -1,6 +1,6 @@
 # Glue Data Connector
 
-Works with `v1.0+`
+Works with `v1.4.0+`
 
 The AWS Glue Data Connector enables Spice to query a tables registered in an AWS Glue Data Catalog. It supports tables referencing S3 data in Iceberg, Hive-style Parquet, and CSV formats.
 


### PR DESCRIPTION
## What the recipe says

`glue/README.md` line 3 declares the recipe "Works with `v1.0+`".

## What the code does

The AWS Glue Catalog and Data Connectors did not exist before v1.4.0. They were introduced in **v1.4.0**.

Source ref: `spiceai/spiceai` at `v2.0.0` — `docs/release_notes/v1.4/v1.4.0.md`: "It introduces the AWS Glue Catalog and Data Connectors for native access to Glue-managed data on S3" ("**AWS Glue Data Connector Alpha**"). Glue does not appear as a connector in v1.0–v1.3 release notes.

## What changed

Updated the version floor from `v1.0+` to `v1.4.0+`. The recipe is otherwise accurate against current stable (v2.0.0): the `glue_region` / `glue_key` / `glue_secret` params map to the connector's S3 `ParameterSpec` (`region`/`key`/`secret`) and the `glue:<db>.<table>` reference parsing matches the source.