### PR TITLE
Fix file recipe: correct stale Markdown query output

### DIFF
--- a/file/README.md
+++ b/file/README.md
@@ -149,15 +149,14 @@ select location from docs;
 Expected output:
 
 ```text
-+---------------------------------------------+
-| location                                    |
-+---------------------------------------------+
-| Users/lukim/dev/cookbook/file/debezium.md   |
-| Users/lukim/dev/cookbook/file/databricks.md |
-| Users/lukim/dev/cookbook/file/README.md     |
-| Users/lukim/dev/cookbook/file/clickhouse.md |
-| Users/lukim/dev/cookbook/file/delta-lake.md |
-+---------------------------------------------+
++----------------------------+
+| location                   |
++----------------------------+
+| path/to/file/clickhouse.md |
+| path/to/file/databricks.md |
+| path/to/file/debezium.md   |
+| path/to/file/delta-lake.md |
++----------------------------+
 ```
 
 ### Step 5: Terminate the Spice Runtime


### PR DESCRIPTION
## What the recipe said

In *Query Markdown Documents*, the expected output for `select location from docs;` shows **5 rows** with a hard-coded personal path:

```text
| Users/lukim/dev/cookbook/file/debezium.md   |
| Users/lukim/dev/cookbook/file/databricks.md |
| Users/lukim/dev/cookbook/file/README.md     |
| Users/lukim/dev/cookbook/file/clickhouse.md |
| Users/lukim/dev/cookbook/file/delta-lake.md |
```

## What actually happens

Step 1 of that section downloads **exactly 4 files** — `clickhouse.md`, `databricks.md`, `debezium.md`, `delta-lake.md`. There is no `README.md` download step. The 5th row (`README.md`) and the `Users/lukim/dev/cookbook/file/` prefix were captured in the author's own cookbook `file/` directory (which contains a README.md). A reader following the steps in a fresh directory gets 4 rows and a different path prefix, so the shown output can't be reproduced.

## What changed

Replace the block with **4 rows** matching the downloaded files and a generic `path/to/file/…` placeholder:

```text
| path/to/file/clickhouse.md |
| path/to/file/databricks.md |
| path/to/file/debezium.md   |
| path/to/file/delta-lake.md |
```

## Verification

Against current stable **spiceai/spiceai v2.1.0**: the file connector's text table exposes a `location` column (`crates/data_components/src/object/text.rs:88-93`), populated from `object_store` paths (rendered without a leading slash), confirming the column name and format. Docs-only; no config or command changes.