### PR TITLE
Fix clickhouse recipe: correct broken Spice CLI install link

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -6,7 +6,7 @@ Follow these steps to get started with Clickhouse as a Data Connector.
 
 ## Preparation
 
-- Install the [Spice.ai CLI](https://docs.spiceai.org/getting-started/installation)
+- Install the [Spice.ai CLI](https://docs.spiceai.org/getting-started)
 - Install [Clickhouse](https://clickhouse.com/docs/en/install#quick-install)
   - `curl https://clickhouse.com/ | sh`
 - Start a Clickhouse instance (`clickhouse server`)


### PR DESCRIPTION
## What the recipe said

The Preparation step linked the Spice.ai CLI install to:

```
https://docs.spiceai.org/getting-started/installation
```

## What the code/docs do

That URL returns **404**. The canonical install page is `https://docs.spiceai.org/getting-started` (verified `200`), which is the target used for the same class of fix in #487 (oracle).

```
$ curl -s -o /dev/null -w '%{http_code}' -L https://docs.spiceai.org/getting-started/installation
404
$ curl -s -o /dev/null -w '%{http_code}' -L https://docs.spiceai.org/getting-started
200
```

## What changed

`clickhouse/README.md` line 9: install link `getting-started/installation` → `getting-started`.