### PR TITLE
Fix ftp recipe: correct broken FTP connector docs link

### DIFF
--- a/ftp/README.md
+++ b/ftp/README.md
@@ -82,4 +82,4 @@ Time: 0.011731833 seconds. 5 rows.
 make clean
 ```
 
-[Learn more](https://docs.spiceai.org/data-connectors/ftp) about Spice FTP/SFTP Data Connector.
+[Learn more](https://docs.spiceai.org/components/data-connectors/ftp) about Spice FTP/SFTP Data Connector.


### PR DESCRIPTION
## What the recipe said
The closing "Learn more" link pointed to `https://docs.spiceai.org/data-connectors/ftp` ([ftp/README.md:85](https://github.com/spiceai/cookbook/blob/trunk/ftp/README.md)).

## What's wrong
That path 404s — connector docs now live under `/components/`. Verified:
- `https://docs.spiceai.org/data-connectors/ftp` → 301 → `spiceai.org/docs/data-connectors/ftp` → **404 Not Found**
- `https://docs.spiceai.org/components/data-connectors/ftp` → 301 → `spiceai.org/docs/components/data-connectors/ftp` → **200, "FTP/SFTP Data Connector" page**

## What changed
Added the `/components/` path segment so the link resolves.