### PR TITLE
Fix search recipe: use _fused_score in spicepod system prompt examples

### DIFF
--- a/search/spicepod.yml
+++ b/search/spicepod.yml
@@ -72,27 +72,27 @@ embeddings:
 
 #         **Basic hybrid search:**
 #         ```sql
-#         SELECT fused_score, text, created_at
+#         SELECT _fused_score, text, created_at
 #         FROM rrf(
 #             text_search(bluesky_posts, 'breaking news'),
 #             vector_search(bluesky_posts, 'latest updates')
 #         )
-#         ORDER BY fused_score DESC LIMIT 10;
+#         ORDER BY _fused_score DESC LIMIT 10;
 #         ```
 
 #         **With rank weighting (within individual searches):**
 #         ```sql
-#         SELECT fused_score, text, rkey
+#         SELECT _fused_score, text, rkey
 #         FROM rrf(
 #             text_search(bluesky_posts, 'climate change', rank_weight => 300.0),
 #             vector_search(bluesky_posts, 'environmental crisis', rank_weight => 100.0)
 #         )
-#         ORDER BY fused_score DESC LIMIT 15;
+#         ORDER BY _fused_score DESC LIMIT 15;
 #         ```
 
 #         **With recency boosting (exponential decay):**
 #         ```sql
-#         SELECT fused_score, text, created_at
+#         SELECT _fused_score, text, created_at
 #         FROM rrf(
 #             text_search(bluesky_posts, 'market crash'),
 #             vector_search(bluesky_posts, 'financial crisis'),
@@ -101,12 +101,12 @@ embeddings:
 #             decay_constant => 0.1,
 #             decay_scale_secs => 3600
 #         )
-#         ORDER BY fused_score DESC LIMIT 10;
+#         ORDER BY _fused_score DESC LIMIT 10;
 #         ```
 
 #         **With linear decay and custom join key:**
 #         ```sql
-#         SELECT fused_score, text, rkey, created_at
+#         SELECT _fused_score, text, rkey, created_at
 #         FROM rrf(
 #             text_search(bluesky_posts, 'election results'),
 #             vector_search(bluesky_posts, 'voting outcomes'),
@@ -115,18 +115,18 @@ embeddings:
 #             recency_decay => 'linear',
 #             decay_window_secs => 86400
 #         )
-#         ORDER BY fused_score DESC LIMIT 20;
+#         ORDER BY _fused_score DESC LIMIT 20;
 #         ```
 
 #         **With custom k parameter:**
 #         ```sql
-#         SELECT fused_score, text, langs
+#         SELECT _fused_score, text, langs
 #         FROM rrf(
 #             text_search(bluesky_posts, 'technology trends'),
 #             vector_search(bluesky_posts, 'tech innovation'),
 #             k => 20.0
 #         )
-#         ORDER BY fused_score DESC LIMIT 12;
+#         ORDER BY _fused_score DESC LIMIT 12;
 #         ```
 
 #         When answering questions:


### PR DESCRIPTION
### What the recipe said

`search/spicepod.yml` ships a commented-out `models` block whose `system_prompt` gives the agent example `rrf(...)` queries. Step 4 ("Enable agentic support") tells the reader to **uncomment** this block. Every example selected and ordered by the bare `fused_score` column:

```sql
SELECT fused_score, text, created_at
FROM rrf( ... )
ORDER BY fused_score DESC LIMIT 10;
```

### What the code does

`rrf(...)` emits the fusion score under **`_fused_score`** in `v2.0+` — the column was renamed from `fused_score` (v1.x):

```rust
// crates/runtime/src/search/rrf.rs
pub const RRF_FUSED_SCORE_COLUMN_NAME: &str = "_fused_score";
```

So once Step 4's block is uncommented, the agent is taught queries that reference a column that no longer exists, and they fail on `v2.0+`. The README body and its version note (line 3) already use `_fused_score` — only the spicepod's system-prompt examples were left on the old name.

Source: `spiceai/spiceai` @ `v2.0.1` — [`crates/runtime/src/search/rrf.rs`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/runtime/src/search/rrf.rs)

### What changed

Updated all 10 `fused_score` references in the `spicepod.yml` system-prompt examples to `_fused_score`, matching the README body. Consistent with the v1.x→v2.0 rename already documented in the recipe and previously corrected elsewhere (#430, #455).

Verified statically against v2.0.1 source.
