### PR TITLE
Fix openai-responses-api recipe: correct version floor to v1.6+

### DIFF
--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -1,6 +1,6 @@
 # Using OpenAI's Responses API with Spice
 
-Works with `v1.10+`
+Works with `v1.6+`
 
 This recipe shows how Spice integrates with [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses), OpenAI's most advanced interface for generating model responses, supporting both hosted and custom tool calls. This recipe also covers how to use the OpenAI SDK's support for the Responses API to connect to compatible models running on Spice.
 


### PR DESCRIPTION
## What the recipe says

`openai-responses-api/README.md` line 3 declares:

```
Works with `v1.10+`
```

## What the code does

The OpenAI Responses API support this recipe demonstrates was introduced in **v1.6.0**, not v1.10:

> **OpenAI Responses API Support**: The OpenAI Responses API (`/v1/responses`) is now supported... To enable the `/v1/responses` HTTP endpoint, set the `responses_api` parameter to `enabled`

The same v1.6.0 release added the OpenAI-hosted `web_search` and `code_interpreter` tools (the `openai_responses_tools` param) that the recipe also uses. Source: `docs/release_notes/v1.6/v1.6.0.md` in spiceai/spiceai.

## What changed

Corrected the floor to `v1.6+` so it no longer steers readers off a still-supported version where the recipe works.

Verified against spiceai/spiceai v1.6.0 release notes.