### PR TITLE
Fix caching/sql_results recipe: correct broken data-refresh docs link

### DIFF
--- a/caching/sql_results/README.md
+++ b/caching/sql_results/README.md
@@ -2,7 +2,7 @@
 
 Works with `v1.10+`
 
-> Spice.ai OSS supports in-memory caching of query results to improve performance for bursts of requests and non-accelerated results, such as refresh data returned [on zero results](https://docs.spiceai.org/data-accelerators/data-refresh#behavior-on-zero-results).
+> Spice.ai OSS supports in-memory caching of query results to improve performance for bursts of requests and non-accelerated results, such as refresh data returned [on zero results](https://docs.spiceai.org/features/data-acceleration/data-refresh#behavior-on-zero-results).
 >
 > [Spice.ai OSS Docs: Results Caching](https://docs.spiceai.org/features/caching)
 


### PR DESCRIPTION
## What the recipe said

The intro note links to data-refresh behavior:

```
... refresh data returned [on zero results](https://docs.spiceai.org/data-accelerators/data-refresh#behavior-on-zero-results).
```

## What the docs do

`https://docs.spiceai.org/data-accelerators/data-refresh` now returns **HTTP 404**. Data refresh moved under `/features/data-acceleration/`; `https://docs.spiceai.org/features/data-acceleration/data-refresh` resolves (HTTP 200, *"Data Refresh | Spice.ai OSS"*) and still has the **Behavior on Zero Results** section (anchor preserved).

## What changed

Repointed the single docs link in `caching/sql_results/README.md` to `/features/data-acceleration/data-refresh#behavior-on-zero-results`.

Verified against current stable **spiceai v2.0.0**.