### PR TITLE
Fix spiceai recipe: correct broken Cloud docs link (building-blocks)

### DIFF
--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -133,4 +133,4 @@ Time: 0.852775583 seconds. 10 rows.
 **Next Steps**
 This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
 
-View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.
+View the [Spice.ai documentation](https://docs.spice.ai/building-blocks) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.


### PR DESCRIPTION
## What the recipe said
`spiceai/README.md` (Next Steps) links to `https://docs.spice.ai/building-blocks/datasets`.

## What the code does
That URL returns **404 / Page Not Found** — the `/datasets` leaf no longer exists under the Cloud docs. The valid parent index is `https://docs.spice.ai/building-blocks` (verified live: returns the "Building Blocks" page indexing Data Connectors and dataset configuration).

## What changed
`https://docs.spice.ai/building-blocks/datasets` → `https://docs.spice.ai/building-blocks`.

Note: this recipe's *other* broken link (`docs.spiceai.org/data-accelerators` → `/components/data-accelerators`) is already handled by #442, so this PR is scoped to only the remaining Cloud-docs link to avoid overlap.