### PR TITLE
Fix full-text-search recipe: correct version floor to v2.0+

### DIFF
--- a/full-text-search/README.md
+++ b/full-text-search/README.md
@@ -1,6 +1,6 @@
 # Full-Text Search with Spice
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 Full-text search uses BM25 scoring to retrieve records matching keywords in indexed columns. This cookbook demonstrates how to configure and query full-text search indexes on markdown files from the Spice cookbook repository.
 


### PR DESCRIPTION
## What the recipe said

The full-text-search recipe declared **`Works with \`v1.0+\``**.

## What the code does

Every search example in the recipe references the **`_score`** column — e.g. `SELECT path, _score FROM text_search(cookbook_files, 'vector search', content) ORDER BY _score DESC`, and the `/v1/search` response shows `"_score": …`. The search score column name was **`score`** until v2.0, when it was renamed to **`_score`**:

- `spiceai/spiceai` @ `v1.11.0` — [`crates/search/src/lib.rs:29`](https://github.com/spiceai/spiceai/blob/v1.11.0/crates/search/src/lib.rs#L29): `pub static SEARCH_SCORE_COLUMN_NAME: &str = "score";`
- `spiceai/spiceai` @ `v2.0.1` — [`crates/search/src/lib.rs:29`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/search/src/lib.rs#L29): `pub static SEARCH_SCORE_COLUMN_NAME: &str = "_score";`

On v1.x the `text_search()` results and `/v1/search` response expose a `score` column, so the recipe's `_score` queries fail. The recipe was written for the v2.0 search surface.

## What changed

Corrected the version floor `v1.0+` → `v2.0+`.

Verified against `spiceai/spiceai` tags `v1.11.0` and `v2.0.1`; current stable is `v2.0.1`.