### PR TITLE
Fix redshift recipe: note postgres-accel build requirement for write path

### DIFF
--- a/redshift/README.md
+++ b/redshift/README.md
@@ -44,6 +44,8 @@ PG_PASS=hGG3ellothere$$$$
 
 ## Step 3: Writing Data into Redshift
 
+> **Note:** The `write` spicepod accelerates data into Redshift using the PostgreSQL data accelerator (`engine: postgresql`). This accelerator is _not_ included in the released Spice binaries — tagged releases are built without the `postgres-accel` feature, so a stock-installed runtime rejects it with `Unknown engine: postgres`. Build and run Spice with the feature enabled, e.g. `cargo run --release --features release,models,postgres-accel -p spiced`. (The `read` spicepod in Step 4 uses the default in-memory `arrow` accelerator and runs on the standard binary.)
+
 To write data into Redshift, navigate to the `write` directory and start Spice using the following command:
 
 ```bash


### PR DESCRIPTION
## What the recipe said
Step 3 ("Writing Data into Redshift") tells the reader to `cd write && spice run`. The `write` spicepod accelerates the TPC-H datasets into Redshift with `acceleration.engine: postgresql`. The recipe declares `Works with v1.0+` and gives no build instructions.

## What the code does
The PostgreSQL data accelerator is gated behind the `postgres-accel` cargo feature (`crates/runtime/src/dataaccelerator/mod.rs`: `#[cfg(feature = "postgres-accel")]`), and tagged-release binaries are built **without** it:
```
# Release builds exclude optional accelerators from the distributed binary
cargo build --profile ... --features release,models -p spiced -p spice   # tagged release
```
(`.github/workflows/build_and_release.yml`). On a stock-installed v2.0.1 runtime, `get_accelerator_engine(Engine::PostgreSQL)` returns `None` and startup fails with `Unknown engine: postgres`.

## What changed
Added a note to Step 3 that the write path requires a binary built with `--features postgres-accel` (e.g. `cargo run --release --features release,models,postgres-accel -p spiced`). The `read` spicepod in Step 4 uses the default `arrow` accelerator and is unaffected.

Verified against spiceai/spiceai @ `v2.0.1`.