### PR TITLE
Fix arrow recipe: Step 3 output shows acceleration before it is enabled

### DIFF
--- a/arrow/README.md
+++ b/arrow/README.md
@@ -37,7 +37,7 @@ datasets:
 spice run
 ```
 
-Confirm in the terminal output the `taxi_trips` dataset has been loaded:
+Confirm in the terminal output the `taxi_trips` dataset has been registered:
 
 ```bash
 2025/07/14 08:50:13 INFO Checking for latest Spice runtime release...
@@ -45,13 +45,10 @@ Confirm in the terminal output the `taxi_trips` dataset has been loaded:
 2025-07-14T15:50:15.370061Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
 2025-07-14T15:50:15.370199Z  INFO runtime::init::caching: Initialized search results cache;
 2025-07-14T15:50:15.732242Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-07-14T15:50:15.732235Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-07-14T15:50:15.734062Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
 2025-07-14T15:50:15.738931Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-07-14T15:50:16.608896Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2025-07-14T15:50:16.610030Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-07-14T15:50:29.423673Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 12s 813ms.
-2025-07-14T15:50:29.494757Z  INFO runtime: All components are loaded. Spice runtime is ready!
+2025-07-14T15:50:16.608896Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
+2025-07-14T15:50:16.610030Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 **Step 4.** Run queries against the dataset using the Spice SQL REPL.


### PR DESCRIPTION
## What the recipe says

In **Step 3**, `taxi_trips` is registered with **no acceleration block** (acceleration is only added in Step 5). Yet the pasted Step 3 output shows:

```
Dataset taxi_trips registered (...), acceleration (arrow), results cache enabled.
Loading data for dataset taxi_trips
Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 12s 813ms.
```

This output cannot occur for a non-accelerated dataset, and it contradicts the recipe's own arc: Step 4 has the reader "observe the long query time" (1.08s federated S3 scan), and Steps 5-7 are about *enabling* acceleration to make queries fast. Showing the data already fully loaded into Arrow at Step 3 undercuts the whole walkthrough.

## What the code does

Verified against `spiceai/spiceai` at tag `v2.0.0`: the `acceleration (...)` clause is only appended to the registration line when `acceleration.enabled` is true — [`crates/runtime/src/tracing_util.rs:36-44`](https://github.com/spiceai/spiceai/blob/v2.0.0/crates/runtime/src/tracing_util.rs#L36). With no acceleration block, no `refresh_task` runs, so there are no `Loading`/`Loaded` lines. The sibling `duckdb`/`cayenne` recipes correctly show the plain registration line at this step.

## What changed

- Step 3 registration line: dropped the `acceleration (arrow)` clause and the two `Loading`/`Loaded` refresh-task lines, so it reads `Dataset taxi_trips registered (...), results cache enabled.`
- Adjusted the lead-in prose from "has been loaded" to "has been registered".
- Removed the `OpenTelemetry listening on 127.0.0.1:50052` line from the same block — that log line does not exist in v2.0.