### PR TITLE
Fix views recipe: correct dead Views docs link (404)

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -2,7 +2,7 @@
 
 Works with `v1.0+`
 
-This recipe demonstrates how to use accelerated [Views](https://spiceai.org/docs/components/views) to pre-calculate and materialize data derived from one or more underlying datasets. By defining views that aggregate, join, or transform source data in advance, you can significantly improve the performance of analytical queries. In this recipe, we will create a locally accelerated view for the [TPC-H Q21 - Suppliers Who Kept Orders Waiting](https://github.com/spiceai/cookbook/tree/trunk/tpc-h) report.
+This recipe demonstrates how to use accelerated [Views](https://spiceai.org/docs/reference/spicepod/views) to pre-calculate and materialize data derived from one or more underlying datasets. By defining views that aggregate, join, or transform source data in advance, you can significantly improve the performance of analytical queries. In this recipe, we will create a locally accelerated view for the [TPC-H Q21 - Suppliers Who Kept Orders Waiting](https://github.com/spiceai/cookbook/tree/trunk/tpc-h) report.
 
 ---
 
@@ -290,4 +290,4 @@ Example output:
 
 ## Additional Resources
 
-- [Views Documentation](https://spiceai.org/docs/components/views)
+- [Views Documentation](https://spiceai.org/docs/reference/spicepod/views)


### PR DESCRIPTION
## What the recipe says

The views recipe links to the Views documentation at `https://spiceai.org/docs/components/views` in two places (views/README.md:5 and views/README.md:293).

## What the code/site does

That URL now returns **HTTP 404** — the Views reference page moved under `reference/spicepod/`:

| URL | Status |
| --- | --- |
| `https://spiceai.org/docs/components/views` | 404 |
| `https://spiceai.org/docs/reference/spicepod/views` | 200 |

(`docs.spiceai.org/components/views` 404s as well; `docs.spiceai.org/reference/spicepod/views` is 200.)

## What changed

Updated both links to `https://spiceai.org/docs/reference/spicepod/views`.

Verified live against the published docs site on 2026-06-11.