### PR TITLE
Fix hashed_partitioning recipe: remove broken #partitioning doc anchor

### DIFF
--- a/hashed_partitioning/README.md
+++ b/hashed_partitioning/README.md
@@ -108,5 +108,5 @@ In this case, only one partitioned file is relevant for scanning and remains in 
 
 ## Learn more
 
-[DuckDB Partitioning Documentation](https://spiceai.org/docs/components/data-accelerators/duckdb#partitioning)
+[DuckDB Partitioning Documentation](https://spiceai.org/docs/components/data-accelerators/duckdb)
 [Data Acceleration](https://spiceai.org/docs/features/data-acceleration)


### PR DESCRIPTION
## What the recipe said
The "Learn more" section linked to:

`https://spiceai.org/docs/components/data-accelerators/duckdb#partitioning`

## What the docs show
The DuckDB Data Accelerator page has no `partitioning` heading/anchor (its sections are Modes, Configuration Parameters, Limitations, Resource Considerations, Temporary Directory, Cookbook, Related Documentation). The `#partitioning` fragment does not resolve, so the link lands at the top of the page rather than a section. Partitioning (`partition_by`, `partition_mode`, etc.) is documented on that page under **Configuration Parameters**.

## What changed
Removed the dangling `#partitioning` fragment so the link resolves cleanly to the DuckDB accelerator page.