### PR TITLE
Fix search/elasticsearch recipe: note Elasticsearch feature build requirement

### DIFF
--- a/search/elasticsearch/README.md
+++ b/search/elasticsearch/README.md
@@ -13,6 +13,7 @@ This recipe demonstrates using Elasticsearch as a unified backend for both **ful
 ## Prerequisites
 
 - [Spice CLI](https://docs.spiceai.org/getting-started) installed
+- **Spice built with Elasticsearch support**: the Elasticsearch search/index engine is _not_ included in the released binaries. Build and run Spice with the `elasticsearch` feature enabled, e.g. `cargo run --release --features elasticsearch -p spiced`. Without it, Spice silently falls back to its built-in local full-text/vector index and this recipe will not use Elasticsearch. See the [Elasticsearch documentation](https://spiceai.org/docs/components/data-connectors/elasticsearch) for details.
 - Docker and Docker Compose installed
 - Python 3 installed
 - OpenAI API key


### PR DESCRIPTION
## What the recipe said
The recipe configures Elasticsearch as the backend for full-text (BM25) and vector search and instructs the reader to run `spice run` with a stock-installed Spice CLI. Nothing tells the reader Elasticsearch support isn't in the released binary.

## What the code does
The Elasticsearch search/index engine is behind the `elasticsearch` cargo feature, which is **not** in the distributed binary:
- Tagged-release builds compile `--features release,models` (`.github/workflows/build_and_release.yml`, "Release builds exclude optional accelerators from the distributed binary") — no `elasticsearch`.
- The engine dispatch is `#[cfg(feature = "elasticsearch")]`-gated (`crates/runtime/src/init/dataset.rs`, `crates/runtime/src/embeddings/udtf.rs`, `crates/runtime/src/embeddings/index/mod.rs`).

Without the feature, the FTS connector **silently falls back** to the built-in local full-text index and the vector path does not use Elasticsearch — so a reader following the recipe on a stock CLI never actually exercises Elasticsearch.

## What changed
Added a prerequisite note that Spice must be built with the `elasticsearch` feature (`cargo run --release --features elasticsearch -p spiced`), mirroring the note already present in the sibling `elasticsearch/connector` recipe.

Verified against spiceai/spiceai @ `v2.0.1`.