### PR TITLE
Fix llm-memory recipe: tool endpoints require runtime.auth in v2.0

### DIFF
--- a/llm-memory/README.md
+++ b/llm-memory/README.md
@@ -106,16 +106,29 @@ You are Alice, and you work as a software engineer.
 
 ### Using Memory Tools Directly
 
+> **Note (Spice `v2.0+`):** Tool-invocation endpoints (`/v1/tools/*`) require an authentication provider to be configured on the runtime. Without `runtime.auth` these routes return `401 Unauthorized`. To call them, add an API-key provider to `spicepod.yml`:
+>
+> ```yaml
+> runtime:
+>   auth:
+>     api-key:
+>       enabled: true
+>       keys:
+>         - ${ secrets:SPICE_API_KEY }
+> ```
+>
+> and pass the key as an `x-api-key` header (shown below). Enabling `runtime.auth` applies to all endpoints, so the earlier `spice chat` step then also needs credentials (`spice chat --api-key <key>`). See the [api_key recipe](https://github.com/spiceai/cookbook/tree/trunk/api_key) for the full flow.
+
 **Step 1.** Store a memory directly
 
 ```shell
-curl -XPOST http://127.0.0.1:8090/v1/tool/store_memory -d '{"thoughts": ["Alice deserves a promotion"]}'
+curl -XPOST http://127.0.0.1:8090/v1/tools/store_memory -H "x-api-key: $SPICE_API_KEY" -d '{"thoughts": ["Alice deserves a promotion"]}'
 ```
 
 **Step 2.** Load stored memories
 
 ```shell
-curl -XPOST http://127.0.0.1:8090/v1/tool/load_memory -d '{"last": "10m"}'
+curl -XPOST http://127.0.0.1:8090/v1/tools/load_memory -H "x-api-key: $SPICE_API_KEY" -d '{"last": "10m"}'
 ```
 
 Output:


### PR DESCRIPTION
## What the recipe says

The "Using Memory Tools Directly" section calls `curl -XPOST http://127.0.0.1:8090/v1/tool/store_memory ...` and `.../v1/tool/load_memory ...` against a plain `spice run` (llm-memory/README.md:107-119). The recipe's spicepod configures no auth.

## What the code does

In v2.0 the tool-invocation routes are gated behind authentication. `/v1/tools/*` (and the deprecated singular `/v1/tool/{name}`) sit behind a `require_auth_configured` layer that returns **401** when no `runtime.auth` provider is attached — see [crates/runtime/src/http/routes.rs](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/runtime/src/http/routes.rs) ("Tool invocation routes require authentication to be configured … we refuse these routes at the edge with a 401"). So the two curl commands fail on a default run.

The chat-based memory flow (Steps 1–6, `spice chat` with `tools: memory`) is unaffected — only this direct-curl section breaks.

## What changed

- Added a `v2.0+` note explaining the routes now require `runtime.auth`, with the minimal `api-key` provider config and a pointer to the [api_key recipe](https://github.com/spiceai/cookbook/tree/trunk/api_key).
- Updated the two calls to the current plural route `/v1/tools/` (the singular form is deprecated) and added the required `x-api-key` header.

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable).