### PR TITLE
Fix api_key recipe: correct 'spice pods' output columns

### DIFF
--- a/api_key/README.md
+++ b/api_key/README.md
@@ -75,8 +75,8 @@ $ spice pods
 ```bash
 $ spice pods --api-key foobar
 
-VERSION NAME    DATASETSCOUNT MODELSCOUNT DEPENDENCIESCOUNT
-v1      api_key 0             0           0
+NAME    VERSION DATASETS MODELS DEPENDENCIES
+api_key v1      0        0      0
 ```
 
 ## SQL REPL


### PR DESCRIPTION
## What the recipe said

`api_key/README.md` showed the `spice pods` output as:

```
VERSION NAME    DATASETSCOUNT MODELSCOUNT DEPENDENCIESCOUNT
v1      api_key 0             0           0
```

## What the code does

The `spice pods` command prints columns **`NAME VERSION DATASETS MODELS DEPENDENCIES`** — a different order and without the `COUNT` suffix. From `bin/spice/src/commands/pods.rs`:

```rust
fn headers() -> Vec<&'static str> {
    vec!["NAME", "VERSION", "DATASETS", "MODELS", "DEPENDENCIES"]
}
```

The `VERSION` value `v1` is **correct** — it reflects the spicepod's own `version: v1` field (`api_key/spicepod.yaml`), not the Spice release — so only the header names/order and row alignment change.

## What changed

```
NAME    VERSION DATASETS MODELS DEPENDENCIES
api_key v1      0        0      0
```

Verified against `spiceai/spiceai` (current stable **v2.0.1**; source `bin/spice/src/commands/pods.rs`).