### PR TITLE
Fix imap recipe: correct broken Spice CLI install link

### DIFF
--- a/imap/README.md
+++ b/imap/README.md
@@ -6,7 +6,7 @@ Follow these steps to get started with the IMAP Data Connector, connecting to an
 
 ## Pre-requisites
 
-- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started/installation).
+- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started).
 - An IMAP server with configured mailboxes, to login using a username (email) and password.
 
 ## Steps


### PR DESCRIPTION
## What the recipe said

Pre-requisites linked the install to `https://docs.spiceai.org/getting-started/installation`.

## What the code/docs do

That URL returns **404**; `https://docs.spiceai.org/getting-started` returns **200** (canonical install page, same target as #487).

## What changed

`imap/README.md` line 9: install link `getting-started/installation` → `getting-started`.

(The `Works with v1.1.0+` floor is correct — the IMAP connector first shipped in v1.1.0.)