### PR TITLE
Fix smb recipe: remove phantom 'acceleration (none)' from expected output

### DIFF
--- a/smb/README.md
+++ b/smb/README.md
@@ -74,7 +74,7 @@ If the configuration is correct, you should see output similar to:
 
 ```console
 INFO runtime::init::dataset: Dataset sales initializing...
-INFO runtime::init::dataset: Dataset sales registered (smb://localhost/data/), acceleration (none), results cache enabled.
+INFO runtime::init::dataset: Dataset sales registered (smb://localhost/data/), results cache enabled.
 ```
 
 ---


### PR DESCRIPTION
## What the recipe says

`smb/README.md` Step 5 shows the expected startup output as:

```console
INFO runtime::init::dataset: Dataset sales registered (smb://localhost/data/), acceleration (none), results cache enabled.
```

## What the code does

The dataset-registration log line is built by `dataset_registered_trace` (`crates/runtime/src/tracing_util.rs`). The `, acceleration (<engine>)` segment is appended **only when `acceleration.enabled` is true**:

```rust
let mut info = format!("Dataset {} registered ({})", &ds.name, &ds.from);
if let Some(acceleration) = &ds.acceleration && acceleration.enabled {
    let _ = write!(info, ", acceleration ({})", ...);
}
```

There is no `acceleration (none)` literal in the runtime. The recipe's `smb/spicepod.yaml` has no `acceleration:` block, so the segment is omitted entirely.

## What changed

Corrected the expected output to what a reader actually sees:

```console
INFO runtime::init::dataset: Dataset sales registered (smb://localhost/data/), results cache enabled.
```

Verified against spiceai/spiceai at tag `v2.0.1` (`crates/runtime/src/tracing_util.rs`).