### PR TITLE
Fix docker recipe: correct /v1/search score field to _score

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -181,7 +181,7 @@ curl -X POST http://localhost:8090/v1/search \
       "matches": {
         "description": "A Beautiful Story of a Dog And a Technical Writer who must Outgun a Student in A Balloon"
       },
-      "score": 0.8974827855112448,
+      "_score": 0.8974827855112448,
       "dataset": "spice.public.films",
       "data": {
         "rental_rate": 2.99,
@@ -193,7 +193,7 @@ curl -X POST http://localhost:8090/v1/search \
       "matches": {
         "description": "A Epic Documentary of a Hunter And a Dog who must Outgun a Dog in A Balloon Factory"
       },
-      "score": 0.8941260610769606,
+      "_score": 0.8941260610769606,
       "dataset": "spice.public.films",
       "data": {
         "title": "IGBY MAKER",
@@ -205,7 +205,7 @@ curl -X POST http://localhost:8090/v1/search \
       "matches": {
         "description": "A Boring Display of a Man And a Dog who must Redeem a Girl in A U-Boat"
       },
-      "score": 0.8896955774714774,
+      "_score": 0.8896955774714774,
       "dataset": "spice.public.films",
       "data": {
         "rental_rate": 0.99,
@@ -217,6 +217,8 @@ curl -X POST http://localhost:8090/v1/search \
   "duration_ms": 30
 }
 ```
+
+> **Version note:** The relevance score is returned in the `_score` field (leading underscore) on Spice `v2.0+`. On `v1.x` it was returned as `score` (no underscore).
 
 ### Using Language Model
 


### PR DESCRIPTION
## What the recipe said

The `docker` recipe's expected `/v1/search` JSON output showed the relevance score in a `score` field (no underscore), in three places:

```json
"score": 0.8974827855112448,
```

## What the code does

In `spiceai/spiceai` at `v2.0.0`, the search response serializes the score in the **`_score`** field (leading underscore). `crates/runtime/src/search/types.rs`:

```rust
pub struct Match {
    ...
    #[serde(rename = "_score")]
    score: f64,
}
```

The field was named `score` on `v1.x` and renamed to `_score` in `v2.0`. (The `spice search` CLI text output above — `Rank N, Score: …` — is a different format and is unchanged.)

## What changed

- Renamed all three `"score"` occurrences in the expected JSON output to `"_score"`.
- Added a version note explaining the `v1.x` → `v2.0+` rename.

This matches the same fix already applied to the sibling recipes [azure_openai (#423)](https://github.com/spiceai/cookbook/pull/423) and [models/openai (#422)](https://github.com/spiceai/cookbook/pull/422).

Static finding (verified against source at `v2.0.0`); not run locally (requires Docker).