### PR TITLE
Fix dremio recipe: correct broken Data Accelerators docs link

### DIFF
--- a/dremio/README.md
+++ b/dremio/README.md
@@ -123,4 +123,4 @@ Time: 0.03241875 seconds. 7 rows.
 ```
 
 **Next Steps**
-This recipe accelerates query performance using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators). Experiment with different acceleration options by editing the dataset.yaml file or removing acceleration altogether to have the Spice runtime federate the query to Dremio directly.
+This recipe accelerates query performance using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators). Experiment with different acceleration options by editing the dataset.yaml file or removing acceleration altogether to have the Spice runtime federate the query to Dremio directly.


### PR DESCRIPTION
## What the recipe said

The "Improving Performance" section linked Data Accelerators as:

> [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators)

## What happens

That URL 301-redirects to `https://spiceai.org/docs/data-accelerators`, which returns **404**. Verified:

```
https://docs.spiceai.org/data-accelerators        -> 404 (after redirect)
https://spiceai.org/docs/components/data-accelerators -> 200
```

## What changed

Updated the link to the live page: `https://docs.spiceai.org/components/data-accelerators` (which redirects to the working `spiceai.org/docs/components/data-accelerators`).

Rest of the recipe audited against `spiceai/spiceai` at `v2.0.0` and verified correct (the `dremio_endpoint` param, `spice login dremio -u/-p`, `from: dremio:...` syntax, and the dataset-registration log line all match source).
