### PR TITLE
Fix openai-responses-api recipe: correct stray 'PRs' query description

### DIFF
--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -184,7 +184,7 @@ Verify this output by, in a separate terminal, starting an interactive SQL query
 spice sql
 ```
 
-Then, query using SQL the `taxi_trips` dataset for the titles of the five most recently created PRs.
+Then, query the `taxi_trips` dataset using SQL for the five highest-fare trips.
 
 ```sql
 SELECT fare_amount, tpep_pickup_datetime, tpep_dropoff_datetime, passenger_count, VendorID FROM taxi_trips ORDER BY fare_amount DESC LIMIT 5;


### PR DESCRIPTION
## What the recipe said

In the SQL-verification step, the README instructs the reader:

> Then, query using SQL the `taxi_trips` dataset for the titles of the five most recently created PRs.

## What the recipe actually does

The query on the next line — and the entire recipe — operates on the NYC `taxi_trips` dataset:

```sql
SELECT fare_amount, tpep_pickup_datetime, tpep_dropoff_datetime, passenger_count, VendorID FROM taxi_trips ORDER BY fare_amount DESC LIMIT 5;
```

There are no PRs anywhere in this recipe — the sentence is leftover copy-paste text from an unrelated recipe and actively misleads a reader about what they're about to run.

## What changed

One line of prose in `openai-responses-api/README.md` now describes the query accurately (the five highest-fare trips). No config, command, or SQL changes.

---
Found during a cookbook accuracy audit against Spice **v2.1.0**. The rest of this recipe's config (`responses_api`, `openai_responses_tools`, hosted `web_search`/`code_interpreter` tools) verified correct against v2.1.0 source.