### PR TITLE
Fix postgres/supabase recipe: correct broken PostgreSQL Data Connector docs link

### DIFF
--- a/postgres/supabase/README.md
+++ b/postgres/supabase/README.md
@@ -39,7 +39,7 @@ insert into spice_test (value) values (10), (20), (30), (40), (50);
     pg_sslmode: require
 ```
 
-See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
+See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/components/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
 
 Ensure the `PG_PASS` environment variable is set to the password for your Supabase instance. Environment variables can be specified on the command line when running the Spice runtime, or in a `.env` file in the same directory as `spicepod.yaml`.
 


### PR DESCRIPTION
## What the recipe said

```
See the [datasets reference](...) ... and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options ...
```

## What the docs do

`https://docs.spiceai.org/data-connectors/postgres` now returns **HTTP 404** (page moved under `/components/`). `https://docs.spiceai.org/components/data-connectors/postgres` resolves (HTTP 200, *"PostgreSQL Data Connector | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the PostgreSQL Data Connector link in `postgres/supabase/README.md`. The sibling `reference/spicepod/datasets` link is unaffected (still valid).

Verified against current stable **spiceai v2.0.0**.