### PR TITLE
Fix catalogs/glue recipe: correct version floor to v1.4.0+

### DIFF
--- a/catalogs/glue/README.md
+++ b/catalogs/glue/README.md
@@ -1,6 +1,6 @@
 # AWS Glue Catalog Connector
 
-Works with `v1.0+`
+Works with `v1.4.0+`
 
 The AWS Glue Catalog Connector enables Spice to query tables registered in an AWS Glue Data Catalog. It supports tables referencing S3 data in Iceberg, Hive-style Parquet, and CSV formats.
 


### PR DESCRIPTION
## What was wrong

The `catalogs/glue` recipe header claimed `Works with v1.0+`, but the AWS Glue **Catalog** Connector it demonstrates (`from: glue` under `catalogs:`) did not exist until **v1.4.0**.

Verified against `spiceai/spiceai`: the catalog connector source `crates/runtime/src/catalogconnector/glue.rs` was introduced in commit `82ecbada1` ("Read Iceberg tables from Glue Catalog Connector", #5965, 2025-05-28). `git tag --contains 82ecbada1` → earliest release tag is **v1.4.0** (not present in v1.3.x). A reader on v1.0–v1.3 would have no `glue` catalog connector and the recipe would fail at `spice run`.

## What changed

Bumped the version floor from `v1.0+` to `v1.4.0+`.

Source of truth: `spiceai/spiceai` (glue catalog connector first released in v1.4.0). Static audit — the recipe requires AWS Glue + S3 credentials to run live.