### PR TITLE
Fix postgres/accelerator recipe: broken docs link and stale startup output

### DIFF
--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -55,7 +55,7 @@ spice init postgres-demo
 cd postgres-demo
 ```
 
-**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/data-connectors/spiceai).
+**Step 3.** [Login](https://docs.spiceai.org/cli/reference/login) to use the [Spice.ai Data Connector](https://docs.spiceai.org/components/data-connectors/spiceai).
 
 ```bash
 spice login
@@ -79,9 +79,7 @@ The Spice runtime terminal will show that Spice Runtime is running.
 
 ```console
 Spice.ai runtime starting...
-2024-05-07T01:01:40.566270Z  INFO spiced: Metrics listening on 127.0.0.1:9090
 2024-05-07T01:01:40.566873Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-05-07T01:01:40.566960Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-05-07T01:01:40.568738Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 ```
 


### PR DESCRIPTION
## What the recipe said

1. **Step 3** linked the Spice.ai Data Connector to `https://docs.spiceai.org/data-connectors/spiceai`.
2. **Step 4** showed this `spice run` output:

```console
Spice.ai runtime starting...
... INFO spiced: Metrics listening on 127.0.0.1:9090
... INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
... INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
... INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
```

## What the code/docs do now (verified against spiceai/spiceai @ v2.0.1)

1. `docs.spiceai.org/data-connectors/spiceai` 301-redirects to `spiceai.org/docs/data-connectors/spiceai`, which **404s**. The connector doc moved under `/components/`; the live page is https://docs.spiceai.org/components/data-connectors/spiceai.
2. The metrics-server line only appears when metrics are explicitly enabled — `metrics_server::start` returns early when the endpoint is unset ([`crates/runtime/src/metrics_server/mod.rs:85-88`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/runtime/src/metrics_server/mod.rs#L85-L88)), and a default `spice run` does not enable it.
3. There is **no** OpenTelemetry `listening` log line in the v2.0 runtime at all (no such log under `crates/runtime/src`). This is the stale v1.x `50052` line.

## What changed

- Step 3 link → `/components/data-connectors/spiceai`.
- Trimmed the Step 4 output to the Flight + HTTP lines a default `spice run` actually emits, matching the validated `arrow` recipe output and consistent with #446 (which removed the same metrics line from `tpc-h`).

Docs-only change to a single recipe README.