### PR TITLE
Fix spiceai recipe: correct two broken docs links

### DIFF
--- a/spiceai/README.md
+++ b/spiceai/README.md
@@ -131,6 +131,6 @@ Time: 0.852775583 seconds. 10 rows.
 ```
 
 **Next Steps**
-This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/data-accelerators).
+This recipe queries the Spice.ai Cloud Platform directly without any acceleration. Experiment with different acceleration options using [Spice Data Accelerators](https://docs.spiceai.org/components/data-accelerators).
 
-View the [Spice.ai documentation](https://docs.spice.ai/building-blocks/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.
+View the [Spice.ai datasets documentation](https://docs.spiceai.org/reference/spicepod/datasets) and search on [spicerack.org](https://spicerack.org/) to explore and experiment with retrieving and accelerating multiple datasets to use with Spice.


### PR DESCRIPTION
## What the recipe said

The `spiceai` recipe's **Next Steps** section linked to two documentation URLs that now 404:

1. `https://docs.spiceai.org/data-accelerators` — Spice Data Accelerators
2. `https://docs.spice.ai/building-blocks/datasets` — Spice.ai documentation

## What the code/docs do now

1. `docs.spiceai.org/data-accelerators` 301-redirects to `spiceai.org/docs/data-accelerators`, which returns **404**. The Data Accelerators page moved under `/components/`. The live page is https://docs.spiceai.org/components/data-accelerators (verified). This matches the fix already applied to the dremio (#432) and snowflake (#441) recipes.
2. `docs.spice.ai/building-blocks/datasets` returns **Page Not Found** (verified).

## What changed

- `/data-accelerators` → `/components/data-accelerators`
- The dead `docs.spice.ai/building-blocks/datasets` link → the canonical datasets reference https://docs.spiceai.org/reference/spicepod/datasets (verified live, on-topic).

Docs-only change to a single recipe README; no config or commands affected.