### PR TITLE
Fix models/openai recipe: correct copy-pasted spicepod name

### DIFF
--- a/models/openai/spicepod.yaml
+++ b/models/openai/spicepod.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: azure_openai
+name: openai
 
 datasets:
   - from: github:github.com/spiceai/spiceai/files/trunk


### PR DESCRIPTION
## What the recipe says

The OpenAI model recipe's spicepod declares `name: azure_openai` (models/openai/spicepod.yaml:3) — a copy-paste leftover from the sibling `azure_openai` recipe. The recipe is entirely about OpenAI (`from: openai:gpt-4o`, `openai:text-embedding-3-small`).

## What changed

Renamed the spicepod to `openai` to match the recipe. Cosmetic only — the spicepod `name` is an identifier and does not change runtime behavior — but the mismatch is confusing for a reader.

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable).