### PR TITLE
Fix hashed_partitioning recipe: correct version floor to v1.9.0+

### DIFF
--- a/hashed_partitioning/README.md
+++ b/hashed_partitioning/README.md
@@ -1,6 +1,6 @@
 # Hashed Partitioning with DuckDB
 
-Works with `v1.0+`
+Works with `v1.9.0+`
 
 Accelerate queries on terabyte and petabyte-scale datasets using hashed partitioning, which prunes irrelevant data during filters on categorical columns like IDs.
 


### PR DESCRIPTION
## What the recipe said

The hashed_partitioning recipe declared **`Works with \`v1.0+\``**.

## What the code does

The recipe accelerates a dataset with `engine: duckdb`, `mode: file`, and `partition_by: [bucket(10, PULocationID)]`. DuckDB **file-mode partitioning with the `bucket()` partition expression** was introduced in **v1.9.0**:

- First commit adding the partitioning module `crates/spicepod/src/partitioning.rs` is [`8f6982a` — "Hive-style partitioning for DuckDB file mode (#7563)"](https://github.com/spiceai/spiceai/pull/7563); the earliest release tag containing it is `v1.9.0`.
- At `v1.9.0` the partitioned-DuckDB code documents the `bucket(...)` expression (`crates/runtime/src/dataaccelerator/partitioned_duckdb/tables_mode/mod.rs`: `// For example: "bucket(3, passenger_count)=2"`).
- The `partition_by` acceleration config does not exist on `v1.0`–`v1.8`, so the recipe's `spicepod.yaml` cannot be parsed there.

## What changed

Corrected the version floor `v1.0+` → `v1.9.0+`.

(Note: this differs from the sibling `acceleration/partitioning` recipe's `v1.11.0+` floor, which is gated on `engine: cayenne`, introduced later in v1.11.0. This recipe uses `engine: duckdb`, available since v1.9.0.)

Verified against `spiceai/spiceai` tags `v1.8.0`, `v1.9.0`, and `v2.0.1`.