### PR TITLE
Fix ai recipe: correct task_history columns in example_queries.sql

### DIFF
--- a/ai/example_queries.sql
+++ b/ai/example_queries.sql
@@ -2,16 +2,8 @@
 -- Copy and paste these into the Spice SQL REPL (spice sql)
 
 -- ==============================================
--- BASIC-- 18. Use AI in WHERE clause (expensive - use sparingly!)
--- SELECT Zone 
--- FROM taxi_zones
--- WHERE ai(concat('Is ', Zone, ' a residential area? Answer yes or no'), 'gpt-4o-mini') = 'yes'
--- LIMIT 5;
-
--- 19. Generate structured data
-SELECT 
-  'Product Analysis' as task,
-  ai('List 3 features of a smartphone, separated by commas', 'gpt-4o-mini') as features;-- ==============================================
+-- BASIC
+-- ==============================================
 
 -- 1. Simple greeting
 SELECT ai('Say hello!', 'gpt-4o-mini') as greeting;
@@ -166,7 +158,7 @@ LIMIT 3;
 -- WHERE ai(concat('Is ', Zone, ' a residential area? Answer yes or no'), 'gpt-4o-mini') = 'yes'
 -- LIMIT 5;
 
--- 18. Generate structured data
+-- 19. Generate structured data
 SELECT 
   'Product Analysis' as task,
   ai('List 3 features of a smartphone, separated by commas', 'gpt-4o-mini') as features;
@@ -187,12 +179,12 @@ SELECT
 -- ==============================================
 
 -- 21. View recent AI tasks
-SELECT 
-  task_id,
+SELECT
+  trace_id,
   task,
-  execution_time,
+  execution_duration_ms,
   left(captured_output, 50) as output_preview
 FROM runtime.task_history
 WHERE task = 'ai'
-ORDER BY captured_at DESC
+ORDER BY start_time DESC
 LIMIT 10;


### PR DESCRIPTION
## What the recipe said

The bundled `ai/example_queries.sql` — a copy-paste-into-`spice sql` file — ends with query 21, "View recent AI tasks":

```sql
SELECT
  task_id,
  task,
  execution_time,
  left(captured_output, 50) as output_preview
FROM runtime.task_history
WHERE task = 'ai'
ORDER BY captured_at DESC
LIMIT 10;
```

## What the code does

At current stable (**v2.0.1**), `runtime.task_history` has none of `task_id`, `execution_time`, or `captured_at`. Its schema is `trace_id`, `span_id`, `parent_span_id`, `task`, `input`, `captured_output`, `start_time`, `end_time`, `execution_duration_ms`, `error_message`, `labels` — see [`crates/runtime/src/task_history/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.0.1/crates/runtime/src/task_history/mod.rs) (`table_schema`). So query 21 fails for anyone who runs the file. The README's own inline version of this query is already correct (it uses `trace_id`, `execution_duration_ms`, `ORDER BY start_time`).

PR #412 corrected the `customer_feedback` columns in this file (`id` → `feedback_id`) but did not reach query 21.

## What changed

- Query 21: `task_id` → `trace_id`, `execution_time` → `execution_duration_ms`, `ORDER BY captured_at` → `ORDER BY start_time` (matching the README's inline query and the runtime schema).
- Removed a corrupted/duplicated block that had been crammed into the `-- BASIC` section header (a stray copy of queries 18-19), and renumbered the duplicate `-- 18` on the structured-data query to `-- 19`.

Verified against `spiceai/spiceai` at tag `v2.0.1`.