### PR TITLE
Fix dual-dataset-registration recipe: point at real taxi_trips dataset

### DIFF
--- a/acceleration/dual-dataset-registration/README.md
+++ b/acceleration/dual-dataset-registration/README.md
@@ -50,13 +50,13 @@ name: dual-dataset-registration
 
 datasets:
   # Federated table — available immediately at startup
-  - from: s3://spiceai-public-datasets/taxi_trips/
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips
     params:
       file_format: parquet
 
   # Accelerated copy — loads in the background
-  - from: s3://spiceai-public-datasets/taxi_trips/
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips_accelerated
     params:
       file_format: parquet
@@ -85,8 +85,8 @@ spice run
 Shortly after startup you will see both datasets register. The federated table is ready immediately, while the accelerated copy begins loading:
 
 ```bash
-2025-03-24T10:00:01.123456Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-public-datasets/taxi_trips/), results cache enabled.
-2025-03-24T10:00:01.234567Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-public-datasets/taxi_trips/), acceleration (duckdb:file), results cache enabled.
+2025-03-24T10:00:01.123456Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
+2025-03-24T10:00:01.234567Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file), results cache enabled.
 2025-03-24T10:00:01.234890Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips_accelerated
 ```
 
@@ -108,7 +108,7 @@ SELECT COUNT(*) AS total_trips FROM taxi_trips;
 +-------------+
 | total_trips |
 +-------------+
-| 1547741     |
+| 2964624     |
 +-------------+
 ```
 
@@ -127,12 +127,12 @@ While still loading:
 ```json
 [
   {
-    "from": "s3://spiceai-public-datasets/taxi_trips/",
+    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips",
     "status": "Ready"
   },
   {
-    "from": "s3://spiceai-public-datasets/taxi_trips/",
+    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips_accelerated",
     "status": "Refreshing"
   }
@@ -144,12 +144,12 @@ When the acceleration finishes:
 ```json
 [
   {
-    "from": "s3://spiceai-public-datasets/taxi_trips/",
+    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips",
     "status": "Ready"
   },
   {
-    "from": "s3://spiceai-public-datasets/taxi_trips/",
+    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips_accelerated",
     "status": "Ready"
   }
@@ -159,7 +159,7 @@ When the acceleration finishes:
 The Spice runtime logs also confirm when the load completes:
 
 ```bash
-2025-03-24T10:03:45.678901Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,547,741 rows () for dataset taxi_trips_accelerated in 3m 44s.
+2025-03-24T10:03:45.678901Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows () for dataset taxi_trips_accelerated in 3m 44s.
 ```
 
 ## Step 6. Switch to the accelerated table
@@ -174,7 +174,7 @@ SELECT COUNT(*) AS total_trips FROM taxi_trips_accelerated;
 +-------------+
 | total_trips |
 +-------------+
-| 1547741     |
+| 2964624     |
 +-------------+
 ```
 

--- a/acceleration/dual-dataset-registration/spicepod.yaml
+++ b/acceleration/dual-dataset-registration/spicepod.yaml
@@ -4,13 +4,13 @@ name: dual-dataset-registration
 
 datasets:
   # Federated table — available immediately at startup
-  - from: s3://spiceai-public-datasets/taxi_trips/
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips
     params:
       file_format: parquet
 
   # Accelerated copy — loads in the background
-  - from: s3://spiceai-public-datasets/taxi_trips/
+  - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips_accelerated
     params:
       file_format: parquet


### PR DESCRIPTION
## What the recipe said
The recipe registers `s3://spiceai-public-datasets/taxi_trips/` twice and demonstrates a *large table* whose background acceleration takes minutes, showing `SELECT COUNT(*)` = `1547741` and a load log `Loaded 1,547,741 rows () ... in 3m 44s`.

## What the data actually is
`s3://spiceai-public-datasets/taxi_trips/` contains a single **7,226-byte** file (`taxi_sample.parquet`, a few hundred rows) — verified via S3 ListBucket:
```
taxi_trips/taxi_sample.parquet   7226 bytes
```
A 7 KB parquet cannot produce 1,547,741 rows or a multi-minute load. A reader running the recipe verbatim sees a sub-second load of a tiny sample, which contradicts the whole Step 4–6 narrative (immediate-federation vs. slow-acceleration, `Refreshing` status, etc.).

Every other cookbook recipe uses `s3://spiceai-demo-datasets/taxi_trips/2024/` — the real dataset (`yellow_tripdata_2024-01.parquet`, ~96 MB, **2,964,624** rows, verified from the parquet footer metadata).

## What changed
- Repoint both datasets (embedded spicepod in the README **and** the shipped `spicepod.yaml`) to `s3://spiceai-demo-datasets/taxi_trips/2024/`.
- Correct the expected row count `1547741` → `2964624` in both `COUNT(*)` outputs, the load-complete log line, and the register/status-API `from` values.

Row count verified against the actual parquet file metadata (`num_rows = 2964624`). Bucket contents verified via S3 ListBucket against both `spiceai-public-datasets` and `spiceai-demo-datasets`.