### PR TITLE
Fix llama recipe: correct stale make install-with-models-* targets

### DIFF
--- a/llama/README.md
+++ b/llama/README.md
@@ -108,7 +108,7 @@ Follow the [CUDA Toolkit installation guide](https://developer.nvidia.com/cuda-d
 ```sh
 git clone git@github.com:spiceai/spiceai.git
 cd spiceai
-make install-with-models-cuda
+make install-cuda
 ```
 
 ### For Apple M-series (Metal)
@@ -122,5 +122,5 @@ make install-with-models-cuda
 ```sh
 git clone git@github.com:spiceai/spiceai.git
 cd spiceai
-make install-with-models-metal
+make install-metal
 ```


### PR DESCRIPTION
## What the recipe said

The *Optional: Enable Hardware Acceleration* section instructs readers to build Spice from source with:

```sh
make install-with-models-cuda   # NVIDIA GPU (CUDA)
make install-with-models-metal  # Apple M-series (Metal)
```

## What the code does

Those Make targets no longer exist. The duplicate `install-with-models` target was removed back in v1.9 (`spiceai/spiceai` PR #8107). In current Spice the default `make install` **includes models by default**, and hardware acceleration is built with dedicated targets:

- `crates`/.. → root `Makefile` (tag `v2.0.0`):
  - `install-cuda` → `make install SPICED_NON_DEFAULT_FEATURES="cuda"`
  - `install-metal` → `make install SPICED_NON_DEFAULT_FEATURES="metal"`
  - comment: `# Default install includes models. Use -data suffix variants to build without models.`

Running `make install-with-models-cuda` today fails with `make: *** No rule to make target 'install-with-models-cuda'`.

Source verified at `spiceai/spiceai` tag `v2.0.0` (current stable).

## What changed

- `make install-with-models-cuda` → `make install-cuda`
- `make install-with-models-metal` → `make install-metal`