### PR TITLE
Fix mcp-server recipe: correct version floor to v2.0+

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,6 +1,6 @@
 # Spice as MCP Server
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 Run Spice as an MCP server and connect your AI assistant (Claude Desktop, Cursor, VS Code, or any MCP client) to it. This recipe loads GitHub issues, pull requests, and commits as accelerated, in-memory datasets and exposes the [GitHub MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/github) through a single unified endpoint at `/v1/mcp`.
 


### PR DESCRIPTION
## What the recipe said

`mcp-server/README.md` declares `Works with \`v1.0+\``.

## What the code does

The whole recipe exposes Spice as an MCP server through the single endpoint `http://localhost:8090/v1/mcp` (`claude mcp add --transport http spice http://localhost:8090/v1/mcp --header "X-API-KEY: foo"`), and authenticates every call with `X-API-KEY`.

Verified against `spiceai/spiceai` at **v2.0.1**:

- The streamable-HTTP `/v1/mcp` endpoint was introduced in v2.0.0 (`crates/runtime/src/http/routes.rs` registers `/v1/mcp`). The last v1 release (v1.11.6) only exposed `/v1/mcp/sse` (SSE).
- That endpoint **requires `runtime.auth`** in v2.0 — `routes.rs`: "The `/v1/mcp` endpoint requires `runtime.auth` to be configured." — which is why the recipe configures an API key. This auth gate is v2.0.0+.

So the recipe cannot run as written on v1.x.

## What changed

Floor `v1.0+` → `v2.0+`.