### PR TITLE
Fix stale runtime.metrics row in SHOW TABLES output (off-by-default in v2.x)

### DIFF
--- a/catalogs/ducklake/README.md
+++ b/catalogs/ducklake/README.md
@@ -136,7 +136,6 @@ SHOW TABLES;
 | my_lakehouse  | main         | region     | BASE TABLE |
 | my_lakehouse  | main         | supplier   | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics    | BASE TABLE |
 +---------------+--------------+------------+------------+
 ```
 

--- a/catalogs/iceberg/README.md
+++ b/catalogs/iceberg/README.md
@@ -81,7 +81,6 @@ sql> show tables;
 | ice           | tpch_sf1     | region       | BASE TABLE |
 | ice           | tpch_sf1     | part         | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 +---------------+--------------+--------------+------------+
 ```
 

--- a/catalogs/mssql/README.md
+++ b/catalogs/mssql/README.md
@@ -138,7 +138,6 @@ SHOW TABLES;
 | ms            | dbo          | orders       | BASE TABLE |
 | ms            | dbo          | lineitem     | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 +---------------+--------------+--------------+------------+
 ```
 

--- a/catalogs/mysql/README.md
+++ b/catalogs/mysql/README.md
@@ -126,7 +126,6 @@ SHOW TABLES;
 | my            | tpch         | orders       | BASE TABLE |
 | my            | tpch         | lineitem     | BASE TABLE |
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 +---------------+--------------+--------------+------------+
 ```
 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -105,7 +105,6 @@ sql> show tables;
 +---------------+--------------+---------------+------------+
 | spice         | public       | lineitem      | BASE TABLE |
 | spice         | runtime      | task_history  | BASE TABLE |
-| spice         | runtime      | metrics       | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
 Time: 0.032075708 seconds. 3 rows.

--- a/spark/README.md
+++ b/spark/README.md
@@ -131,7 +131,6 @@ sql> show tables;
 | table_catalog | table_schema | table_name   | table_type |
 +---------------+--------------+--------------+------------+
 | spice         | runtime      | task_history | BASE TABLE |
-| spice         | runtime      | metrics      | BASE TABLE |
 | spice         | public       | nyc_taxis    | BASE TABLE |
 +---------------+--------------+--------------+------------+
 


### PR DESCRIPTION
## What the recipes said

The `SHOW TABLES` expected-output blocks in six recipes list a runtime metrics table that a reader running the recipe as written will **not** see:

```
| spice | runtime | metrics | BASE TABLE |
```

## What the code does

Prometheus metrics are **disabled by default** in Spice `v2.x`. The metrics table is only registered when `--metrics` is passed:

- `bin/spiced/src/lib.rs:312` — `/// Enable Prometheus metrics. (disabled by default)`
- `bin/spiced/src/lib.rs:461` — `let prometheus_registry = args.metrics.map(|_| prometheus::Registry::new());`
- `crates/runtime/src/lib.rs:1220` — `.register_metrics_table(self.prometheus_registry.is_some())`
- `crates/runtime/src/init/metrics.rs:29` — `register_metrics_table` only registers the table `if metrics_enabled`

Since every affected recipe uses a plain `spice run` (no `--metrics`), `runtime.metrics` is never registered, so it does not appear in `SHOW TABLES`. `runtime.task_history` **is** enabled by default (`crates/runtime/src/init/task_history.rs:39`) and is correctly retained.

This also matches the cookbook's own convention: the majority of recipes (e.g. `catalogs/unity_catalog`, `catalogs/spiceai`, `tpc-h`, `retention`, `delta-lake`, `s3`) already show only `runtime.task_history` in their `SHOW TABLES` output.

## What changed

Removed the phantom `spice | runtime | metrics` row from the `SHOW TABLES` output in:

- `catalogs/ducklake`
- `catalogs/iceberg`
- `catalogs/mssql`
- `catalogs/mysql`
- `snowflake`
- `spark`

Verified statically against `spiceai/spiceai` at tag `v2.1.0` (current stable). These six share a single root cause, so they are grouped into one focused, single-purpose PR rather than six near-identical one-line PRs.

> Note: some of these recipes also carry a stale `Spice Runtime Metrics listening on ...:9090` startup-log line from the same root cause. That log-line drift is more pervasive across the cookbook and is left out of this PR to keep the scope tight to the `SHOW TABLES` output correctness.
