### PR TITLE
Fix databricks recipe: correct mode label in sql_warehouse section

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -325,7 +325,7 @@ Note: A dataset can be accelerated when configured by specifying yes (y) to `loc
    Time: 0.035188167 seconds. 2 rows.
    ```
 
-6. Query against the Databricks table connected with `mode: spark_connect`
+6. Query against the Databricks table connected with `mode: sql_warehouse`
 
    ```shell
    sql> select * from customer limit 1;


### PR DESCRIPTION
## What the recipe says

In the `## mode: sql_warehouse` section, step 6 (`databricks/README.md` line 328) reads:

> 6. Query against the Databricks table connected with `mode: spark_connect`

## What it should say

That step is inside the `sql_warehouse` walkthrough — the spicepod immediately above it (line 291) sets `mode: sql_warehouse` and the query targets the `customer` dataset registered there. The `mode: spark_connect` label was copy-pasted from the `spark_connect` section's step 6.

## What changed

Changed the step-6 label in the `sql_warehouse` section from `mode: spark_connect` to `mode: sql_warehouse`. The other two `spark_connect` step-6 labels (the `spark_connect` section and the M2M service-principal section, which both genuinely use `mode: spark_connect`) are left unchanged. No functional/config change — documentation accuracy only.