### PR TITLE
Fix command in java cookbook

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -37,7 +37,7 @@ spice run
 
 ```bash
 MAVEN_OPTS="--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED" \
-mvn exec:java \
+mvn exec:exec \
   -Dexec.mainClass="MessagingServiceApp"
 ```
 


### PR DESCRIPTION
## 🗣 Description

Minor fix `exec:java` -> `exec:exec` in Java cookbook