### PR TITLE
Fix oracle recipe: correct broken Spice CLI install link

### DIFF
--- a/oracle/README.md
+++ b/oracle/README.md
@@ -12,7 +12,7 @@ This recipe requires:
 
 - [Oracle ODPI-C library](https://oracle.github.io/odpi/)
 - [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/)
-- [Spice CLI](https://docs.spice.ai/getting-started/install-spice) installed locally
+- [Spice CLI](https://docs.spiceai.org/getting-started) installed locally
 
 ## Step 1. Clone the repository and navigate to the Oracle cookbook
 


### PR DESCRIPTION
## What the recipe said

`oracle/README.md` prerequisites linked the Spice CLI to:

```
[Spice CLI](https://docs.spice.ai/getting-started/install-spice)
```

## What's wrong

That URL returns **404** on two counts:
- Wrong host — `docs.spice.ai` is the Cloud product; the OSS docs live at `docs.spiceai.org`.
- The path `/getting-started/install-spice` does not exist.

Verified: `curl -L https://docs.spice.ai/getting-started/install-spice` → `404`.

## What changed

Point it to `https://docs.spiceai.org/getting-started` (HTTP 200) — the same OSS install link the other recipes already use (`clients/java`, `clients/scala`, `openai_sdk`).

Verified against current stable **v2.0.1**.