### PR TITLE
Fix localpod recipe: correct README file_format to csv

### DIFF
--- a/localpod/README.md
+++ b/localpod/README.md
@@ -14,7 +14,7 @@ datasets:
     name: time_series
     description: taxi trips in s3
     params:
-      file_format: parquet
+      file_format: csv
     acceleration:
       enabled: true
       refresh_check_interval: 15s


### PR DESCRIPTION
## What the recipe said
The README's inline spicepod snippet declares the `time_series` dataset as `from: file:data.csv` but sets `params.file_format: parquet` ([localpod/README.md:17](https://github.com/spiceai/cookbook/blob/trunk/localpod/README.md)).

## What's wrong
A reader copying the README snippet verbatim would point the `file` connector at a CSV file while telling it to parse Parquet, which fails to load the dataset. The recipe's shipped `spicepod.yaml` (`file_format: csv`) and the bundled `data.csv` both use CSV — only the README snippet drifted.

## What changed
Aligned the README inline snippet to `file_format: csv`, matching `localpod/spicepod.yaml` and the data file.

Verified against the shipped `localpod/spicepod.yaml` and `localpod/data.csv` in this repo.