### PR TITLE
Fix ai recipe: correct Anthropic/Grok model ids and vector-search links

### DIFF
--- a/ai/README.md
+++ b/ai/README.md
@@ -292,7 +292,7 @@ Add to `spicepod.yaml`:
 ```yaml
 models:
   - name: sonnet-4-5
-    from: anthropic:claude-4-5-sonnet
+    from: anthropic:claude-sonnet-4-5
     params:
       anthropic_api_key: ${secrets:ANTHROPIC_API_KEY}
 ```
@@ -313,7 +313,7 @@ Then use in queries:
 SELECT
   ai('Hello!', 'gpt-4o-mini') as openai_response,
   ai('Hello!', 'sonnet-4-5') as claude_response,
-  ai('Hello!', 'grok-4-1-fast-non-reasoning') as grok_response;
+  ai('Hello!', 'grok-4-1-fast') as grok_response;
 ```
 
 ## Real-World Use Cases
@@ -387,6 +387,6 @@ Check the Spice logs for error messages:
 ## Next Steps
 
 - Explore the [text-to-sql](../text-to-sql) cookbook for natural language to SQL
-- Check out [vector search](../vectors) for semantic search capabilities
+- Check out [vector search](../vectors/s3) for semantic search capabilities
 - Try [embeddings](../search) for similarity search
 - Learn about [LLM tools](https://docs.spiceai.org/features/large-language-models/tools) for more advanced AI integration

--- a/ai/WHEN_TO_USE.md
+++ b/ai/WHEN_TO_USE.md
@@ -351,6 +351,6 @@ execute("""
 - **AI SQL Function** (this recipe): See [README.md](./README.md)
 - **Text-to-SQL**: [../text-to-sql/README.md](../text-to-sql/README.md)
 - **Chat & Tools**: [../openai_sdk/README.md](../openai_sdk/README.md)
-- **Vector Search**: [../vectors/README.md](../vectors/) and [../search/README.md](../search/README.md)
+- **Vector Search**: [../vectors/s3/README.md](../vectors/s3/README.md) and [../search/README.md](../search/README.md)
 - **Evaluations**: [../evals/README.md](../evals/README.md)
 - **Memory**: [../llm-memory/README.md](../llm-memory/README.md)


### PR DESCRIPTION
## What the recipe said → what the code does → what changed

While auditing the `ai/` recipe against current stable Spice (**v2.0.1**), I found three copy-paste-breaking inaccuracies. All are in the `ai` recipe, so they're fixed together here.

### 1. Anthropic provider example uses a transposed model id
- **Said:** `from: anthropic:claude-4-5-sonnet`
- **Code/docs:** The canonical Anthropic id is `anthropic:claude-sonnet-4-5` — the form used throughout the Spice docs (`components/models/anthropic.md` references `anthropic:claude-sonnet-4-5`). `claude-4-5-sonnet` is not a valid Anthropic model id and the example would fail for a reader who pastes it.
- **Changed:** `anthropic:claude-4-5-sonnet` → `anthropic:claude-sonnet-4-5`

### 2. Multi-model query passes a provider model id where a configured name is required
- **Said:**
  ```sql
  ai('Hello!', 'grok-4-1-fast-non-reasoning') as grok_response;
  ```
  …but the model is configured as `name: grok-4-1-fast` (`from: xai:grok-4-1-fast-non-reasoning`).
- **Code:** The recipe's own "Function Signatures" section states the second argument is *"the identifier you use in `ai(message, 'model_name')`"* — i.e. the configured `name`, not the provider `from:` id. The two other columns in the same query correctly use the configured names (`'gpt-4o-mini'`, `'sonnet-4-5'`).
- **Changed:** `'grok-4-1-fast-non-reasoning'` → `'grok-4-1-fast'`

### 3. Vector-search links point at a directory with no README
- **Said:** `[vector search](../vectors)` (README.md) and `[../vectors/README.md](../vectors/)` (WHEN_TO_USE.md)
- **Reality:** There is no `vectors/README.md`; the vector-search recipe lives at `vectors/s3/`. The links land a reader on a bare folder listing instead of the recipe.
- **Changed:** repointed both to `../vectors/s3` (and `../vectors/s3/README.md`).

## Verification
- Source ref: `spiceai/spiceai` @ `v2.0.1` and `spiceai/docs` `components/models/anthropic.md` (canonical `anthropic:claude-sonnet-4-5`).
- `vectors/s3/README.md` is the only recipe under `vectors/`; `vectors/README.md` does not exist.

Static review only (no secrets/live model calls made).