### PR TITLE
Fix mongodb/connector recipe: correct version floor to v1.6.0+

### DIFF
--- a/mongodb/connector/README.md
+++ b/mongodb/connector/README.md
@@ -1,6 +1,6 @@
 # MongoDB Data Connector
 
-Works with `v1.0+`
+Works with `v1.6.0+`
 
 This recipe will use a demo instance of MongoDB with a generated dataset. Follow the recipe to create MongoDB instance and get started with MongoDB as a Data Connector.
 
@@ -130,10 +130,8 @@ Confirm in the terminal output the `sample_data` dataset has been loaded:
 ```bash
 2025/01/13 11:52:51 INFO Spice.ai runtime starting...
 2025-01-13T19:52:51.473621Z  INFO runtime::init::dataset: Initializing dataset sample_data
-2025-01-13T19:52:51.474059Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-13T19:52:51.474795Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-13T19:52:51.474869Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-13T19:52:51.481201Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-13T19:52:51.491591Z  INFO runtime::init::dataset: Dataset sample_data registered (mongodb:sample_data).
 2025-01-13T19:52:51.673260Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
 ```
@@ -177,7 +175,7 @@ Time: 0.011687958 seconds. 10 rows.
 
 For more information on using `spice sql`, see the [CLI reference](https://docs.spiceai.org/cli/reference/sql).
 
-**Step 6.** Cleanup
+**Step 7.** Cleanup
 
 ```bash
 docker rm -f mongodb-cookbook


### PR DESCRIPTION
## What the recipe said

The `mongodb/connector` recipe declared **`Works with \`v1.0+\``**, and its Step 5 expected `spice run` output included a metrics-server line and an OpenTelemetry line.

## What the code does

- The **MongoDB data connector was introduced in v1.6.0**, not v1.0.0. It is absent from the connector registry at `v1.0.0`–`v1.5.0` and first registered at `v1.6.0`:
  - `spiceai/spiceai` @ `v1.6.0` — [`crates/runtime/src/dataconnector/mod.rs:402`](https://github.com/spiceai/spiceai/blob/v1.6.0/crates/runtime/src/dataconnector/mod.rs#L402): `register_connector_factory("mongodb", mongodb::MongoDBFactory::new_arc())`. At `v1.5.0` there is no MongoDB connector source or registration.
- In **v2.0** the metrics server is **off by default** — `metrics: Option<SocketAddr>` defaults to `None` and the server only starts with `--metrics` ([`bin/spiced/src/lib.rs` @ v2.0.1](https://github.com/spiceai/spiceai/blob/v2.0.1/bin/spiced/src/lib.rs#L314)), so the `Spice Runtime Metrics listening on …:9090` line does not appear in a default `spice run`.
- The **`runtime::opentelemetry: Spice Runtime OpenTelemetry listening on …:50052`** log line no longer exists in v2.0 — the string was removed from the codebase entirely (no match for `OpenTelemetry listening` at `v2.0.1`).

## What changed

- Version floor `v1.0+` → `v1.6.0+`.
- Removed the two stale log lines (metrics server + OpenTelemetry) from the Step 5 expected output so it matches a default v2.0 `spice run`.
- Fixed duplicate `Step 6.` heading (cleanup step → `Step 7.`).

Verified against `spiceai/spiceai` at tags `v1.5.0`, `v1.6.0`, and `v2.0.1`.