### PR TITLE
Fix indexes recipe: correct sqlite to DuckDB in Step 2

### DIFF
--- a/acceleration/indexes/README.md
+++ b/acceleration/indexes/README.md
@@ -21,7 +21,7 @@ wget https://public-data.spiceai.org/large_eth_traces.parquet
 
 **Step 2.** Start Spice
 
-Spice will start and load the dataset into sqlite. **This may take several minutes.**
+Spice will start and load the dataset into DuckDB. **This may take several minutes.**
 
 ```bash
 spice run


### PR DESCRIPTION
## What the recipe says

`acceleration/indexes/README.md` Step 2 (line 24) tells the reader:

> Spice will start and load the dataset into sqlite.

## What the recipe actually does

The shipped `acceleration/indexes/spicepod.yaml` accelerates **both** `traces` and `traces_no_index` with `engine: duckdb` (`mode: file`) — there is no SQLite anywhere in the recipe. The recipe's own expected output two steps later confirms this:

```
Dataset traces registered (file:large_eth_traces.parquet), acceleration (duckdb:file) ...
Dataset traces_no_index registered (file:large_eth_traces.parquet), acceleration (duckdb:file) ...
```

The "sqlite" wording is a leftover error that contradicts both the config and the displayed output, regardless of Spice version.

## What changed

Step 2 prose now says "DuckDB" to match the spicepod's `engine: duckdb` and the expected output.