### PR TITLE
Fix mongodb/connector recipe: correct version floor to v1.6+

### DIFF
--- a/mongodb/connector/README.md
+++ b/mongodb/connector/README.md
@@ -1,6 +1,6 @@
 # MongoDB Data Connector
 
-Works with `v1.0+`
+Works with `v1.6+`
 
 This recipe will use a demo instance of MongoDB with a generated dataset. Follow the recipe to create MongoDB instance and get started with MongoDB as a Data Connector.
 
@@ -177,7 +177,7 @@ Time: 0.011687958 seconds. 10 rows.
 
 For more information on using `spice sql`, see the [CLI reference](https://docs.spiceai.org/cli/reference/sql).
 
-**Step 6.** Cleanup
+**Step 7.** Cleanup
 
 ```bash
 docker rm -f mongodb-cookbook


### PR DESCRIPTION
## What the recipe said
`mongodb/connector/README.md` declares **`Works with `v1.0+``** at the top.

## What the code does
The MongoDB Data Connector first shipped in **Spice v1.6.0**. The connector source `crates/data_components/src/mongodb.rs` is present at tag `v1.6.0` but **absent from `v1.5.0` and all earlier tags** (verified in `spiceai/spiceai` at the release tags). On any v1.0–v1.5 runtime the recipe fails — there is no `mongodb:` connector to register.

## What changed
- `Works with `v1.0+`` → `Works with `v1.6+`` (accurate floor).
- Fixed duplicate **Step 6** numbering: the *Cleanup* step was labeled `Step 6` alongside the query step; renumbered to **Step 7**.

All `mongodb_*` params in the recipe verified valid against the v2.0.1 `ParameterSpec` (`crates/data_components/src/mongodb.rs`).

Source ref: `spiceai/spiceai` tags `v1.5.0` / `v1.6.0` (connector dir presence) and `v2.0.1` (param spec).