### PR TITLE
Fix nvidia-nim/kubernetes recipe: bump stale image tag to 2.0.0

### DIFF
--- a/nvidia-nim/kubernetes/spiceai.yaml
+++ b/nvidia-nim/kubernetes/spiceai.yaml
@@ -1,6 +1,6 @@
 image:
   repository: spiceai/spiceai
-  tag: 1.0.0-rc.1-models # `-models` is required for the LLMs
+  tag: 2.0.0
 
 # This could be any Spicepod components you like!
 spicepod:


### PR DESCRIPTION
## What the recipe says

`nvidia-nim/kubernetes/spiceai.yaml:3` pins the runtime image to `tag: 1.0.0-rc.1-models` with a comment that the `-models` suffix "is required for the LLMs".

## What the code does

That tag is an RC from before v2.0 GA, and the `-models` image variant no longer exists. In v2.0 the Helm chart default is `tag: 2.0.0` with no suffix ([deploy/chart/values.yaml:6](https://github.com/spiceai/spiceai/blob/v2.0.0/deploy/chart/values.yaml#L6)), and model support is built into the standard release image ([Dockerfile-release](https://github.com/spiceai/spiceai/blob/v2.0.0/Dockerfile-release)). A reader deploying this manifest would pull a stale pre-release image.

## What changed

Bumped `tag` to `2.0.0` (current stable) and dropped the obsolete `-models` comment.

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable).