### PR TITLE
Fix mcp recipe: correct version floor to v2.0+

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # Model Context Protocol with Spice
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 ## Prerequisties
 


### PR DESCRIPTION
## What the recipe said

`mcp/README.md` declares `Works with \`v1.0+\``.

## What the code does

The recipe's second half connects Spice to its own MCP server:

```yaml
from: mcp:http://localhost:8090/v1/mcp
params:
  mcp_headers: "x-api-key: foobar"
```

Both pieces are **v2.0.0+**, verified against `spiceai/spiceai` at **v2.0.1**:

- The streamable-HTTP `/v1/mcp` endpoint was introduced in v2.0.0 (`crates/runtime/src/http/routes.rs` registers `/v1/mcp`). In the last v1 release (v1.11.6) the MCP server was only exposed at `/v1/mcp/sse` (SSE).
- The `mcp_headers` connector param (`crates/runtime/src/tools/mcp/mod.rs` — `const MCP_HEADERS_PARAM: &str = "mcp_headers"`) does not exist before v2.0.0 (`git grep mcp_headers v1.11.6` returns nothing).

So the recipe cannot run as written on v1.x.

## What changed

Floor `v1.0+` → `v2.0+`.