### PR TITLE
Fix postgres/rds recipe: correct broken PostgreSQL Data Connector docs link

### DIFF
--- a/postgres/rds/README.md
+++ b/postgres/rds/README.md
@@ -23,7 +23,7 @@ Follow these steps to get started with federated SQL query against AWS RDS for P
 echo "PG_PASS=<password>" > .env
 ```
 
-See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
+See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [PostgreSQL Data Connector](https://docs.spiceai.org/components/data-connectors/postgres) for more options on configuring a PostgreSQL Data Connector.
 
 To securely store the RDS password, see [Secret Stores](https://docs.spiceai.org/components/secret-stores)
 


### PR DESCRIPTION
## What the recipe said

```
See the [datasets reference](...) ... and [PostgreSQL Data Connector](https://docs.spiceai.org/data-connectors/postgres) for more options ...
```

## What the docs do

`https://docs.spiceai.org/data-connectors/postgres` now returns **HTTP 404** (page moved under `/components/`). `https://docs.spiceai.org/components/data-connectors/postgres` resolves (HTTP 200, *"PostgreSQL Data Connector | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the PostgreSQL Data Connector link in `postgres/rds/README.md`. The sibling `reference/spicepod/datasets` link is unaffected (still valid).

Verified against current stable **spiceai v2.0.0**.