### PR TITLE
Fix snowflake recipe: correct broken Data Accelerators docs link

### DIFF
--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -153,7 +153,7 @@ Output:
 Time: 1.398187833 seconds. 4 rows.
 ```
 
-**Step 7. (Optional)** Enable [Data Acceleration](https://docs.spiceai.org/data-accelerators)
+**Step 7. (Optional)** Enable [Data Acceleration](https://docs.spiceai.org/components/data-accelerators)
 
 Use text editor to update `spicepod.yaml`
 


### PR DESCRIPTION
## What the recipe said

Step 7 (Optional) links to the accelerators docs:

```
**Step 7. (Optional)** Enable [Data Acceleration](https://docs.spiceai.org/data-accelerators)
```

## What the docs do

`https://docs.spiceai.org/data-accelerators` 301-redirects to `spiceai.org/docs/data-accelerators` → **HTTP 404**. The page now lives at `https://docs.spiceai.org/components/data-accelerators` (HTTP 200, *"Data Accelerators | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the single docs link in `snowflake/README.md`.

Verified against current stable **spiceai v2.0.0**.