### PR TITLE
Fix caching/sql_results recipe: correct broken data-refresh docs link

### DIFF
--- a/caching/sql_results/README.md
+++ b/caching/sql_results/README.md
@@ -2,7 +2,7 @@
 
 Works with `v1.10+`
 
-> Spice.ai OSS supports in-memory caching of query results to improve performance for bursts of requests and non-accelerated results, such as refresh data returned [on zero results](https://docs.spiceai.org/data-accelerators/data-refresh#behavior-on-zero-results).
+> Spice.ai OSS supports in-memory caching of query results to improve performance for bursts of requests and non-accelerated results, such as refresh data returned [on zero results](https://docs.spiceai.org/features/data-acceleration/data-refresh#behavior-on-zero-results).
 >
 > [Spice.ai OSS Docs: Results Caching](https://docs.spiceai.org/features/caching)
 


### PR DESCRIPTION
## What the recipe said
The intro note links 'on zero results' to `https://docs.spiceai.org/data-accelerators/data-refresh#behavior-on-zero-results` ([caching/sql_results/README.md:5](https://github.com/spiceai/cookbook/blob/trunk/caching/sql_results/README.md)).

## What's wrong
That path 404s. The Data Refresh documentation — which contains the **Behavior on Zero Results** section — now lives at `/features/data-acceleration/data-refresh`. (Verified: `docs.spiceai.org/data-accelerators/data-refresh` and `/components/data-accelerators/data-refresh` both 404; `https://docs.spiceai.org/features/data-acceleration/data-refresh` resolves with a "Behavior on Zero Results" heading.)

## What changed
Repointed the link to `https://docs.spiceai.org/features/data-acceleration/data-refresh#behavior-on-zero-results`.