### PR TITLE
Fix search/elasticsearch recipe: correct broken Full-Text Search docs link

### DIFF
--- a/search/elasticsearch/README.md
+++ b/search/elasticsearch/README.md
@@ -201,7 +201,7 @@ Time: 0.274407607 seconds. 3 rows.
 
 ### Hybrid Search with RRF
 
-Fuse BM25 and vector results with [Reciprocal Rank Fusion (RRF)](https://spiceai.org/docs/next/features/search#hybrid-search-with-rrf) for the best of both search modes:
+Fuse BM25 and vector results with [Reciprocal Rank Fusion (RRF)](https://spiceai.org/docs/features/search#hybrid-search-with-rrf) for the best of both search modes:
 
 ```sql
 SELECT id, title, category, _fused_score
@@ -421,7 +421,7 @@ This means a single Elasticsearch cluster serves all search modalities, keeping 
 
 - [Elasticsearch Documentation](https://spiceai.org/docs/components/vectors/elasticsearch)
 
-- [Full-Text Search Documentation](https://spiceai.org/docs/features/search/full-text-search)
+- [Full-Text Search Documentation](https://spiceai.org/docs/features/search/full-text)
 - [Vector Search Documentation](https://spiceai.org/docs/features/search/vector-search)
 - [Hybrid Search with RRF](https://spiceai.org/docs/features/search#hybrid-search-with-rrf)
 - [Datasets Reference](https://spiceai.org/docs/reference/spicepod/datasets)


### PR DESCRIPTION
## What the recipe says

The "Learn more" section links Full-Text Search docs at `https://spiceai.org/docs/features/search/full-text-search`, and the inline RRF reference uses the unreleased `/docs/next/` channel: `https://spiceai.org/docs/next/features/search#hybrid-search-with-rrf`.

## What the code does

- `https://spiceai.org/docs/features/search/full-text-search` returns **HTTP 404**. The live page is `https://spiceai.org/docs/features/search/full-text` (verified — it renders the full-text search docs, covering both the Tantivy and Elasticsearch engines).
- The `/docs/next/` path is the unreleased docs channel and will drift; the same recipe's "Hybrid Search with RRF" link already uses the stable `/docs/features/search#hybrid-search-with-rrf`.

## What changed

- Fixed the broken Full-Text Search link: `.../search/full-text-search` → `.../search/full-text`.
- Normalized the inline RRF link from `/docs/next/features/search...` to the stable `/docs/features/search...`, matching the Learn-more entry.