### PR TITLE
Fix elasticsearch/connector recipe: note connector requires a feature build

### DIFF
--- a/elasticsearch/connector/README.md
+++ b/elasticsearch/connector/README.md
@@ -11,7 +11,7 @@ The Elasticsearch connector can also power `vector_search`, `text_search`, and `
 
 ## Prerequisites
 
-- [Spice CLI](https://docs.spiceai.org/getting-started) installed
+- **Spice with Elasticsearch support**: the Elasticsearch connector is not included in the released binaries. Build and run Spice with the `elasticsearch` feature enabled, e.g. `cargo run --release --features elasticsearch -p spiced`. See the [Elasticsearch Data Connector documentation](https://spiceai.org/docs/components/data-connectors/elasticsearch) for details.
 - Docker installed
 
 ## Getting Started


### PR DESCRIPTION
## What the recipe says

The `elasticsearch/connector` recipe lists only **Spice CLI** + **Docker** as prerequisites and starts the runtime with `spice run`, implying it works on a stock `v2.0+` install.

## What the code does

The Elasticsearch data connector is **feature-gated and excluded from all released binaries**. Verified against `spiceai/spiceai` at tag `v2.0.0`:

- `connector-elasticsearch` is an **optional** dependency — [`bin/spiced/Cargo.toml:19`](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spiced/Cargo.toml#L19)
- `elasticsearch` is **absent** from the `default` feature list, and `release = []`
- The release build compiles with `--features release,models[,postgres-accel]` ([`build_and_release.yml:238,244`](https://github.com/spiceai/spiceai/blob/v2.0.0/.github/workflows/build_and_release.yml#L238)) — none of which pull in `elasticsearch`; `models = ["runtime/models"]` does not include it either
- Connector registration is gated by `#[cfg(feature = "elasticsearch")]` — [`bin/spiced/src/lib.rs:116-119`](https://github.com/spiceai/spiceai/blob/v2.0.0/bin/spiced/src/lib.rs#L116)

So a reader following the recipe on a binary from `curl https://install.spiceai.org | bash` (or the official Docker image, which defaults to `CARGO_FEATURES=default`) cannot register the `articles`/`all_types` Elasticsearch datasets — `spice run` errors on startup.

## What changed

Adds a Prerequisites note that Spice must be built/run with the `elasticsearch` feature (e.g. `cargo run --release --features elasticsearch -p spiced`), mirroring how the existing **odbc** recipe documents the same build requirement for its feature-gated connector.