### PR TITLE
Fix kafka recipe: remove dead data_generator.py volume mount

### DIFF
--- a/kafka/compose.yaml
+++ b/kafka/compose.yaml
@@ -53,7 +53,6 @@ services:
       MPS: "1" # messages per second
     volumes:
       - ./producer.py:/app/producer.py:ro
-      - ./data_generator.py:/app/data_generator.py:ro
     entrypoint: >
       sh -c "pip install -q confluent-kafka && python -u /app/producer.py"
   


### PR DESCRIPTION
## What the recipe says

`kafka/compose.yaml:56` mounts `./data_generator.py:/app/data_generator.py:ro` into the producer container.

## What's actually there

There is no `data_generator.py` in the `kafka/` recipe directory, and `producer.py` (the actual entrypoint, `python -u /app/producer.py`) is self-contained — it imports only stdlib and `confluent_kafka`, never `data_generator`. Docker Compose creates an empty directory at the missing bind-mount source, so the mount is dead weight (harmless, but confusing).

## What changed

Removed the unused `data_generator.py` volume line. The recipe still runs unchanged via `producer.py`.

(Static finding; recipe runs against a local Docker stack.)