### PR TITLE
Fix search recipe: correct version floor to v1.6+

### DIFF
--- a/search/README.md
+++ b/search/README.md
@@ -1,6 +1,6 @@
 # Hybrid Search & Real Time Indexing
 
-Works with `v1.0+`. The fusion-score column emitted by `rrf(...)` was renamed from `fused_score` (Spice `v1.x`) to `_fused_score` (Spice `v2.0+`). The examples below use the `v2.0+` name; replace `_fused_score` with `fused_score` if you are running a `v1.x` build.
+Works with `v1.6+`. This recipe embeds text with a Model2Vec model (`model2vec:minishlab/potion-multilingual-128M`), and Model2Vec embedding support was added in Spice `v1.6.0`. The fusion-score column emitted by `rrf(...)` was renamed from `fused_score` (Spice `v1.x`) to `_fused_score` (Spice `v2.0+`). The examples below use the `v2.0+` name; replace `_fused_score` with `fused_score` if you are running a `v1.x` build.
 
 In today's hyper-connected digital ecosystem, social media represents an untapped goldmine of actionable intelligence for organizations. Beyond traditional metrics, these platforms offer unprecedented visibility into market dynamics, consumer sentiment trajectories, demographic clustering patterns, and emergent behavioral signals that can fundamentally transform go-to-market strategies and competitive positioning.
 


### PR DESCRIPTION
## What the recipe said
`Works with v1.0+`.

## What the code requires
The spicepod (`search/spicepod.yml`) embeds text with `from: model2vec:minishlab/potion-multilingual-128M`. Model2Vec embedding support was added in Spice **v1.6.0** — the earliest release tag containing the `model2vec` source in `spiceai/spiceai` (verified with `git tag --contains` on the introducing commit → `v1.6.0`). On v1.0–v1.5 the embeddings block fails to load, so the recipe cannot run on its declared floor.

## What changed
Corrected the floor to `v1.6+` with a one-line reason. The existing `fused_score` → `_fused_score` (v2.0) note is preserved.

Verified against spiceai/spiceai.