### PR TITLE
Fix tpc-h recipe: correct show tables schema to tpch

### DIFF
--- a/tpc-h/README.md
+++ b/tpc-h/README.md
@@ -76,14 +76,14 @@ show tables;
 | table_catalog | table_schema | table_name   | table_type |
 +---------------+--------------+--------------+------------+
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | public       | customer     | BASE TABLE |
-| spice         | public       | region       | BASE TABLE |
-| spice         | public       | lineitem     | BASE TABLE |
-| spice         | public       | partsupp     | BASE TABLE |
-| spice         | public       | part         | BASE TABLE |
-| spice         | public       | nation       | BASE TABLE |
-| spice         | public       | orders       | BASE TABLE |
-| spice         | public       | supplier     | BASE TABLE |
+| spice         | tpch         | customer     | BASE TABLE |
+| spice         | tpch         | region       | BASE TABLE |
+| spice         | tpch         | lineitem     | BASE TABLE |
+| spice         | tpch         | partsupp     | BASE TABLE |
+| spice         | tpch         | part         | BASE TABLE |
+| spice         | tpch         | nation       | BASE TABLE |
+| spice         | tpch         | orders       | BASE TABLE |
+| spice         | tpch         | supplier     | BASE TABLE |
 +---------------+--------------+--------------+------------+
 
 Time: 0.006163958 seconds. 9 rows.


### PR DESCRIPTION
## What the recipe said
The `show tables` expected output listed all eight TPC-H tables under `table_schema = public`:

```
| spice | public | customer | BASE TABLE |
| spice | public | lineitem | BASE TABLE |
...
```

## What the code does
`spice add spiceai/tpch` registers the datasets with **dotted names** (`tpch.customer`, `tpch.lineitem`, …), which resolve to schema `tpch`, not `public`. The recipe's own runtime log confirms this: `Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/)` (README lines 36-44). A dotted dataset name parses to `schema = tpch, table = customer` (spiceai/spiceai @ v2.0.1, `crates/runtime/src/component/dataset/mod.rs`).

This also contradicted the recipe's **own Q1 query** a few lines later, which selects `from tpch.lineitem` — a query that only works because the schema is `tpch`.

## What changed
Updated the `show tables` block to show `table_schema = tpch` for the eight TPC-H tables (`task_history` stays under `runtime`). Row count unchanged (9 rows).

Verified against spiceai/spiceai at tag `v2.0.1` (current stable).