### PR TITLE
Fix distributed recipe: correct version floor to v2.0+

### DIFF
--- a/distributed/README.md
+++ b/distributed/README.md
@@ -1,6 +1,6 @@
 # Distributed Query
 
-Works with `v1.9+`
+Works with `v2.0+`
 
 This recipe demonstrates how to run Spice.ai OSS in a distributed mode, for maximum performance in queries on large datasets across multiple nodes. It shows how to:
 
@@ -81,7 +81,6 @@ The Spice scheduler will now start:
 2025-12-15T23:14:50.185608Z  INFO ballista_scheduler::scheduler_process: Starting Scheduler grpc server with task scheduling policy of PullStaged
 2025-12-15T23:14:50.185612Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
 2025-12-15T23:14:50.185719Z  INFO ballista_scheduler::scheduler_server::query_stage_scheduler: Starting QueryStageScheduler
-2025-12-15T23:14:50.185866Z  WARN runtime: Distributed Query (Alpha) is in preview and should not be used in production.
 2025-12-15T23:14:50.186108Z  INFO runtime::init::dataset: Dataset data initializing...
 2025-12-15T23:14:50.186157Z  INFO ballista_core::event_loop: Starting the event loop query_stage
 2025-12-15T23:14:50.186890Z  INFO runtime::cluster::servers: Cluster mTLS enabled for internal cluster server
@@ -117,7 +116,6 @@ The Spice executor will now start:
 2025-12-15T23:16:55.202032Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
 2025-12-15T23:16:55.202128Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
 2025-12-15T23:16:56.023942Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
-2025-12-15T23:16:56.053505Z  WARN runtime: Distributed Query (Alpha) is in preview and should not be used in production.
 2025-12-15T23:16:56.053559Z  INFO ballista_executor::execution_loop: Starting poll work loop with scheduler
 2025-12-15T23:16:56.053746Z  INFO runtime::cluster::servers: Cluster mTLS enabled for executor flight server
 2025-12-15T23:16:56.053952Z  INFO runtime::cluster::servers: Spice Runtime executor Flight listening on [::1]:50053


### PR DESCRIPTION
## What the recipe said

`distributed/README.md` declared **`Works with v1.9+`** and its expected `spice run` output included the line:

```
WARN runtime: Distributed Query (Alpha) is in preview and should not be used in production.
```

## What the code does

The workflow the recipe documents requires **Spice v2.0.0+**:

- The `spice cluster tls init` / `spice cluster tls add <name>` subcommands live in `bin/spice/src/commands/cluster.rs`, added in the Go→Rust CLI rewrite. That file **does not exist at `v1.9.0` or `v1.10.0`** (`git cat-file -e v1.9.0:bin/spice/src/commands/cluster.rs` → absent; present at `v2.0.0`).
- The mTLS spiced flags `--node-mtls-ca-certificate-file`, `--node-mtls-certificate-file`, `--node-mtls-key-file`, `--node-bind-address`, `--node-advertise-address`, `--scheduler-address` are absent from `v1.9.0:crates/runtime/src/config.rs` (0 occurrences of `node-mtls`) and present in `v2.0.1` (3 occurrences).
- The `Distributed Query (Alpha) is in preview` warning was removed in v2.0 — `git grep "Distributed Query" v2.0.1 -- crates/runtime/src` returns no match, so it never appears for a reader on current stable.

A reader on v1.9.x/v1.10.x following this recipe verbatim hits `unknown command "cluster"` and unknown-flag errors.

## What changed

- `Works with v1.9+` → `Works with v2.0+`.
- Removed the stale `Distributed Query (Alpha) is in preview…` WARN line from both the scheduler and executor expected-output blocks.

Verified against `spiceai/spiceai` (current stable **v2.0.1**; source `bin/spice/src/commands/cluster.rs`, `crates/runtime/src/config.rs`).