### PR TITLE
Fix catalogs/iceberg-hadoop recipe: correct version floor to `v1.6.0+`

### DIFF
--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -1,6 +1,6 @@
 # Iceberg Hadoop Catalog Connector
 
-Works with `v1.0+`
+Works with `v1.6.0+`
 
 The Iceberg Catalog Connector supports connecting to Hadoop catalogs, locally or on S3-compatible object storage.
 


### PR DESCRIPTION
## What the recipe said
`catalogs/iceberg-hadoop/README.md` declares:
```
Works with `v1.0+`
```

## What the code does
The Iceberg **Hadoop** catalog connector — which this recipe uses via `from: iceberg:s3a://hadoop/…` — does not exist before **v1.6.0**. The module directory `crates/data_components/src/iceberg/catalog/hadoop/` is absent at v1.0.0 and v1.4.0, and first present at v1.6.0 (verified by `git ls-tree` bisection). The recipe's own sample output even shows `Starting runtime v1.6.0-unstable` (`README.md:41`), so a reader on the claimed `v1.0+` floor would hit an unknown-catalog failure.

Verified against `spiceai/spiceai` at tag **v2.1.0** (current stable, module present) and by tag bisection (v1.0.0 / v1.4.0 absent → v1.6.0 present).

## What changed
Version floor `v1.0+` → `v1.6.0+`. No other changes; the recipe is correct on current stable v2.1.0.