### PR TITLE
Fix spiceai catalog recipe: correct catalog name and SHOW TABLES output

### DIFF
--- a/catalogs/spiceai/README.md
+++ b/catalogs/spiceai/README.md
@@ -80,10 +80,9 @@ sql> show tables;
 | scp           | tpch         | customer     | BASE TABLE |
 | scp           | tpch         | partsupp     | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 +---------------+--------------+--------------+------------+
 
-Time: 0.005605209 seconds. 10 rows.
+Time: 0.005605209 seconds. 9 rows.
 ```
 
 ## Step 8. Filter the included tables with `include`
@@ -106,14 +105,13 @@ sql> show tables;
 +---------------+--------------+---------------+------------+
 | table_catalog | table_schema | table_name    | table_type |
 +---------------+--------------+---------------+------------+
-| spiceai       | tpch         | partsupp      | BASE TABLE |
-| spiceai       | tpch         | part          | BASE TABLE |
-| spiceai       | tpch         | supplier      | BASE TABLE |
+| scp           | tpch         | partsupp      | BASE TABLE |
+| scp           | tpch         | part          | BASE TABLE |
+| scp           | tpch         | supplier      | BASE TABLE |
 | spice         | runtime      | task_history  | BASE TABLE |
-| spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
-Time: 0.001866958 seconds. 9 rows.
+Time: 0.001866958 seconds. 4 rows.
 ```
 
 ## Step 9. Add the Quickstart Catalog
@@ -136,15 +134,14 @@ sql> show tables;
 +---------------+--------------+--------------+------------+
 | table_catalog | table_schema | table_name   | table_type |
 +---------------+--------------+--------------+------------+
-| spiceai       | tpch         | partsupp     | BASE TABLE |
-| spiceai       | tpch         | part         | BASE TABLE |
-| spiceai       | tpch         | supplier     | BASE TABLE |
+| scp           | tpch         | partsupp     | BASE TABLE |
+| scp           | tpch         | part         | BASE TABLE |
+| scp           | tpch         | supplier     | BASE TABLE |
 | quickstart    | public       | taxi_trips   | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 +---------------+--------------+--------------+------------+
 
-Time: 0.011640125 seconds. 6 rows.
+Time: 0.011640125 seconds. 5 rows.
 
 sql> SELECT trip_distance, fare_amount FROM quickstart.public.taxi_trips LIMIT 10;
 +---------------+-------------+


### PR DESCRIPTION
### What the recipe said

The catalog is registered as `name: scp` (Steps 4–9, unchanged):

```yaml
catalogs:
  - from: spice.ai/spiceai/tpch
    name: scp
```

Step 7's `SHOW TABLES` correctly shows `scp` as `table_catalog`. But **Steps 8 and 9** show the same catalog's tpch tables under `table_catalog` = **`spiceai`**:

```
| spiceai       | tpch         | partsupp      | BASE TABLE |
| spiceai       | tpch         | part          | BASE TABLE |
| spiceai       | tpch         | supplier      | BASE TABLE |
```

Separately, all three blocks listed a `spice | runtime | metrics` row.

### What the code does

- **Catalog name** comes from the `name:` field; it does not change between steps, so the column must read `scp` everywhere, as Step 7 already shows. The `spiceai` values in Steps 8–9 are a copy-paste artifact.
- **`runtime.metrics`** is only registered when the metrics server is enabled, which is **off by default**. A default `spice run` + `spice sql` session never lists it:

```rust
// crates/runtime/src/lib.rs:1185
.register_metrics_table(self.prometheus_registry.is_some())
// crates/runtime/src/init/metrics.rs:29
if metrics_enabled { /* register */ }
```

Source: `spiceai/spiceai` @ `v2.0.1` — [`crates/runtime/src/init/metrics.rs:25-42`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/runtime/src/init/metrics.rs#L25-L42)

### What changed

- Steps 8 & 9: `table_catalog` `spiceai` → `scp`.
- Removed the off-by-default `spice | runtime | metrics` row from all three `SHOW TABLES` blocks and corrected the trailing row counts (Step 7 `10 → 9`, Step 8 `9 → 4`, Step 9 `6 → 5`). Consistent with #446 / #441.

Verified statically against v2.0.1 source (recipe requires a Spice.ai Cloud account, so not run locally). The catalog-name correction is provable from the recipe's own config independent of runtime.
