### PR TITLE
Fix caching/accelerator recipe: correct broken caching refresh-mode docs link

### DIFF
--- a/caching/accelerator/README.md
+++ b/caching/accelerator/README.md
@@ -182,5 +182,5 @@ The caching accelerator is ideal for:
 
 ## Learn More
 
-- [Caching Accelerator Documentation](https://docs.spiceai.org/features/data-accelerators/refresh-modes/caching)
+- [Caching Accelerator Documentation](https://docs.spiceai.org/features/data-acceleration/refresh-modes/caching)
 - [HTTPS Connector Documentation](https://docs.spiceai.org/components/data-connectors/https)


### PR DESCRIPTION
## What the recipe said

The closing links section:

```
- [Caching Accelerator Documentation](https://docs.spiceai.org/features/data-accelerators/refresh-modes/caching)
```

## What the docs do

The path segment is `data-accelerators` (plural), but the feature lives under `data-acceleration` (singular). `.../features/data-accelerators/refresh-modes/caching` returns **HTTP 404**; `.../features/data-acceleration/refresh-modes/caching` resolves (HTTP 200, *caching refresh mode* docs).

## What changed

Corrected the single docs link in `caching/accelerator/README.md` (`data-accelerators` → `data-acceleration`).

Verified against current stable **spiceai v2.0.0**.