### PR TITLE
Fix postgres/accelerator recipe: correct broken Spice.ai connector docs link

### DIFF
--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -55,7 +55,7 @@ spice init postgres-demo
 cd postgres-demo
 ```
 
-**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/data-connectors/spiceai).
+**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/components/data-connectors/spiceai).
 
 ```bash
 spice login


### PR DESCRIPTION
## What the recipe said
Step 3 links to `https://docs.spiceai.org/data-connectors/spiceai` ([postgres/accelerator/README.md:58](https://github.com/spiceai/cookbook/blob/trunk/postgres/accelerator/README.md)).

## What's wrong
That path 404s — connector docs now live under `/components/`. `https://docs.spiceai.org/data-connectors/spiceai` → 301 → `spiceai.org/docs/data-connectors/spiceai` → **404**, while `https://docs.spiceai.org/components/data-connectors/spiceai` resolves (verified live).

## What changed
Added the `/components/` path segment so the link resolves.