### PR TITLE
Fix spiceai recipe: correct broken Data Accelerators docs link

### DIFF
--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -131,6 +131,6 @@ Time: 0.852775583 seconds. 10 rows.
 ```
 
 **Next Steps**
-This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
+This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators).
 
 View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.


### PR DESCRIPTION
## What the recipe said
The Next Steps section links to `https://docs.spiceai.org/data-accelerators` ([spiceai/README.md:134](https://github.com/spiceai/cookbook/blob/trunk/spiceai/README.md)).

## What's wrong
That path 404s — accelerator docs now live under `/components/` (verified: `spiceai.org/docs/data-accelerators` → 404; `https://docs.spiceai.org/components/data-accelerators` → 200). Same fix direction as the merged dremio fix (#432).

## What changed
Added the `/components/` path segment so the link resolves.