### PR TITLE
Fix models/filesystem recipe: drop no-op model_type param for file: models

### DIFF
--- a/models/filesystem/README.md
+++ b/models/filesystem/README.md
@@ -49,8 +49,6 @@ Spice is configured to load the model from the `phi-3-mini` folder (downloaded i
 models:
   - from: file:phi-3-mini
     name: local_model
-    params:
-      model_type: phi3
 ```
 
 Run Spice

--- a/models/filesystem/spicepod.yaml
+++ b/models/filesystem/spicepod.yaml
@@ -5,5 +5,3 @@ name: local_model
 models:
   - from: file:phi-3-mini
     name: local_model
-    params:
-      model_type: phi3


### PR DESCRIPTION
## What the recipe says

The filesystem-model recipe configures the local Phi-3 model with `params: model_type: phi3` (models/filesystem/spicepod.yaml:8-9 and the snippet at models/filesystem/README.md:52-53), presenting it as load configuration.

## What the code does

`model_type` is **not a valid parameter for `file:` models**. The `file:` ParameterSpec only declares `chat_template` plus the common params ([crates/runtime/src/model/params/file.rs](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/runtime/src/model/params/file.rs)), and the `file()` chat loader never reads `model_type` — only the `huggingface()` loader does. Unknown params are silently dropped with a warning (`Ignoring parameter \`model_type\`: not supported for model file.`). The model type is inferred from the directory's `config.json`; the param has no effect.

## What changed

Removed the no-op `params: model_type: phi3` block from both the spicepod and the README snippet so the recipe reflects what the runtime actually uses. The model still loads via weight auto-discovery from the `phi-3-mini` folder.

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable). Flagging as a judgment call — the param is harmless (just warns), so a reviewer may prefer to keep it; happy to adjust.