### PR TITLE
Fix graphql recipe: broken install link and phantom dataset name

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -6,11 +6,11 @@ Follow these steps to get started with GraphQL as a Data Connector.
 
 ## Pre-requisites
 
-- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started/installation)
+- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started)
 - A GraphQL endpoint with a query that returns data in JSON format.
   - The GitHub GraphQL API (<https://api.github.com/graphql>) is a good example to get started with. [GitHub GraphQL API](https://docs.github.com/en/graphql)
 
-**Step 1 (Optional).** The example uses the GitHub GraphQL API to fetch the `spiceai` stargazers. If you would like to use your own GraphQL endpoint, edit the `spicepod.yaml` file in this directory and replace the `graphql_recipe` dataset parameters with the connection details for your GraphQL instance.
+**Step 1 (Optional).** The example uses the GitHub GraphQL API to fetch the `spiceai` stargazers. If you would like to use your own GraphQL endpoint, edit the `spicepod.yaml` file in this directory and replace the `stargazers` dataset parameters with the connection details for your GraphQL instance.
 
 - `name`: The desired name for the federated table within Spice
 - `from: graphql:<URL>`: The URL to your GraphQL endpoint


### PR DESCRIPTION
## What the recipe said

1. Pre-requisites linked the install to `https://docs.spiceai.org/getting-started/installation`.
2. Step 1 instructed: *"replace the `graphql_recipe` dataset parameters…"*

## What the code/docs do

1. `getting-started/installation` returns **404**; `getting-started` returns **200** (canonical install page, same target as #487).
2. The recipe's `spicepod.yaml` defines a single dataset named **`stargazers`** — there is no `graphql_recipe` dataset, so the instruction points at a name that doesn't exist.

```
$ grep 'name:' graphql/spicepod.yaml
name: graphql          # spicepod name
    name: stargazers   # dataset name
```

## What changed

`graphql/README.md`:
- line 9: install link `getting-started/installation` → `getting-started`
- line 13: `graphql_recipe` → `stargazers`