### PR TITLE
Fix vectors/s3 recipe: correct version floor to `v2.0+`

### DIFF
--- a/vectors/s3/README.md
+++ b/vectors/s3/README.md
@@ -1,6 +1,6 @@
 # Amazon S3 Vectors Engine with Spice.ai
 
-Works with `v1.8+`
+Works with `v2.0+`
 
 Spice.ai integrates Amazon S3 Vectors, launched in public preview at AWS Summit New York 2025, as a scalable vector index backend for embedding storage and similarity search. This recipe configures a dataset of GitHub pull requests from the `spiceai/spiceai` repository, embeds the `body` column using OpenAI, stores embeddings in S3 Vectors, and demonstrates semantic search via SQL and HTTP. Spice manages index creation, data synchronization, and query execution, enabling sub-second similarity queries on large datasets at ~$0.02/GB, reducing costs by up to 90% versus traditional vector databases.
 


### PR DESCRIPTION
## What the recipe said

`vectors/s3/README.md` declares a compatibility floor of:

```
Works with `v1.8+`
```

but every SQL and HTTP example in the recipe uses the underscore-prefixed result columns `_score` and `_match` (e.g. `SELECT url, title, _score FROM vector_search(pulls, 'bugs in DuckDB', 4) ORDER BY _score DESC`).

## What the code does

The search result-column rename `score` → `_score` and `match` → `_match` landed in **v2.0.0**. On `v1.8`–`v1.9` the columns are still named `score` / `match` (no leading underscore), so the recipe's documented queries fail with a "no such column `_score`" error on those releases.

Verified against `spiceai/spiceai`:
- At `v1.9.0`: [`crates/search/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v1.9.0/crates/search/src/lib.rs) defines `SEARCH_SCORE_COLUMN_NAME = "score"` / `SEARCH_MATCH_COLUMN_NAME = "match"`.
- At `v2.1.0` (current stable) the columns are `_score` / `_match`, matching the recipe.

The S3 Vectors engine itself exists at v1.8, but the recipe as written only runs against the v2.0+ column names, so the floor understates the real requirement.

This is the same class of fix already applied to sibling search recipes (e.g. #455 converted the remaining `score` → `_score` in this recipe but did not reconcile the floor, which was added generically in #375).

## What changed

Bumped the declared floor from `v1.8+` to `v2.0+` to match the `_score` / `_match` columns the recipe's queries use.