### PR TITLE
Fix http recipe: broken docs links and incorrect v1.0+ version floor

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -1,6 +1,6 @@
 # HTTP Data Connector
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 The HTTP(s) data connector enables querying data from HTTP(s) endpoints such as REST APIs. The connector supports dynamic query construction and data refresh through SQL-based filtering, making it ideal for integrating external APIs and web-hosted datasets into your Spice application.
 
@@ -8,7 +8,7 @@ This recipe demonstrates how to use the HTTP connector with the [TVMaze API](htt
 
 ## Pre-requisites
 
-- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started/installation)
+- The latest version of Spice. [Install Spice](https://docs.spiceai.org/getting-started)
 - An HTTP(s) endpoint that returns data in a [supported file format](https://docs.spiceai.org/components/data-connectors#object-store-file-formats)
 
 ## Configuration
@@ -159,7 +159,7 @@ Time: 0.336182833 seconds. 40 rows.
 
 ### Processing JSON Responses
 
-TVMaze API responses contain nested JSON. Use [JSON functions](/docs/reference/sql/json) to extract specific fields:
+TVMaze API responses contain nested JSON. Use [JSON functions](https://docs.spiceai.org/reference/sql/json) to extract specific fields:
 
 ```sql
 -- Extract show details from JSON response


### PR DESCRIPTION
## What the recipe said

1. Pre-requisites install link → `https://docs.spiceai.org/getting-started/installation`
2. Advanced Usage → *"Use [JSON functions](/docs/reference/sql/json)…"* (a site-relative path)
3. Header: `Works with \`v1.0+\``

## What the code/docs do

1. `getting-started/installation` returns **404**; `getting-started` returns **200** (canonical, same target as #487).
2. `/docs/reference/sql/json` is relative, so on GitHub it resolves to `github.com/spiceai/cookbook/docs/reference/sql/json` (broken). Canonical: `https://docs.spiceai.org/reference/sql/json` (`200`).
3. The version floor is too low. Verified against `spiceai/spiceai` tags:
   - `allowed_request_paths` / `request_query_filters` (Step 1 config) — first present in **v1.9.0**
   - the entire **Pagination** section (`pagination`, `pagination_query_params`, `pagination_page_size`, `pagination_data_pointer`, `pagination_max_pages`) — first present in **v2.0.0**

   A reader on v1.x following the recipe as written would fail. The newest feature used is pagination → floor is **v2.0+**.

```
# pagination params present only at v2.0.0
$ for t in v1.9.0 v1.11.0 v2.0.0; do git grep -lq pagination_max_pages $t -- crates/ && echo "$t PRESENT" || echo "$t absent"; done
v1.9.0 absent
v1.11.0 absent
v2.0.0 PRESENT
```

## What changed

`http/README.md`:
- line 3: `Works with v1.0+` → `Works with v2.0+`
- line 11: install link `getting-started/installation` → `getting-started`
- line 162: `/docs/reference/sql/json` → `https://docs.spiceai.org/reference/sql/json`