### PR TITLE
Fix postgres/accelerator recipe: correct broken Spice.ai Data Connector docs link

### DIFF
--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -55,7 +55,7 @@ spice init postgres-demo
 cd postgres-demo
 ```
 
-**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/data-connectors/spiceai).
+**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/components/data-connectors/spiceai).
 
 ```bash
 spice login


### PR DESCRIPTION
## What the recipe said
`postgres/accelerator/README.md` (Step 3) links to the Spice.ai Data Connector docs as `https://docs.spiceai.org/data-connectors/spiceai`.

## What the code does
That URL **404s** — it 301-redirects to `spiceai.org/docs/data-connectors/spiceai`, which returns HTTP 404. The connector docs now live under `/components/`.

## What changed
`https://docs.spiceai.org/data-connectors/spiceai` → `https://docs.spiceai.org/components/data-connectors/spiceai` (verified live: this target returns the valid "Spice.ai Data Connector | Spice.ai OSS" page).

Same broken-link vein as the recent connector docs-link sweep; this was a straggler.