### PR TITLE
Fix catalogs/postgres recipe: remove stray api-key auth block from spicepod

### DIFF
--- a/catalogs/postgres/postgres-catalog-recipe/spicepod.yaml
+++ b/catalogs/postgres/postgres-catalog-recipe/spicepod.yaml
@@ -1,14 +1,7 @@
 version: v1
 kind: Spicepod
 name: postgres-catalog-recipe
-runtime:
-  flight:
-    max_message_size: 5GiB
-  auth:
-    api-key:
-      enabled: true
-      keys:
-        - foo:rw
+
 catalogs:
   - from: pg
     name: pg


### PR DESCRIPTION
## What was wrong

The committed `catalogs/postgres/postgres-catalog-recipe/spicepod.yaml` carried a `runtime:` block that the README never introduces:

```yaml
runtime:
  flight:
    max_message_size: 5GiB
  auth:
    api-key:
      enabled: true
      keys:
        - foo:rw
```

This looks like leftover test-harness config, and it contradicts the recipe as documented:

- **Step 4** ("Add the PostgreSQL Catalog Connector to `spicepod.yaml`") shows a spicepod with **no** `runtime:` section.
- No step enables or mentions API-key authentication.
- **Step 3** creates a `.env` containing only `PG_USER=postgres`, and `.env.example` likewise only lists `PG_USER`.

With `runtime.auth.api-key.enabled: true` set, the runtime requires an API key on every Flight request, and `spice sql` only sends one if a `SPICE_API_KEY` (or `SPICE_SPICEAI_API_KEY`) is present in `.env`/`.env.local` (`bin/spice/src/context.rs`, `load_api_key_from_env`). Since the recipe never sets such a key, the **Step 6** `spice sql` queries would be rejected with an authentication error for anyone running the committed spicepod.

Verified against `spiceai/spiceai` @ **v2.0.1**: the `api-key` auth schema (`ApiKeyAuth` / `keys`, with `foo:rw` = read-write) is in `crates/spicepod/src/component/runtime.rs`.

## What changed

Removed the stray `runtime:` block so the committed spicepod matches the config the README actually documents in Step 4 (a plain PostgreSQL catalog connector, no auth). The catalog-connector recipe is about schema/table discovery — auth and a 5 GiB Flight message size are unrelated to the tutorial.

Static audit (Docker + Postgres required to run live; the config mismatch is confirmed against source).