### PR TITLE
Fix kafka recipe: correct version floor to v1.6.0+

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -1,6 +1,6 @@
 # Live Orders Analytics with Apache Kafka Data Connector
 
-Works with `v1.0+`
+Works with `v1.6.0+`
 
 In this recipe, you'll learn how to combine real-time data streaming from Kafka with other datasets using federated queries. The setup uses Apache Kafka with a test producer generating order events to the `orders_events` topic. The Spice runtime consumes these events, keeping an accelerated `orders` dataset updated in real time, enabling you to join this live data with other sources (such as S3 TPC-H benchmark data) for powerful analytics.
 
@@ -70,7 +70,6 @@ Observe that Spice loads data from the configured Kafka topic into the `orders` 
 2025-08-24T05:06:40.086387Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
 2025-08-24T05:06:40.086548Z  INFO runtime::init::caching: Initialized search results cache;
 2025-08-24T05:06:40.525189Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-08-24T05:06:40.534247Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-24T05:06:40.538475Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-24T05:06:40.575784Z  INFO runtime::init::dataset: Dataset nation initializing...
 2025-08-24T05:06:40.575784Z  INFO runtime::init::dataset: Dataset supplier initializing...


### PR DESCRIPTION
## What the recipe said

The kafka recipe declared **`Works with \`v1.0+\``** and its expected `spice run` output included an OpenTelemetry log line.

## What the code does

- The **Apache Kafka data connector was introduced in v1.6.0**, not v1.0.0. It is absent from the connector registry at `v1.0.0`–`v1.5.0` and first registered at `v1.6.0`:
  - `spiceai/spiceai` @ `v1.6.0` — [`crates/runtime/src/dataconnector/mod.rs:427`](https://github.com/spiceai/spiceai/blob/v1.6.0/crates/runtime/src/dataconnector/mod.rs#L427): `register_connector_factory("kafka", kafka::KafkaFactory::new_arc())`. There is no kafka connector factory at `v1.5.0`.
  - Corroborated by the recipe's own example output, which shows `Starting runtime v1.6.0-unstable-build…`.
- The **`runtime::opentelemetry: Spice Runtime OpenTelemetry listening on …:50052`** log line no longer exists in v2.0 — the string was removed from the codebase entirely (no match for `OpenTelemetry listening` at `v2.0.1`).

## What changed

- Version floor `v1.0+` → `v1.6.0+`.
- Removed the stale OpenTelemetry log line from the expected `spice run` output so it matches a default v2.0 run.

Verified against `spiceai/spiceai` at tags `v1.5.0`, `v1.6.0`, and `v2.0.1`.