### PR TITLE
Fix ftp recipe: correct broken Data Connector docs link

### DIFF
--- a/ftp/README.md
+++ b/ftp/README.md
@@ -82,4 +82,4 @@ Time: 0.011731833 seconds. 5 rows.
 make clean
 ```
 
-[Learn more](https://docs.spiceai.org/data-connectors/ftp) about Spice FTP/SFTP Data Connector.
+[Learn more](https://docs.spiceai.org/components/data-connectors/ftp) about Spice FTP/SFTP Data Connector.


### PR DESCRIPTION
## What the recipe said

The **Next Steps** section linked to the FTP/SFTP connector docs:

```
[Learn more](https://docs.spiceai.org/data-connectors/ftp) about Spice FTP/SFTP Data Connector.
```

## What the docs do

`https://docs.spiceai.org/data-connectors/ftp` 301-redirects to `https://spiceai.org/docs/data-connectors/ftp`, which returns **HTTP 404**. The connector reference pages now live under `/components/`; `https://docs.spiceai.org/components/data-connectors/ftp` resolves (HTTP 200, *"FTP/SFTP Data Connector | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the single docs link in `ftp/README.md`. No other changes.

Verified against current stable **spiceai v2.0.0**.