### PR TITLE
Fix search_github_files recipe: correct /v1/search score field to _score

### DIFF
--- a/search_github_files/README.md
+++ b/search_github_files/README.md
@@ -85,7 +85,7 @@ Result:
       "primary_key": {
         "path": "docs/EXTENSIBILITY.md"
       },
-      "score": 0.9217255119459336,
+      "_score": 0.9217255119459336,
       "dataset": "spiceai.files"
     },
     {
@@ -98,13 +98,15 @@ Result:
       "primary_key": {
         "path": "docs/dev/style_guide.md"
       },
-      "score": 0.8344974606243043,
+      "_score": 0.8344974606243043,
       "dataset": "spiceai.files"
     }
   ],
   "duration_ms": 86
 }
 ```
+
+> **Version note:** The relevance score is returned in the `_score` field (leading underscore) on Spice `v2.0+`. On `v1.x` it was returned as `score` (no underscore).
 
 4. Rerun the search, and retrieve the full document by adding `content` column to `additional_columns`).
 
@@ -136,7 +138,7 @@ Result:
       "primary_key": {
         "path": "docs/EXTENSIBILITY.md"
       },
-      "score": 0.9320302128251334,
+      "_score": 0.9320302128251334,
       "dataset": "spiceai.files"
     },
     {
@@ -150,7 +152,7 @@ Result:
       "primary_key": {
         "path": "docs/criteria/models/beta.md"
       },
-      "score": 0.8549700824464589,
+      "_score": 0.8549700824464589,
       "dataset": "spiceai.files"
     }
   ],
@@ -218,7 +220,7 @@ Result:
       "primary_key": {
         "path": "docs/EXTENSIBILITY.md"
       },
-      "score": 0.9320302128251334,
+      "_score": 0.9320302128251334,
       "dataset": "spiceai.files"
     },
     {
@@ -231,7 +233,7 @@ Result:
       "primary_key": {
         "path": "docs/criteria/models/beta.md"
       },
-      "score": 0.8549700824464589,
+      "_score": 0.8549700824464589,
       "dataset": "spiceai.files"
     }
   ],


### PR DESCRIPTION
## What the recipe said

The `search_github_files` recipe's expected `/v1/search` JSON output showed the relevance score in a `score` field (no underscore), in six places:

```json
"score": 0.9217255119459336,
```

## What the code does

In `spiceai/spiceai` at `v2.0.0`, the search response serializes the score in the **`_score`** field (leading underscore). `crates/runtime/src/search/types.rs`:

```rust
pub struct Match {
    ...
    #[serde(rename = "_score")]
    score: f64,
}
```

The `/v1/search` OpenAPI examples in `crates/runtime/src/http/v1/search.rs` likewise show `"_score"`. The field was named `score` on `v1.x` and renamed to `_score` in `v2.0`.

## What changed

- Renamed all six `"score"` occurrences in the expected JSON output to `"_score"`.
- Added a version note explaining the `v1.x` → `v2.0+` rename.

This matches the same fix already applied to the sibling recipes [azure_openai (#423)](https://github.com/spiceai/cookbook/pull/423) and [models/openai (#422)](https://github.com/spiceai/cookbook/pull/422).

Static finding (verified against source at `v2.0.0`); not run locally (requires a GitHub token + OpenAI API key).