### PR TITLE
Fix postgres/accelerator recipe: correct broken Spice.ai Data Connector docs link

### DIFF
--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -55,7 +55,7 @@ spice init postgres-demo
 cd postgres-demo
 ```
 
-**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/data-connectors/spiceai).
+**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/components/data-connectors/spiceai).
 
 ```bash
 spice login


### PR DESCRIPTION
## What the recipe said

```
**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/data-connectors/spiceai).
```

## What the docs do

`https://docs.spiceai.org/data-connectors/spiceai` now returns **HTTP 404** (page moved under `/components/`). `https://docs.spiceai.org/components/data-connectors/spiceai` resolves (HTTP 200, *"Spice.ai Data Connector | Spice.ai OSS"*). The `cli/reference/login` link in the same line is still valid and left unchanged.

## What changed

Inserted `/components/` into the Spice.ai Data Connector link in `postgres/accelerator/README.md`.

Verified against current stable **spiceai v2.0.0**.