### PR TITLE
Fix docker recipe: correct broken Search API docs link

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -162,7 +162,7 @@ A Intrepid Reflection of a Waitress And a A Shark who must Kill a Squirrel in Th
 Time: 32ms. 10 results.
 ```
 
-Or using API: https://docs.spiceai.org/api/http/search
+Or using API: https://docs.spiceai.org/api/HTTP/post-search
 
 ```shell
 curl -X POST http://localhost:8090/v1/search \


### PR DESCRIPTION
## What the recipe said

```
Or using API: https://docs.spiceai.org/api/http/search
```

## What the docs do

`https://docs.spiceai.org/api/http/search` returns **HTTP 404**. The Search API endpoint reference is at `https://docs.spiceai.org/api/HTTP/post-search` (HTTP 200, *"Search | Spice.ai OSS"*) — the same path the full-text-search recipe already uses.

## What changed

Repointed the single Search API link in `docker/README.md`.

Verified against current stable **spiceai v2.0.0**.