### PR TITLE
Fix postgres/rds recipe: correct broken PostgreSQL connector docs link

### DIFF
--- a/postgres/rds/README.md
+++ b/postgres/rds/README.md
@@ -23,7 +23,7 @@ Follow these steps to get started with federated SQL query against AWS RDS for P
 echo "PG_PASS=<password>" > .env
 ```
 
-See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
+See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/components/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
 
 To securely store the RDS password, see [Secret Stores](https://docs.spiceai.org/components/secret-stores)
 


### PR DESCRIPTION
## What the recipe said
Links to `https://docs.spiceai.org/data-connectors/postgres` ([postgres/rds/README.md:26](https://github.com/spiceai/cookbook/blob/trunk/postgres/rds/README.md)).

## What's wrong
That path 404s — connector docs now live under `/components/`. `https://docs.spiceai.org/data-connectors/postgres` → 301 → `spiceai.org/docs/data-connectors/postgres` → **404**, while `https://docs.spiceai.org/components/data-connectors/postgres` resolves.

## What changed
Added the `/components/` path segment so the link resolves.