### PR TITLE
Fix caching/sql_results recipe: correct cache init log line

### DIFF
--- a/caching/sql_results/README.md
+++ b/caching/sql_results/README.md
@@ -33,7 +33,7 @@ Observe the Spice runtime terminal for cache initialization. Example output:
 
 ```bash
 2024-08-05T05:25:10.627005Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-08-05T05:26:50.262092Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), results cache enabled.
 2024-08-05T05:26:51.569841Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), results cache enabled.
 2024-08-05T05:26:52.871013Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.
@@ -47,7 +47,7 @@ Observe the Spice runtime terminal for cache initialization. Example output:
 Notice the following line confirming the default cache configuration with cached items expiration time of 1 second is loaded.
 
 ```bash
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```
 
 ## Step 3: Update Cache Configuration
@@ -89,11 +89,11 @@ Restart the Spice runtime:
 spice run
 ```
 
-Verify the following output is shown in the Spice runtime terminal, confirming that the updated in-memory caching settings (`Initialized results cache; max size: 128.00 MiB, item ttl: 300s`) were applied:
+Verify the following output is shown in the Spice runtime terminal, confirming that the updated in-memory caching settings (`Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s`) were applied:
 
 ```bash
 2024-08-05T05:29:06.876281Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:29:06.876579Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: XXH3, encoding: none
+2024-08-05T05:29:06.876579Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: XXH3, encoding: none
 2024-08-05T05:29:08.395163Z  INFO runtime: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), results cache enabled.
 2024-08-05T05:29:08.399137Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.
 2024-08-05T05:29:08.399887Z  INFO runtime: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), results cache enabled.
@@ -197,7 +197,7 @@ Observe the Spice runtime terminal for cache initialization. Example output:
 
 ```console
 2024-08-05T05:25:10.627005Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: Ahash, encoding: none
+2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: Ahash, encoding: none
 2024-08-05T05:26:50.262092Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), results cache enabled.
 2024-08-05T05:26:51.569841Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), results cache enabled.
 2024-08-05T05:26:52.871013Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.


### PR DESCRIPTION
## What the recipe said

`caching/sql_results/README.md` showed the SQL results cache initializing as:

```
INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
```

and explicitly directs the reader to *"Notice the following line confirming the default cache configuration…"* pointing at that exact string.

## What the code does

The runtime emits **`Initialized sql results cache;`** — note the word `sql` — in `crates/runtime/src/init/caching.rs`:

```rust
tracing::info!("Initialized sql results cache; {cache_provider}");
```

(There are separate `Initialized search results cache;` and `Initialized embeddings cache;` lines.) Verified at both `v2.0.0` and `v2.0.1`. A reader grepping the terminal for the printed line as instructed would not find it.

## What changed

Corrected all occurrences of `Initialized results cache;` → `Initialized sql results cache;` in the expected-output blocks and the accompanying prose. The `max size / item ttl / hashing algorithm / encoding` suffix and the `INFO runtime:` module prefix used throughout the block are left as-is.

Verified against `spiceai/spiceai` (current stable **v2.0.1**; source `crates/runtime/src/init/caching.rs`).