### PR TITLE
Fix s3 recipe: correct show tables output and private-bucket step numbering

### DIFF
--- a/s3/README.md
+++ b/s3/README.md
@@ -114,7 +114,6 @@ show tables;
 +---------------+--------------+---------------+------------+
 | spice         | public       | taxi_trips    | BASE TABLE |
 | spice         | runtime      | task_history  | BASE TABLE |
-| spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
 Time: 0.010070708 seconds. 2 rows.
@@ -205,7 +204,7 @@ SPICE_S3_KEY=<aws_access_key_id>
 SPICE_S3_SECRET=<aws_secret_access_key>
 ```
 
-**Step 6.** Configure spicepod to contain correct s3_region
+**Step 5.** Configure spicepod to contain correct s3_region
 
 s3_region parameter [defaults to us-east-1](https://docs.spiceai.org/components/data-connectors/s3). Update the spicepod to include s3_region parameter if the s3 bucket used in this recipe is not in `us-east-1`
 


### PR DESCRIPTION
## What the recipe says

**`show tables` output** (`s3/README.md`) lists three tables but states `2 rows.`:

```console
| spice | public  | taxi_trips   | BASE TABLE |
| spice | runtime | task_history | BASE TABLE |
| spice | runtime | metrics      | BASE TABLE |
...
Time: 0.010070708 seconds. 2 rows.
```

**Private-bucket section** numbers its steps `1, 2, 3, 4, 6, 6, 7, 8` — Step 5 is skipped and Step 6 appears twice.

## What the code does

Prometheus metrics are **disabled by default**: the `spiced --metrics` flag is documented as "disabled by default" (`bin/spiced/src/lib.rs`), and the `runtime.metrics` table is only registered when a Prometheus registry is present (`crates/runtime/src/spice_metrics.rs`). The recipe uses a plain `spice init` + `spice run` with no `--metrics`, so only `public.taxi_trips` and `runtime.task_history` exist — exactly the `2 rows` the text already states.

## What changed

- Removed the phantom `runtime.metrics` row so the table matches the stated `2 rows.`
- Renumbered the private-bucket "Configure spicepod ... s3_region" step from Step 6 to Step 5, giving a clean `1–8` sequence.

Verified against spiceai/spiceai at tag `v2.0.1`.