### PR TITLE
Fix views recipe: correct version floor to `v1.4.0+`

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -1,6 +1,6 @@
 # Accelerated Views
 
-Works with `v1.0+`
+Works with `v1.4.0+`
 
 This recipe demonstrates how to use accelerated [Views](https://spiceai.org/docs/reference/spicepod/views) to pre-calculate and materialize data derived from one or more underlying datasets. By defining views that aggregate, join, or transform source data in advance, you can significantly improve the performance of analytical queries. In this recipe, we will create a locally accelerated view for the [TPC-H Q21 - Suppliers Who Kept Orders Waiting](https://github.com/spiceai/cookbook/tree/trunk/tpc-h) report.
 


### PR DESCRIPTION
## What the recipe said
`views/README.md` declares:
```
Works with `v1.0+`
```

## What the code does
The recipe cannot run on v1.0–v1.3:

- **Accelerated views** — the `views[].acceleration` field the whole recipe depends on (Step: "Add a view definition … We enable local acceleration for the view") first appears in **v1.2.0**. It is absent from `crates/spicepod/src/component/view.rs` at v1.0.0 and v1.1.0, and present at v1.2.0.
- **`refresh_cron`** — the later step (`views/README.md` ~line 259/268: "Define a new `acceleration.refresh_cron` for the view with a value of `* * * * *`") uses a key that first appears in **v1.4.0** (`crates/spicepod/src/acceleration/mod.rs`; absent at v1.2.0/v1.3.0). `Acceleration` deserializes with `deny_unknown_fields`, so `refresh_cron` on a pre-v1.4.0 runtime is a hard parse error, not a silently-ignored key.

Verified against `spiceai/spiceai` at tag **v2.1.0** (current stable) and by tag bisection (v1.0.0 → v1.4.0).

## What changed
Version floor `v1.0+` → `v1.4.0+` (the newest feature the recipe uses). No other changes; the recipe is correct on current stable v2.1.0.