### PR TITLE
Fix evals recipe: note eval subsystem removed in v2.0

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -2,6 +2,8 @@
 
 Deprecated in `v2.0+`. Works with `v1.0+`
 
+> **Note:** The evaluation subsystem this recipe relies on — the `evals:` / `scorers:` spicepod config, the `POST /v1/evals/{eval}` endpoint, and the `eval.results` table — was removed in Spice `v2.0.0`. Run this recipe with a Spice `v1.x` release.
+
 Spice can be used to both run language models but also to evaluate their performance on specific tasks.
 
 This recipe demonstrates how to measure the performance of a language model, configured entirely in the spice runtime.


### PR DESCRIPTION
## What the recipe says

`evals/README.md` carries only a one-line note (`Deprecated in `v2.0+`. Works with `v1.0+``) and then walks the reader through the eval subsystem: the `evals:` / `scorers:` spicepod config, `POST /v1/evals/tetris`, and `SELECT ... FROM eval.results`.

## What the code does

The entire evaluation subsystem was **removed in Spice `v2.0.0`**. Verified against `spiceai/spiceai` at tag `v2.0.1`:

- No `evals:` / `scorers:` field in any spicepod component (`crates/spicepod/src/component/` has no eval module).
- No `POST /v1/evals` route in `crates/runtime/src/http/`.
- No `spice eval` subcommand in `bin/spice/src/commands/`.
- The only `eval` references left are unrelated (an internal reserved schema name `SPICE_EVAL_SCHEMA = "eval"` in `crates/runtime/src/datafusion/mod.rs`, and DataFusion-internal types).

So on current stable (v2.0.1) every step of this recipe fails — it only runs on a v1.x release.

## What changed

Adds the same explanatory blockquote the sibling `llm-judge` recipe already received (`llm-judge/README.md:5`), tailored to this recipe's surface (the `evals:`/`scorers:` config, the `/v1/evals/{eval}` endpoint, and the `eval.results` table), pointing readers to a v1.x release.

No functional recipe change — the walkthrough is intentionally left intact for v1.x users.