### PR TITLE
Fix snowflake recipe: show tables row count and broken Data Accelerators link

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -108,7 +108,7 @@ sql> show tables;
 | spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
-Time: 0.032075708 seconds. 2 rows.
+Time: 0.032075708 seconds. 3 rows.
 ```
 
 Run _Pricing Summary Report Query (Q1)_. More information about TPC-H and all the queries involved can be found in the official [TPC Benchmark H Standard Specification](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf).

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -153,7 +153,7 @@ Output:
 Time: 1.398187833 seconds. 4 rows.
 ```
 
-**Step 7. (Optional)** Enable [Data Acceleration](https://docs.spiceai.org/data-accelerators)
+**Step 7. (Optional)** Enable [Data Acceleration](https://docs.spiceai.org/components/data-accelerators)
 
 Use text editor to update `spicepod.yaml`
 


### PR DESCRIPTION
Two fixes to the Snowflake recipe README:

## 1. `show tables` row count
The example output lists three tables — `lineitem`, `task_history`, `metrics` — but the footer reported `2 rows` ([snowflake/README.md:111](https://github.com/spiceai/cookbook/blob/trunk/snowflake/README.md)). Corrected to `3 rows` to match the displayed result set.

## 2. Broken Data Accelerators docs link
Step 7 linked to `https://docs.spiceai.org/data-accelerators`, which 404s — accelerator docs now live under `/components/` (verified: bare path → 404; `https://docs.spiceai.org/components/data-accelerators` → 200). Same fix direction as the merged dremio fix (#432).