### PR TITLE
Fix dynamodb recipe: correct version floor to v1.9.0+

### DIFF
--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -1,6 +1,6 @@
 # DynamoDB Data Connector (AWS Hosted)
 
-Works with `v1.0+`
+Works with `v1.9.0+`
 
 This recipe demonstrates how to configure a Spice dataset to connect to an AWS-hosted DynamoDB table and query data from it.
 


### PR DESCRIPTION
The DynamoDB connector recipe declares `Works with v1.0+`, but its `spicepod.yaml` sets `unnest_depth: 1` — the parameter that flattens the nested `location` map into the `location.lat` / `location.lon` columns shown in the recipe’s sample output.

**What the recipe says:** `Works with v1.0+`

**What the code does:** `unnest_depth` was added to the DynamoDB connector in **v1.9.0** ([spiceai/spiceai#7715](https://github.com/spiceai/spiceai/pull/7715)). On v1.0–v1.8 the parameter does not exist, so a reader would not get the flattened columns the recipe demonstrates.

**What changed:** Version floor `v1.0+` → `v1.9.0+`.

**Source ref:** Verified against `spiceai/spiceai` at `v2.0.1` — `crates/runtime/src/dataconnector/dynamodb.rs` registers `ParameterSpec::runtime("unnest_depth")`; `git tag --contains` on the introducing commit shows the earliest release is `v1.9.0`.

Note: the sibling `dynamodb/streams` recipe correctly declares `v1.10+` (DynamoDB Streams landed in v1.10.0), so it is left unchanged. The generic `v1.0+` floor here traces back to #375, which bulk-added compatibility lines before `unnest_depth` was configured (#329).