### PR TITLE
Fix tpc-h recipe: remove metrics table/server from default-run output

### DIFF
--- a/tpc-h/README.md
+++ b/tpc-h/README.md
@@ -30,7 +30,6 @@ The following output is shown in the Spice runtime terminal:
 2024/12/31 09:36:45 INFO Spice.ai runtime starting...
 2024-12-31T00:36:46.690599Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
 2024-12-31T00:36:46.690681Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-12-31T00:36:46.690713Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-12-31T00:36:46.691410Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-12-31T00:36:46.692600Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-12-31T00:36:46.887621Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
@@ -77,7 +76,6 @@ show tables;
 | table_catalog | table_schema | table_name   | table_type |
 +---------------+--------------+--------------+------------+
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 | spice         | public       | customer     | BASE TABLE |
 | spice         | public       | region       | BASE TABLE |
 | spice         | public       | lineitem     | BASE TABLE |


### PR DESCRIPTION
## What the recipe says

With a plain `spice run` + `spice add spiceai/tpch`, the recipe shows:
- a startup line `runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090` (tpc-h/README.md:33), and
- a `spice | runtime | metrics | BASE TABLE` row in `show tables` (tpc-h/README.md:80).

The `show tables` block lists **10** rows but its footer says `9 rows` — internally inconsistent.

## What the code does

Prometheus metrics are **disabled by default** in v2.0. The `--metrics` flag is `Option<SocketAddr>` defaulting to `None` ([bin/spiced/src/lib.rs:312-314](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spiced/src/lib.rs#L312)), and `prometheus_registry = args.metrics.map(...)` is `None` when unset ([lib.rs:461](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spiced/src/lib.rs#L461)). The `runtime.metrics` table is only registered when metrics are enabled ([crates/runtime/src/init/metrics.rs:25-39](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/runtime/src/init/metrics.rs#L25)). So neither the `metrics_server` listening line nor the `runtime.metrics` table appears for a default `spice run`.

## What changed

Removed the `metrics_server` startup line and the `runtime.metrics` row from the `show tables` output. The remaining 9 rows now match the `9 rows` footer.

(Left the unrelated stale OpenTelemetry log line untouched.)

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable).