### PR TITLE
Fix mysql/planetscale recipe: correct broken MySQL Data Connector docs link

### DIFF
--- a/mysql/planetscale/README.md
+++ b/mysql/planetscale/README.md
@@ -24,7 +24,7 @@ Follow these steps to get started with federated SQL query against [Planetscale]
 - `[mysql_user]` with the username from the generated credentials in step 3.
 - `[mysql_db]` with the name of your Planetscale database.
 
-See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [MySQL Data Connector](https://docs.spiceai.org/data-connectors/mysql) for more options on configuring a MySQL Data Connector.
+See the [datasets reference](https://docs.spiceai.org/reference/spicepod/datasets) for more dataset configuration options and [MySQL Data Connector](https://docs.spiceai.org/components/data-connectors/mysql) for more options on configuring a MySQL Data Connector.
 
 Ensure the `MYSQL_PASS` environment variable is set to the password for your Planetscale instance. Environment variables can be specified on the command line when running the Spice runtime, or in a `.env` file in the same directory as `spicepod.yaml`.
 


### PR DESCRIPTION
## What the recipe said

```
See the [datasets reference](...) ... and [MySQL Data Connector](https://docs.spiceai.org/data-connectors/mysql) for more options ...
```

## What the docs do

`https://docs.spiceai.org/data-connectors/mysql` now returns **HTTP 404** (page moved under `/components/`). `https://docs.spiceai.org/components/data-connectors/mysql` resolves (HTTP 200, *"MySQL Data Connector | Spice.ai OSS"*).

## What changed

Inserted `/components/` into the MySQL Data Connector link in `mysql/planetscale/README.md`. The sibling `reference/spicepod/datasets` link is unaffected (still valid).

Verified against current stable **spiceai v2.0.0**.