### PR TITLE
Fix odbc cookbook: use mysql

### DIFF
--- a/odbc/README.md
+++ b/odbc/README.md
@@ -2,125 +2,140 @@
 
 Works with `v1.0+`
 
-Follow these steps to get started with ODBC as a Data Connector. This recipe will create an SQLite database, install the SQLite ODBC driver, and connect to SQLite via ODBC with the Spice Runtime.
+Follow these steps to get started with ODBC as a Data Connector. This recipe installs the MariaDB Connector/ODBC driver, runs a MySQL server in Docker with a sample `users` table, and connects to it via ODBC with the Spice Runtime.
+
+> **Why MariaDB Connector/ODBC?**
+> Spice (via the `odbc-api` library) declares **ODBC 3.8** to the Driver Manager when it opens a connection. Older drivers — notably the popular SQLite ODBC driver (`libsqlite3odbc`), which only implements **ODBC 3.0** — cannot honor that and the Driver Manager logs a warning:
+>
+> ```
+> WARN odbc_api::handles::logging: State: 01000, Native error: 0, Message: [unixODBC][Driver Manager]Driver does not support the requested version
+> ```
+>
+> The connection still works (the driver negotiates down), but the warning is noise. MariaDB Connector/ODBC is a modern **ODBC 3.8** driver, so the version handshake is clean and no warning is emitted. It speaks the MySQL protocol, so the same driver works against both **MySQL** and **MariaDB** servers.
 
 ## Preparation
 
 - **Spice with ODBC support**: ODBC support is not included in the released binaries. See [Building Spice with ODBC](https://spiceai.org/docs/components/data-connectors/odbc#building-spice-with-odbc) for instructions on how to build Spice with ODBC support.
+- **Docker**: used to run the MySQL server. No local database install is required.
 
 ## Steps
 
-### Step 1: Install the SQLite ODBC Driver
+### Step 1: Install the MariaDB Connector/ODBC driver
 
-#### Generic \*nix Instructions
-
-Install the [SQLite ODBC driver](https://github.com/softace/sqliteodbc) for your operating system.
-
-On Unix, this requires cloning and compiling the SQLite ODBC driver project. First, install build dependencies:
-
-```bash
-sudo apt-get install unixodbc odbcinst sqlite3 libsqlite3-dev
-```
-
-On Fedora, install the equivalent dependencies:
-
-```bash
-sudo dnf install unixODBC unixODBC-devel sqlite sqlite-devel
-```
-
-Then, clone and compile the SQLite ODBC driver:
-
-```bash
-git clone https://github.com/softace/sqliteodbc
-cd sqliteodbc
-./configure && make
-sudo make install
-```
-
-Once the driver is installed, configure the ODBC driver profile by editing the `/etc/odbcinst.ini` and adding the SQLite driver:
-
-```ini
-[SQLite3]
-Driver = /usr/local/lib/libsqlite3odbc.so
-```
+The ODBC driver must be installed on the **host** where Spice runs — Spice loads it in-process and connects over TCP to the MySQL server (which we will run in Docker in Step 2).
 
 #### macOS
 
-Install via brew:
+Install the ODBC Driver Manager and the MariaDB ODBC driver via brew:
 
 ```bash
-brew install unixodbc sqliteodbc
+brew install unixodbc mariadb-connector-odbc
 ```
 
-Configure the SQLite driver:
+Register the driver with the Driver Manager using `odbcinst` (the official unixODBC tool — it writes to the correct `odbcinst.ini` and is safe to re-run, unlike appending to the file by hand):
 
 ```bash
-cat <<EOF >> /opt/homebrew/etc/odbcinst.ini
-[SQLite3]
-Driver = /opt/homebrew/lib/libsqlite3odbc.so
+odbcinst -i -d -r <<EOF
+[MariaDB]
+Description = MariaDB Connector/ODBC (ODBC 3.8)
+Driver = /opt/homebrew/opt/mariadb-connector-odbc/lib/mariadb/libmaodbc.dylib
 EOF
 ```
 
-### Step 2: Setup Data
+Confirm it registered with `odbcinst -q -d` (you should see `[MariaDB]`).
 
-Setup an SQLite database with some sample data. Use the SQLite CLI to create a database, and run the provided SQL:
+#### Generic \*nix Instructions
+
+On Debian/Ubuntu:
 
 ```bash
-sqlite3 data.sqlite
+sudo apt-get install unixodbc odbcinst odbc-mariadb
 ```
 
-```sql
-CREATE TABLE taxi_trips (
-  vendorid INT,
-  tpep_pickup_datetime DATETIME,
-  tpep_dropoff_datetime DATETIME,
-  passenger_count INT,
-  trip_distance FLOAT,
-  ratecodeid INT,
-  store_and_fwd_flag CHAR(1),
-  pulocationid INT,
-  dolocationid INT,
-  payment_type INT,
-  fare_amount FLOAT,
-  extra FLOAT,
-  mta_tax FLOAT,
-  tip_amount FLOAT,
-  tolls_amount FLOAT,
-  improvement_surcharge FLOAT,
-  total_amount FLOAT,
-  congestion_surcharge FLOAT,
-  airport_fee FLOAT
+On Fedora:
+
+```bash
+sudo dnf install unixODBC mariadb-connector-odbc
+```
+
+The distro packages usually register the driver automatically. Confirm with:
+
+```bash
+odbcinst -q -d
+```
+
+If `[MariaDB]` is not listed, register it with `odbcinst` (adjust the `Driver` path to match your distribution — e.g. `/usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so`):
+
+```bash
+odbcinst -i -d -r <<EOF
+[MariaDB]
+Description = MariaDB Connector/ODBC (ODBC 3.8)
+Driver = /usr/lib/x86_64-linux-gnu/odbc/libmaodbc.so
+EOF
+```
+
+### Step 2: Run MySQL in Docker and load sample data
+
+Start a MySQL server in a container. The environment variables create the `spice_demo` database and a `spice` user automatically:
+
+```bash
+docker run -d --name spice-mysql \
+  -e MYSQL_ROOT_PASSWORD=root_pw \
+  -e MYSQL_DATABASE=spice_demo \
+  -e MYSQL_USER=spice \
+  -e MYSQL_PASSWORD=spice_pw \
+  -p 3306:3306 \
+  mysql:9
+```
+
+Wait a few seconds for the server to become ready:
+
+```bash
+until docker exec spice-mysql mysqladmin ping -uspice -pspice_pw -h127.0.0.1 --silent; do sleep 2; done
+```
+
+Load the sample data:
+
+```bash
+docker exec -i spice-mysql mysql -uspice -pspice_pw spice_demo <<'SQL'
+CREATE TABLE users (
+  id INT,
+  username VARCHAR(64),
+  email VARCHAR(128),
+  signup_date DATE,
+  active BOOLEAN
 );
 
-INSERT INTO taxi_trips VALUES
-(2, '2024-01-01 00:57:55', '2024-01-01 01:17:43', 1, 1.72, 1, 'N', 186, 79, 2, 17.7, 1, 0.5, 0, 0, 1, 22.7, 2.5, 0),
-(1, '2024-01-01 00:03:00', '2024-01-01 00:09:36', 1, 1.8, 1, 'N', 140, 236, 1, 10.0, 3.5, 0.5, 3.75, 0, 1, 18.75, 2.5, 0),
-(1, '2024-01-01 00:17:06', '2024-01-01 00:35:01', 1, 4.7, 1, 'N', 236, 79, 1, 23.3, 3.5, 0.5, 3, 0, 1, 31.3, 2.5, 0);
+INSERT INTO users VALUES
+(1, 'alice_j', 'alice@example.com', '2024-01-15', 1),
+(2, 'bob_s',   'bob@example.com',   '2024-02-03', 1),
+(3, 'carol_w', 'carol@example.com', '2024-03-22', 0);
+SQL
 ```
+
+The `spicepod.yaml` in this directory connects with the following ODBC connection string:
+
+```
+DRIVER={MariaDB};SERVER=127.0.0.1;PORT=3306;DATABASE=spice_demo;UID=spice;PWD=spice_pw;SSLMODE=REQUIRED;
+```
+
+> `SSLMODE=REQUIRED` is needed because MySQL 8+/9+ default to the `caching_sha2_password` authentication plugin, which requires a secure channel for the initial authentication.
 
 ### Step 3: Run Spice
 
-Start Spice inside the cookbook directory, which contains a Spicepod pre-configured to connect to the newly created `taxi_trips` table via ODBC:
+Start Spice inside the cookbook directory, which contains a Spicepod pre-configured to connect to the `users` table via ODBC:
 
 ```bash
 spice run
 ```
 
-The Spice Runtime should start and become ready:
+The Spice Runtime should start and become ready — note that there is **no ODBC version warning**:
 
 ```console
-Spice.ai OSS CLI v1.5.1-build.af574cb4e
-2025/07/29 12:02:26 INFO Checking for latest Spice runtime release...
-2025/07/29 12:02:26 INFO Spice.ai runtime starting...
-2025-07-29T02:02:26.714448Z  INFO spiced: Starting runtime v1.5.1-build.af574cb4e
-2025-07-29T02:02:26.714895Z  INFO runtime::init::caching: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
-2025-07-29T02:02:26.714952Z  INFO runtime::init::caching: Initialized search results cache;
-2025-07-29T02:02:27.601396Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-07-29T02:02:27.601397Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
-2025-07-29T02:02:27.601542Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-07-29T02:02:27.601629Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
-2025-07-29T02:02:27.602927Z  INFO runtime::init::dataset: Dataset taxi_trips registered (odbc:taxi_trips), results cache enabled.
-2025-07-29T02:02:27.704384Z  INFO runtime: All components are loaded. Spice runtime is ready!
+2026-06-30T23:57:36.290458Z  INFO spiced: Starting runtime v2.1.0
+2026-06-30T23:57:36.383106Z  INFO runtime::init::dataset: Dataset users initializing...
+2026-06-30T23:57:36.410556Z  INFO runtime::init::dataset: Dataset users registered (odbc:users), results cache enabled.
+2026-06-30T23:57:36.515305Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 ### Step 4: Run a query
@@ -128,17 +143,27 @@ Spice.ai OSS CLI v1.5.1-build.af574cb4e
 In a new terminal, use `spice sql` to run a query:
 
 ```sql
-SELECT * FROM taxi_trips;
+SELECT * FROM users;
 ```
 
 Example output:
 
 ```console
-+----------+----------------------+-----------------------+-----------------+---------------+------------+--------------------+--------------+--------------+--------------+-------------+-------+---------+------------+--------------+-----------------------+--------------+----------------------+-------------+
-| vendorid | tpep_pickup_datetime | tpep_dropoff_datetime | passenger_count | trip_distance | ratecodeid | store_and_fwd_flag | pulocationid | dolocationid | payment_type | fare_amount | extra | mta_tax | tip_amount | tolls_amount | improvement_surcharge | total_amount | congestion_surcharge | airport_fee |
-+----------+----------------------+-----------------------+-----------------+---------------+------------+--------------------+--------------+--------------+--------------+-------------+-------+---------+------------+--------------+-----------------------+--------------+----------------------+-------------+
-| 2        | 2024-01-01T00:57:55  | 2024-01-01T01:17:43   | 1               | 1.72          | 1          | N                  | 186          | 79           | 2            | 17.7        | 1.0   | 0.5     | 0.0        | 0.0          | 1.0                   | 22.7         | 2.5                  | 0.0         |
-| 1        | 2024-01-01T00:03:00  | 2024-01-01T00:09:36   | 1               | 1.8           | 1          | N                  | 140          | 236          | 1            | 10.0        | 3.5   | 0.5     | 3.75       | 0.0          | 1.0                   | 18.75        | 2.5                  | 0.0         |
-| 1        | 2024-01-01T00:17:06  | 2024-01-01T00:35:01   | 1               | 4.7           | 1          | N                  | 236          | 79           | 1            | 23.3        | 3.5   | 0.5     | 3.0        | 0.0          | 1.0                   | 31.3         | 2.5                  | 0.0         |
-+----------+----------------------+-----------------------+-----------------+---------------+------------+--------------------+--------------+--------------+--------------+-------------+-------+---------+------------+--------------+-----------------------+--------------+----------------------+-------------+
++----+----------+-------------------+-------------+--------+
+| id | username | email             | signup_date | active |
++----+----------+-------------------+-------------+--------+
+| 1  | alice_j  | alice@example.com | 2024-01-15  | 1      |
+| 2  | bob_s    | bob@example.com   | 2024-02-03  | 1      |
+| 3  | carol_w  | carol@example.com | 2024-03-22  | 0      |
++----+----------+-------------------+-------------+--------+
 ```
+
+### Cleanup
+
+When you're done, stop and remove the container:
+
+```bash
+docker rm -f spice-mysql
+```
+
+> **Note on `ORDER BY`:** Spice pushes `ORDER BY` down to the source as `ORDER BY ... NULLS LAST`. MySQL does not support that ANSI syntax and will reject the query, whereas MariaDB servers accept it. If you are on MySQL and need ordering, sort on the Spice side (e.g. by materializing into an accelerator) or omit pushed-down `ORDER BY`. This is a SQL-dialect detail and is unrelated to the ODBC version handshake above.

--- a/odbc/spicepod.yaml
+++ b/odbc/spicepod.yaml
@@ -1,8 +1,8 @@
 version: v1
 kind: Spicepod
-name: sqlite_odbc
+name: mysql_odbc
 datasets:
-  - from: odbc:taxi_trips
-    name: taxi_trips
-    params: &odbc_params
-      odbc_connection_string: "Driver={SQLite3};Database=data.sqlite;"
+  - from: odbc:users
+    name: users
+    params:
+      odbc_connection_string: "DRIVER={MariaDB};SERVER=127.0.0.1;PORT=3306;DATABASE=spice_demo;UID=spice;PWD=spice_pw;SSLMODE=REQUIRED;"


### PR DESCRIPTION
## 🗣 Description

Use mysql in odbc cookbook to avoid warning:
```bash
State: 01000, Native error: 0, Message: [unixODBC][Driver Manager]Driver does not support the requested version
```
