### PR TITLE
Fix github recipe: correct version floor to v1.6.0+

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -1,6 +1,6 @@
 # GitHub Data Connector
 
-Works with `v1.0+`
+Works with `v1.6+`
 
 This recipe will use the [spiceai/spiceai](https://github.com/spiceai/spiceai) repo for a demo.
 


### PR DESCRIPTION
The GitHub connector recipe declares `Works with v1.0+`, but it relies on PR-comment features that did not ship until v1.6.0.

**What the recipe says:** `Works with v1.0+`.

**What the code does:** The spicepod sets `github_include_comments: all` and `github_max_comments_fetched: 100`, and the README queries the `review_comments` and `discussion` columns (UNNEST examples). The `include_comments` param and the `review_comments`/`discussion` columns were added by [spiceai/spiceai#6569](https://github.com/spiceai/spiceai/pull/6569) ("Initial support for PR comments") and first shipped in **v1.6.0**. `include_comments` does not exist in the GitHub connector source at `v1.5.0` (`crates/runtime/src/dataconnector/github/`).

**Change:** Bump the floor to `Works with v1.6+`. The recipe as written cannot run on v1.0–v1.5.

Verified against `spiceai/spiceai`: param/columns present at [`v1.6.0`](https://github.com/spiceai/spiceai/blob/v1.6.0/crates/runtime/src/dataconnector/github/mod.rs), absent at v1.5.0.