### PR TITLE
Fix sharepoint recipe: correct stale dataset-registration output

### DIFF
--- a/sharepoint/README.md
+++ b/sharepoint/README.md
@@ -36,8 +36,9 @@ Confirm in the terminal output that the `important_documents` dataset has been l
 
 ```bash
 Spice.ai runtime starting...
-2024-09-16T12:34:56.789012Z  INFO spiced: Metrics listening on 127.0.0.1:9090
-2024-09-16T12:34:56.789012Z  INFO runtime: Loaded dataset: important_documents
+2024-09-16T12:34:56.789012Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2024-09-16T12:34:56.789012Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2024-09-16T12:34:56.789012Z  INFO runtime::init::dataset: Dataset important_documents registered (sharepoint:me/root), results cache enabled.
 ```
 
 **Step 4.** Run queries against the dataset using the Spice SQL REPL.


### PR DESCRIPTION
## What the recipe says

`sharepoint/README.md` Step 3 shows the expected startup output as:

```
Spice.ai runtime starting...
2024-09-16T12:34:56.789012Z  INFO spiced: Metrics listening on 127.0.0.1:9090
2024-09-16T12:34:56.789012Z  INFO runtime: Loaded dataset: important_documents
```

## What the code does

The runtime no longer emits a `Loaded dataset: <name>` line. A registered dataset is logged by `dataset_registered_trace` (`crates/runtime/src/tracing_util.rs`):

```
Dataset important_documents registered (sharepoint:me/root), results cache enabled.
```

The `Metrics listening on ...:9090` line also won't appear: the `spiced --metrics` flag is "disabled by default" (`bin/spiced/src/lib.rs`) and this recipe runs without it.

## What changed

Replaced the obsolete `Loaded dataset` line with the current `Dataset ... registered (...)` format, and swapped the off-by-default metrics line for the Flight/HTTP `listening` lines a reader actually sees.

Verified against spiceai/spiceai at tag `v2.0.1`.