### PR TITLE
Fix kubernetes recipe: correct broken Helm Values docs link

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -79,7 +79,7 @@ show tables;
 +---------------+--------------+---------------+------------+
 ```
 
-**Step 6.** Create a `values.yaml` file to configure the Spice deployment. See [Spice Helm Values](https://spiceai.org/docs/deployment/kubernetes#values) for more deails.
+**Step 6.** Create a `values.yaml` file to configure the Spice deployment. See [Spice Helm Values](https://spiceai.org/docs/deployment/kubernetes/helm) for more details.
 
 ```bash
 cat <<EOF > values.yaml


### PR DESCRIPTION
## What the recipe said

Step 6 links to Helm chart values via:

> See [Spice Helm Values](https://spiceai.org/docs/deployment/kubernetes#values) for more deails.

## What the docs do

- `https://spiceai.org/docs/deployment/kubernetes` has **no `#values` anchor** — its only sections are *Kubernetes Deployment*, *Spice.ai Enterprise Operator*, *Prerequisites*, and *Cookbook*. The fragment does not resolve.
- The Helm chart parameters now live on the dedicated sub-page **`https://spiceai.org/docs/deployment/kubernetes/helm`**, under a *Common Parameters* table (verified live).

## What changed

- Repoint the link to `https://spiceai.org/docs/deployment/kubernetes/helm`.
- Fix the adjacent typo `deails` → `details`.

Docs-only; no config or command changes. Verified against current stable **spiceai/spiceai v2.1.0** (Helm chart `deploy/chart` is `version: 2.1.0`).