### PR TITLE
Fix sqlite/accelerator recipe: correct broken Advanced Data Refresh link

### DIFF
--- a/sqlite/accelerator/README.md
+++ b/sqlite/accelerator/README.md
@@ -6,7 +6,7 @@ Follow this recipe to configure dataset acceleration using SQLite.
 
 _Tip: Open and refer to the [SQLite Data Accelerator](https://spiceai.org/docs/components/data-accelerators/sqlite) documentation while completing this recipe._
 
-_Tip: Follow the [Advanced Data Refresh Recipe](../data-refresh/README.md) to learn more about advanced data refresh scenarios, such as programmatically updating `refresh_sql` and triggering data refreshes._
+_Tip: Follow the [Advanced Data Refresh Recipe](../../acceleration/data-refresh/README.md) to learn more about advanced data refresh scenarios, such as programmatically updating `refresh_sql` and triggering data refreshes._
 
 ## Step 1. Initialize the Spice app
 


### PR DESCRIPTION
## What the recipe said
A tip links to the Advanced Data Refresh Recipe via `../data-refresh/README.md` ([sqlite/accelerator/README.md:9](https://github.com/spiceai/cookbook/blob/trunk/sqlite/accelerator/README.md)).

## What's wrong
From `sqlite/accelerator/`, `../data-refresh/README.md` resolves to `sqlite/data-refresh/README.md`, which does not exist (the `sqlite/` dir only contains `accelerator/`). The data-refresh recipe actually lives at `acceleration/data-refresh/`.

## What changed
Repointed the link to `../../acceleration/data-refresh/README.md` (verified the target file exists).