### PR TITLE
Fix dynamodb streams recipe: correct output mismatch and step numbering

### DIFF
--- a/dynamodb/streams/README.md
+++ b/dynamodb/streams/README.md
@@ -74,7 +74,7 @@ INFO runtime: All components are loaded. Spice runtime is ready!
 
 ---
 
-## Step 6. Insert Records and Watch Them Stream
+## Step 6. Query the Streamed Record
 
 In the Spice SQL REPL (run `spice sql` in another terminal), query the table:
 
@@ -94,9 +94,9 @@ You should see the new record:
 
 ---
 
-## Step 8. Update a Record and See the Change
+## Step 7. Insert Another Record and See the Change
 
-Update the order status:
+Insert a second order — it will stream into the table:
 
 ```bash
 aws dynamodb put-item --table-name orders --item \
@@ -110,20 +110,20 @@ Query again in the SQL REPL:
 SELECT * FROM orders_stream;
 ```
 
-The status should now be updated:
+The new record should now appear:
 
 ```console
 +-----------+----------+---------+---------+
 | id        | customer | amount  | status  |
 +-----------+----------+---------+---------+
 | order-001 | Alice    | 99.99   | pending |
-| order-002 | Bob      | 199.99  | pending |
+| order-002 | Bob      | 149.99  | pending |
 +-----------+----------+---------+---------+
 ```
 
 ---
 
-## Step 9. Cleanup
+## Step 8. Cleanup
 
 To delete the DynamoDB table:
 


### PR DESCRIPTION
## What the recipe said

The `dynamodb/streams` sub-recipe had three internal inconsistencies in its walkthrough (README prose, not config — nothing to verify against runtime source):

1. **Output mismatch.** Step "8" inserts `order-002` with `"amount": {"N": "149.99"}`, but the expected-output table showed `order-002 | Bob | 199.99`.
2. **Broken step numbering.** Steps ran 1 → 2 → 3 → 4 → 5 → 6 → **8** → 9 — there was no Step 7.
3. **Mislabeled action.** The insert step was titled *"Update a Record and See the Change"* and the prose said *"Update the order status"* / *"The status should now be updated"*, but the command is a `put-item` that adds a **new** record (`order-002`), not an update to `order-001`. Step 6 was titled *"Insert Records and Watch Them Stream"* but its body only queries the already-streamed record.

## What changed

- Corrected the expected-output amount `199.99` → `149.99` to match the inserted value.
- Renumbered the trailing steps so the sequence is contiguous (6 → 7 → 8).
- Retitled/reworded the insert step to reflect that it adds a second record, and renamed Step 6 to "Query the Streamed Record" to match what it actually does.

No config or source claims involved — this is a self-contained README correctness fix.
