### PR TITLE
Fix postgres/supabase recipe: correct broken PostgreSQL connector docs link

### DIFF
--- a/postgres/supabase/README.md
+++ b/postgres/supabase/README.md
@@ -39,7 +39,7 @@ insert into spice_test (value) values (10), (20), (30), (40), (50);
     pg_sslmode: require
 ```
 
-See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
+See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/components/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
 
 Ensure the `PG_PASS` environment variable is set to the password for your Supabase instance. Environment variables can be specified on the command line when running the Spice runtime, or in a `.env` file in the same directory as `spicepod.yaml`.
 


### PR DESCRIPTION
## What the recipe said
The closing line links to `https://docs.spiceai.org/data-connectors/postgres` ([postgres/supabase/README.md:42](https://github.com/spiceai/cookbook/blob/trunk/postgres/supabase/README.md)).

## What's wrong
That path 404s — connector docs now live under `/components/`. `https://docs.spiceai.org/data-connectors/postgres` → 301 → `spiceai.org/docs/data-connectors/postgres` → **404**, while `https://docs.spiceai.org/components/data-connectors/postgres` resolves.

## What changed
Added the `/components/` path segment so the link resolves.