### PR TITLE
Fix openai_sdk recipe: correct Python prerequisite to >= 3.12

### DIFF
--- a/openai_sdk/README.md
+++ b/openai_sdk/README.md
@@ -6,7 +6,7 @@ One of Spice's best features is to act in place of the OpenAI API. Even better, 
 
 ## Prerequisites
 
-1. Python >= 3.10
+1. Python >= 3.12
 2. Python package manager (`pip` or `uv`)
 3. Spice [installed](https://docs.spiceai.org/getting-started)
 4. OpenAI API Key


### PR DESCRIPTION
## What the recipe said

The **Prerequisites** section of `openai_sdk/README.md` lists:

> 1. Python >= 3.10

## What the recipe actually requires

The recipe is a `uv`-managed project. Its own `openai_sdk/pyproject.toml` declares:

```toml
requires-python = ">=3.12"
```

and it ships a committed `uv.lock`. The README's client step runs:

```bash
uv run spice_openai_sdk.py
```

`uv run` enforces `requires-python`, so a reader who follows the stated "Python >= 3.10" prerequisite on Python 3.10 or 3.11 hits a version mismatch against the project's own metadata.

## What changed

Align the prerequisite with the project's actual requirement:

```diff
-1. Python >= 3.10
+1. Python >= 3.12
```

Verified against the recipe's `pyproject.toml` and `uv.lock` on `trunk`. Audited as part of a cookbook accuracy review against Spice **v2.1.0** (current stable); no other functional drift found in this recipe.