### PR TITLE
Fix scylladb recipe: correct false 'no filter pushdown' claim

### DIFF
--- a/scylladb/README.md
+++ b/scylladb/README.md
@@ -150,7 +150,7 @@ Sample output:
 
 ## Using Acceleration for Better Performance
 
-Since ScyllaDB queries fetch all data for processing (filter pushdown is not supported), enabling acceleration is recommended for frequently queried tables:
+ScyllaDB pushes down partition-key equality filters (and clustering-key comparisons when a partition-key filter is also present); queries without a partition-key filter fetch all data and filter locally. Enabling acceleration is therefore recommended for frequently queried tables:
 
 ```yaml
 datasets:
@@ -230,7 +230,7 @@ The following SQL operations cannot be pushed down to ScyllaDB and are performed
 - **Aggregations**: COUNT, SUM, AVG, etc. are computed locally
 - **Subqueries**: Nested queries are not supported in CQL
 - **Window functions**: RANK, ROW_NUMBER, etc. not supported
-- **Complex WHERE clauses**: CQL requires partition key in WHERE; Spice fetches all data
+- **WHERE clauses without a partition key**: Partition-key equality and clustering-key comparison (`=`, `<`, `<=`, `>`, `>=`) filters are pushed down to CQL; queries without a partition-key filter fetch all data and filter locally
 - **ORDER BY**: Sorting is done locally
 
 ### Connector Limitations


### PR DESCRIPTION
## What the recipe said

The acceleration section claimed:

> Since ScyllaDB queries fetch all data for processing (filter pushdown is not supported), enabling acceleration is recommended...

and the CQL Limitations list said:

> - **Complex WHERE clauses**: CQL requires partition key in WHERE; Spice fetches all data

## What the code does

The ScyllaDB connector implements partition-key and clustering-key filter pushdown. From `spiceai/spiceai` at `v2.0.0`, `crates/data_components/src/scylladb/mod.rs`:

- Module doc (line 17): *"`ScyllaDB` connector module with CQL dialect and partition key filter pushdown support."*
- Pushes down **partition-key equality** (`WHERE pk = value`, returned `Exact`) and **clustering-key comparisons** `=`, `<`, `<=`, `>`, `>=` when a partition-key filter is present (`Inexact`).
- `supports_filters_pushdown` (line 121) delegates to the table schema; `scan` (lines 140–147) only fetches everything when **no** partition-key filter is present.

This pushdown has existed since the connector shipped (verified present at tag `v1.11.0`, the recipe's declared floor), so the claim was wrong across the entire supported range.

## What changed

- Acceleration rationale: now states that partition-key equality and clustering-key comparison filters push down, and only queries without a partition-key filter fetch all data and filter locally.
- CQL Limitations row reworded from "Complex WHERE clauses ... Spice fetches all data" to accurately scope the local-filtering case to queries lacking a partition-key filter.

Source: [crates/data_components/src/scylladb/mod.rs @ v2.0.0](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/data_components/src/scylladb/mod.rs)
