### PR TITLE
Fix generative-visualisations recipe: use non-deprecated response_format param

### DIFF
--- a/generative-visualisations/spicepod.yaml
+++ b/generative-visualisations/spicepod.yaml
@@ -23,7 +23,7 @@ models:
       tools: sql, list_datasets, table_schema
       system_prompt: |
         Your job is to make a chart.js scripts and the SQL query needed for the given question a user asks. Use the `list_datasets` and `table_schema` tools to ensure the SQL query is correct. Before you return the SQL query, make sure it works by running `EXPLAIN <query>`.
-      openai_response_format:
+      response_format:
         type: json_schema
         json_schema:
           name: visualisation_and_sql


### PR DESCRIPTION
## What the recipe does

`generative-visualisations/spicepod.yaml` configures the `visualisation_and_sql` model with a structured-output constraint via the model param key `openai_response_format`.

## What the code does (Spice v2.1.0, current stable)

The `openai_<param>` language-model override keys are **deprecated**. In [`crates/runtime/src/model/params/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.1.0/crates/runtime/src/model/params/mod.rs):

- `ParameterSpec::runtime("openai_response_format").deprecated(DEPRECATED_MESSAGE)` — the deprecation message reads: *"The `openai_<param>` language model overrides parameter is deprecated and will be removed in a future release. Please use `<model_prefix>_<param>` parameter name instead."*
- The current, non-deprecated key is the bare `ParameterSpec::runtime("response_format")` in `COMMON_MODEL_PARAMETERS` (runtime params are used without a prefix).

At runtime the old key still resolves via a backwards-compat alias, but it emits a deprecation warning (`crates/runtime-parameters/src/lib.rs`: *"Parameter '…' is deprecated for …"*) and is slated for removal. `response_format` is also the key published in `.schema/spicepod.schema.json` at v2.1.0.

## What changed

```diff
-      openai_response_format:
+      response_format:
```

Value structure is unchanged; only the (deprecated) key name is updated to the current one. This keeps the recipe working after the deprecated alias is removed and stops it from teaching a deprecated param.

Verified against `spiceai/spiceai` at tag `v2.1.0`.