### PR TITLE
Fix partitioning recipe: correct version floor to v1.11.0+

### DIFF
--- a/acceleration/partitioning/README.md
+++ b/acceleration/partitioning/README.md
@@ -1,6 +1,6 @@
 # Dataset Partitioning
 
-Works with `v1.8+`
+Works with `v1.11.0+`
 
 This recipe demonstrates how to partition accelerated datasets to improve query performance by enabling partition pruning for queries. Partitioning groups rows into separate files based on an expression, allowing Spice to skip reading unnecessary partitions during queries.
 


### PR DESCRIPTION
## What the recipe says

`acceleration/partitioning/README.md:3` claims the recipe "Works with `v1.8+`".

## What the code does

The recipe configures `engine: cayenne` with `partition_by: [bucket(50, PULocationID)]` (README.md:34, 116-119). The `Engine::Cayenne` spicepod variant — i.e. the ability to write `engine: cayenne` — was **not introduced until v1.11.0**:

- `engine.rs` at `v1.10.0` contains no `Cayenne` variant (`git show v1.10.0:crates/runtime-acceleration/src/engine.rs | grep -c Cayenne` → 0).
- It is present at `v1.11.0` (added by [#8858](https://github.com/spiceai/spiceai/pull/8858)), which also carries Cayenne partition support.

On v1.8/v1.9/v1.10 the runtime cannot parse `engine: cayenne`, so the recipe fails. `v1.8+` predates the engine entirely.

## What changed

Corrected the version floor to `v1.11.0+`.

Verified against `spiceai/spiceai` tags v1.10.0 and v1.11.0; current stable is v2.0.0.