### PR TITLE
Fix spark recipe Docker builds

### DIFF
--- a/spark/README.md
+++ b/spark/README.md
@@ -24,7 +24,7 @@ cd cookbook/spark
 1. Navigate to `spark-3.5` folder and start the Docker Compose stack, which includes a Spark 3.5.6 instance and init notebook to load the NYC taxi trip parquet data:
 
 ```shell
-docker compose up -d
+docker compose up -d --build
 ```
 
 It will take about about 30 seconds to start the Spark instance and load the sample dataset.
@@ -205,10 +205,10 @@ docker compose down --volumes --rmi local
 
 ### Spark 4
 
-1. Navigate to `spark-4` folder and start the Docker Compose stack, which includes a Spark 4.0.0 instance and init notebook to load the NYC taxi trip parquet data:
+1. Navigate to `spark-4` folder and start the Docker Compose stack, which includes a Spark 4.0.3 instance and init notebook to load the NYC taxi trip parquet data:
 
 ```shell
-docker compose up -d
+docker compose up -d --build
 ```
 
 It will take about about 30 seconds to start the Spark instance and load the sample dataset.

--- a/spark/spark-3.5/spark/Dockerfile
+++ b/spark/spark-3.5/spark/Dockerfile
@@ -57,12 +57,7 @@ RUN cd ${SPARK_HOME} \
 
 ENV SPARK_VERSION=3.5.6
 RUN cd ${SPARK_HOME} && \
-    wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.12/${SPARK_VERSION}/spark-connect_2.12-${SPARK_VERSION}.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect-client-jvm_2.12/${SPARK_VERSION}/spark-connect-client-jvm_2.12-${SPARK_VERSION}.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/grpc/grpc-all/1.47.0/grpc-all-1.47.0.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.47.0/grpc-netty-1.47.0.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.77.Final/netty-codec-http2-4.1.77.Final.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.77.Final/netty-handler-proxy-4.1.77.Final.jar -P jars/
+    curl -fL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.12/${SPARK_VERSION}/spark-connect_2.12-${SPARK_VERSION}.jar -o jars/spark-connect_2.12-${SPARK_VERSION}.jar
 
 RUN mkdir -p /home/spark/data \
     && curl https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-04.parquet -o /home/spark/data/yellow_tripdata_2022-04.parquet \

--- a/spark/spark-4/spark/Dockerfile
+++ b/spark/spark-4/spark/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 
 WORKDIR ${SPARK_HOME}
 
-ENV SPARK_VERSION=4.0.2
+ENV SPARK_VERSION=4.0.3
 
 RUN mkdir -p /home/spark/data \
     /home/spark/notebooks \
@@ -51,18 +51,13 @@ COPY ipython/startup/*.py /root/.ipython/profile_default/startup/
 
 # Download spark
 RUN cd ${SPARK_HOME} \
-    && curl https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
+    && curl -fL https://dlcdn.apache.org/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop3.tgz -o spark-${SPARK_VERSION}-bin-hadoop3.tgz \
     && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
     && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 
-ENV SPARK_VERSION=4.0.2
+ENV SPARK_VERSION=4.0.3
 RUN cd ${SPARK_HOME} && \
-    wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.13/${SPARK_VERSION}/spark-connect_2.13-${SPARK_VERSION}.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/org/apache/spark/spark-connect-client-jvm_2.13/${SPARK_VERSION}/spark-connect-client-jvm_2.13-${SPARK_VERSION}.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/grpc/grpc-all/1.47.0/grpc-all-1.47.0.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/grpc/grpc-netty/1.47.0/grpc-netty-1.47.0.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/netty/netty-codec-http2/4.1.77.Final/netty-codec-http2-4.1.77.Final.jar -P jars/ && \
-    wget https://repo1.maven.org/maven2/io/netty/netty-handler-proxy/4.1.77.Final/netty-handler-proxy-4.1.77.Final.jar -P jars/
+    curl -fL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.13/${SPARK_VERSION}/spark-connect_2.13-${SPARK_VERSION}.jar -o jars/spark-connect_2.13-${SPARK_VERSION}.jar
 
 RUN mkdir -p /home/spark/data \
     && curl https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-04.parquet -o /home/spark/data/yellow_tripdata_2022-04.parquet \


### PR DESCRIPTION
Fixes the Spark cookbook Docker builds by using only the Spark Connect server jar, forcing rebuilt images in the README, and updating Spark 4 to 4.0.3.