### PR TITLE
Fix text-to-sql recipe: model name `nql` → `nsql` to match documented menu output

### DIFF
--- a/text-to-sql/spicepod.yaml
+++ b/text-to-sql/spicepod.yaml
@@ -13,7 +13,7 @@ datasets:
 
 models:
   - from: openai:gpt-4o-mini
-    name: nql
+    name: nsql
     params:
       openai_api_key: ${ secrets:SPICE_OPENAI_API_KEY }
   # - name: local


### PR DESCRIPTION
## What the recipe said

`text-to-sql/spicepod.yaml` configures the NSQL model as:

```yaml
models:
  - from: openai:gpt-4o-mini
    name: nql
```

But the README's model-selection menu (shown after uncommenting the second `local` model) documents the menu as:

```console
? Select model:
    nsql
  ▸ local
```

The `spice nsql` selection menu lists models by their configured `name:`, so a reader running the recipe as written would see `nql` in that menu — not the `nsql` shown in the README. `nql` reads as a typo of `nsql` (the recipe is entirely about natural-language-to-SQL: the `spice nsql` command, the `/v1/nsql` endpoint, the `nsql>` prompt, and the `task = 'nsql'` trace filter all use `nsql`).

## What the code does

`/v1/nsql` uses the single configured model when the request omits a `model` field (`resolve_nsql_model_name` — it only requires an explicit `model` when *multiple* compatible LLMs are configured), so the single-model curl/REPL examples work regardless of the name. The name only surfaces in the multi-model selection menu, where the mismatch shows.

Verified against `spiceai/spiceai` at `v2.1.0`: [`crates/runtime/src/http/v1/nsql.rs`](https://github.com/spiceai/spiceai/blob/v2.1.0/crates/runtime/src/http/v1/nsql.rs) (model resolution, lines ~568–611).

## What changed

Renamed the model `nql` → `nsql` in `text-to-sql/spicepod.yaml` so the configured model name matches the documented selection-menu output. `nql` appears nowhere else in the recipe, so no other changes are needed.