### PR TITLE
ScyllaDB Data Connector: change replication strategy in README

### DIFF
--- a/scylladb/README.md
+++ b/scylladb/README.md
@@ -54,7 +54,7 @@ Create a keyspace and table with sample data:
 ```sql
 -- Create keyspace
 CREATE KEYSPACE IF NOT EXISTS demo
-WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
+WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1};
 
 -- Use the keyspace
 USE demo;


### PR DESCRIPTION
## 🗣 Description

PR fixes local ScyllaDB setup

>cqlsh> CREATE KEYSPACE IF NOT EXISTS demo
   ... WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};
ConfigurationException: SimpleStrategy doesn't support tablet replication

## 🔨 Related Issues

<!-- list any linked issues this pull request will close, or exclude if none -->

## 🤔 Concerns

<!-- list any particular concerns you have about this pull request that you want reviewers to directly address, or exclude if none -->
