### PR TITLE
Fix snowflake/dml recipe: phantom tv_shows_ro output and broken install link

### DIFF
--- a/snowflake/dml/README.md
+++ b/snowflake/dml/README.md
@@ -6,7 +6,7 @@ Works with `v2.0+`
 
 ## Pre-requisites
 
-- Spice `v2.0+` — [Install Spice](https://docs.spiceai.org/getting-started/installation)
+- Spice `v2.0+` — [Install Spice](https://docs.spiceai.org/getting-started)
 - [A Snowflake account](https://signup.snowflake.com/)
 
 ## Step 1. Create the destination table in Snowflake

--- a/snowflake/dml/README.md
+++ b/snowflake/dml/README.md
@@ -84,10 +84,9 @@ Spice.ai runtime starting...
 2026-05-10T22:03:07.237660Z  INFO runtime::init::worker: Scheduler for worker [ingest_tvmaze_shows] created successfully
 2026-05-10T22:03:07.246890Z  INFO runtime::init::dataset: Dataset tvmaze_shows_raw registered (https://api.tvmaze.com/shows), results cache enabled. duration_ms=0
 2026-05-10T22:03:07.250581Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2026-05-10T22:03:10.209492Z  INFO runtime::init::dataset: Dataset tv_shows_ro registered (snowflake:SPICE_DEMO.PUBLIC."TV_SHOWS"), results cache enabled. duration_ms=0
 2026-05-10T22:03:11.936902Z  INFO runtime::init::dataset: Dataset tv_shows registered (snowflake:SPICE_DEMO.PUBLIC."TV_SHOWS"), results cache enabled. duration_ms=1865
 2026-05-10T22:03:12.039156Z  INFO runtime: All components are loaded. Spice runtime is ready!
-2026-05-10T22:03:37.238925Z  INFO runtime::init::dataset: Dataset load summary (after 30s): 4/4 ready, 0 unhealthy, 0 still initializing.
+2026-05-10T22:03:37.238925Z  INFO runtime::init::dataset: Dataset load summary (after 30s): 2/2 ready, 0 unhealthy, 0 still initializing.
 ```
 
 ## Step 4. Wait for the ingestion worker to run


### PR DESCRIPTION
## What the recipe says

`snowflake/dml/README.md` Step 3 expected output shows a third dataset registering and a 4-component ready count:

```
... Dataset tv_shows_ro registered (snowflake:SPICE_DEMO.PUBLIC."TV_SHOWS") ...
... Dataset tv_shows registered (snowflake:SPICE_DEMO.PUBLIC."TV_SHOWS") ...
... Dataset load summary (after 30s): 4/4 ready, 0 unhealthy, 0 still initializing.
```

## What the recipe actually ships

The shipped `snowflake/dml/spicepod.yaml` defines only **two** datasets — `tvmaze_shows_raw` and `tv_shows` — plus one worker. There is no `tv_shows_ro` dataset; it is a leftover from an earlier revision of the recipe that had a read-only mirror dataset.

The `4/4 ready` count is also wrong. The load summary counts **datasets only**, not workers — verified against `spiceai/spiceai` at tag `v2.0.1`, `crates/runtime/src/init/dataset.rs:231-255` (`get_dataset_statuses()` → `{ready}/{total}`). With two datasets the line is `2/2 ready`.

## What changed

- Removed the `Dataset tv_shows_ro registered ...` line (that dataset is not in the spicepod).
- Corrected the load summary from `4/4 ready` to `2/2 ready` to match the two shipped datasets.