### PR TITLE
Fix async-queries recipe: correct 'spice query list' header to STATE

### DIFF
--- a/async-queries/README.md
+++ b/async-queries/README.md
@@ -214,7 +214,7 @@ spice query list --status running
 ```
 
 ```console
-QUERY ID                STATUS    CREATED                    SQL PREVIEW
+QUERY ID                STATE     CREATED                    SQL PREVIEW
 01ABC-DEF-456-7890AB    RUNNING   2026-03-02T12:00:00+00:00  SELECT * FROM data
 
 Total: 1 queries


### PR DESCRIPTION
## What the recipe says

The `spice query list --status running` example output (async-queries/README.md:217) shows the column header `QUERY ID  STATUS  CREATED  SQL PREVIEW`.

## What the code does

The `spice query list` CLI table header is `QUERY ID | STATE | CREATED | SQL PREVIEW` — see [bin/spice/src/commands/query/mod.rs:217](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spice/src/commands/query/mod.rs#L217). The recipe prints `STATUS` where the CLI prints `STATE`.

(The `--status` filter flag is correct and unchanged. The separate REPL `.list` output later in the recipe at line 258 — `QUERY ID | STATUS | SUBMITTED | SQL` — is a different code path and **does** print `STATUS` per [mod.rs:568](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spice/src/commands/query/mod.rs#L568), so it was left untouched.)

## What changed

Changed the `spice query list` example header from `STATUS` to `STATE` (kept alignment).

Verified against `spiceai/spiceai` at tag `v2.0.0` (current stable).