### PR TITLE
Fix catalogs DB recipes: correct version floor to v2.0+

### DIFF
--- a/catalogs/mssql/README.md
+++ b/catalogs/mssql/README.md
@@ -1,6 +1,6 @@
 # Microsoft SQL Server Catalog Connector
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 The Microsoft SQL Server Catalog Connector enables Spice to automatically discover and query all schemas and tables in an MSSQL database. This recipe demonstrates the connector using the standard TPC-H benchmark dataset (Scale Factor 1) with full foreign key constraints defined between tables.
 

--- a/catalogs/mysql/README.md
+++ b/catalogs/mysql/README.md
@@ -1,6 +1,6 @@
 # MySQL Catalog Connector
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 The MySQL Catalog Connector enables Spice to automatically discover and query all databases and tables in a MySQL server. This recipe demonstrates the connector using the standard TPC-H benchmark dataset (Scale Factor 1) with full foreign key constraints defined between tables.
 

--- a/catalogs/postgres/README.md
+++ b/catalogs/postgres/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Catalog Connector
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 The PostgreSQL Catalog Connector enables Spice to automatically discover and query all schemas and tables in a PostgreSQL database. This recipe demonstrates the connector using the standard TPC-H benchmark dataset (Scale Factor 1) with full foreign key constraints defined between tables.
 


### PR DESCRIPTION
The PostgreSQL, MySQL, and MSSQL **catalog** recipes each declare `Works with v1.0+`, but those catalog connectors did not exist before v2.0.

**What the recipes say:** `Works with v1.0+` (catalogs/postgres, catalogs/mysql, catalogs/mssql).

**What the code does:** The Postgres/MySQL/MSSQL catalog connectors were introduced together by [spiceai/spiceai#9509](https://github.com/spiceai/spiceai/pull/9509) ("feat: Implement catalog connectors for various databases", commit `128b60d0`) and first shipped in **v2.0**. At tags `v1.6.0` and `v1.11.0`, `crates/runtime/src/catalogconnector/` contains only `databricks.rs`, `glue.rs`, `iceberg.rs`, `spice_cloud.rs`, and `unity_catalog.rs` — no `postgres.rs`/`mysql.rs`/`mssql.rs`. They first appear at `v2.0.1` ([`crates/runtime/src/catalogconnector/`](https://github.com/spiceai/spiceai/tree/v2.0.1/crates/runtime/src/catalogconnector)).

**Change:** Bump the floor on all three recipes to `Works with v2.0+`, matching the sibling `catalogs/unity_catalog` recipe which already declares `v2.0+`.

Verified against `spiceai/spiceai` at tag `v2.0.1`. These three sibling recipes share one identical one-line fix derived from a single source fact, so they are grouped here.