### PR TITLE
Fix delta-lake recipe: correct default-run output for v2.0

### DIFF
--- a/delta-lake/README.md
+++ b/delta-lake/README.md
@@ -44,9 +44,7 @@ Spice supports reading data directly from Delta Lake tables. This recipe will cr
    2025/01/17 16:30:47 INFO Spice.ai runtime starting...
    2025-01-18T00:30:48.557502Z  INFO runtime::init::dataset: Initializing dataset delta_lake_table
    2025-01-18T00:30:48.561170Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-   2025-01-18T00:30:48.561514Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
    2025-01-18T00:30:48.569153Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-   2025-01-18T00:30:48.574811Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
    2025-01-18T00:30:48.758689Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
    2025-01-18T00:30:49.116731Z  INFO runtime::init::dataset: Dataset delta_lake_table registered (delta_lake:s3:<s3://my_bucket/path/to/s3/delta/table/>), results cache enabled.
    ```
@@ -67,11 +65,10 @@ Spice supports reading data directly from Delta Lake tables. This recipe will cr
     | table_catalog | table_schema | table_name       | table_type |
     +---------------+--------------+------------------+------------+
     | spice         | runtime      | task_history     | BASE TABLE |
-    | spice         | runtime      | metrics          | BASE TABLE |
     | spice         | public       | delta_lake_table | BASE TABLE |
     +---------------+--------------+------------------+------------+
 
-    Time: 0.004799292 seconds. 3 rows.
+    Time: 0.004799292 seconds. 2 rows.
    ```
 
 6. Query against the Delta Lake table.


### PR DESCRIPTION
## What the recipe said

The Step 4 boot log and Step 5 `show tables` output show a metrics server, an OpenTelemetry listener, and a `runtime.metrics` table:

```
... INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
... INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
```
```
| spice | runtime | metrics      | BASE TABLE |
...
Time: 0.004799292 seconds. 3 rows.
```

## What the code does (verified against spiceai/spiceai v2.0.1)

- The Prometheus **metrics server is disabled by default** (`bin/spiced/src/lib.rs`: `Enable Prometheus metrics. (disabled by default)`). A plain `spice run` never binds it, so the `Metrics listening on :9090` line is not emitted.
- There is **no OpenTelemetry listener** in v2.0 — the `--open_telemetry` arg is documented as "Deprecated ... (no effect)" and no "OpenTelemetry listening" log line exists in the codebase. (Port 50052 is now the cluster control-stream port.)
- The `runtime.metrics` table is **only registered when Prometheus is enabled** (`crates/runtime/src/lib.rs`: `register_metrics_table(self.prometheus_registry.is_some())`). With metrics off, `show tables` returns `task_history` + `delta_lake_table` = **2 rows**, not 3.

## What changed

Removed the metrics/OpenTelemetry boot lines, dropped the `runtime.metrics` row, and corrected `3 rows` → `2 rows`. Matches the same fix already applied to the snowflake (#441) and tpc-h (#446) recipes.