### PR TITLE
Fix databricks catalog recipe: correct azure storage account key param

### DIFF
--- a/catalogs/databricks/README.md
+++ b/catalogs/databricks/README.md
@@ -72,7 +72,7 @@ params:
   mode: delta_lake
   databricks_token: ${env:DATABRICKS_TOKEN}
   databricks_azure_storage_account_name: ${env:AZURE_ACCOUNT_NAME}
-  databricks_azure_account_key: ${env:AZURE_ACCOUNT_KEY}
+  databricks_azure_storage_account_key: ${env:AZURE_ACCOUNT_KEY}
 ```
 
 Set the `AZURE_ACCOUNT_NAME` and `AZURE_ACCOUNT_KEY` environment variables to the Azure storage account name and account key, respectively.


### PR DESCRIPTION
### What the recipe said

In **"Using Delta Lake directly against Azure Blob Storage"** the spicepod params used:

```yaml
databricks_azure_storage_account_name: ${env:AZURE_ACCOUNT_NAME}
databricks_azure_account_key: ${env:AZURE_ACCOUNT_KEY}
```

### What the code does

The Databricks catalog connector's `ParameterSpec` list defines the Azure storage credentials as `azure_storage_account_*` — there is **no** `azure_account_key`:

```rust
ParameterSpec::component("azure_storage_account_name")   // databricks.rs:138
ParameterSpec::component("azure_storage_account_key")    // databricks.rs:141
```

With the component prefix, the valid param is **`databricks_azure_storage_account_key`** — matching the `databricks_azure_storage_account_name` already used on the line above. As written, `databricks_azure_account_key` is unrecognized, so the account key is never applied and Azure Blob authentication fails.

Source: `spiceai/spiceai` @ `v2.0.1` — [`crates/runtime/src/catalogconnector/databricks.rs:141`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/runtime/src/catalogconnector/databricks.rs#L141)

### What changed

`databricks_azure_account_key` → `databricks_azure_storage_account_key`.

Verified statically against the v2.0.1 source (recipe requires Databricks + Azure credentials, so not run locally).
