### PR TITLE
Fix spiceai recipe: correct broken Data Accelerators docs link

### DIFF
--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -131,6 +131,6 @@ Time: 0.852775583 seconds. 10 rows.
 ```
 
 **Next Steps**
-This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
+This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators).
 
 View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.


### PR DESCRIPTION
## What the recipe said

The closing paragraph links to the accelerators docs:

```
... Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
```

## What the docs do

`https://docs.spiceai.org/data-accelerators` now returns **HTTP 404** (the page moved under `/components/`). `https://docs.spiceai.org/components/data-accelerators` resolves (HTTP 200, *"Data Accelerators | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the single docs link in `spiceai/README.md`.

Verified against current stable **spiceai v2.0.0**.