### PR TITLE
Fix spiceai recipe: correct two broken docs links

### DIFF
--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -131,6 +131,6 @@ Time: 0.852775583 seconds. 10 rows.
 ```
 
 **Next Steps**
-This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
+This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators).
 
 View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.

--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -133,4 +133,4 @@ Time: 0.852775583 seconds. 10 rows.
 **Next Steps**
 This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators).
 
-View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.
+View the [Spice.ai documentation](https://docs.spice.ai/building-blocks) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.


### PR DESCRIPTION
## What the recipe said
`spiceai/README.md` had two broken documentation links in its **Next Steps** section:
1. Data Accelerators → `https://docs.spiceai.org/data-accelerators`
2. Spice.ai documentation → `https://docs.spice.ai/building-blocks/datasets`

## What the code does
Both **404**:
- `docs.spiceai.org/data-accelerators` 301-redirects to `spiceai.org/docs/data-accelerators` → HTTP 404. The page moved under `/components/`.
- `docs.spice.ai/building-blocks/datasets` → "Page Not Found". The `/datasets` leaf no longer exists; the valid parent index is `docs.spice.ai/building-blocks`.

## What changed
- `https://docs.spiceai.org/data-accelerators` → `https://docs.spiceai.org/components/data-accelerators` (verified: valid "Data Accelerators | Spice.ai OSS" page).
- `https://docs.spice.ai/building-blocks/datasets` → `https://docs.spice.ai/building-blocks` (verified: valid "Building Blocks" index covering Data Connectors and datasets).

Same broken-link vein as the recent docs-link sweep; these were stragglers.