### PR TITLE
Fix openai-responses-api recipe: correct Python prerequisite to >= 3.12

### DIFF
--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -8,7 +8,7 @@ This recipe shows how Spice integrates with [OpenAI's Responses API](https://pla
 
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation)
 - `OPENAI_API_KEY` is set in `.env`. To acquire an OpenAI API Key, see [OpenAI's Guide](https://platform.openai.com/account/api-keys).
-- Python >= 3.10
+- Python >= 3.12
 - Python package manager (`pip` or `uv`)
 
 ## How to run


### PR DESCRIPTION
## What the recipe said

The **Prerequisites** section of `openai-responses-api/README.md` lists:

> - Python >= 3.10

## What the recipe actually requires

The recipe is a `uv`-managed project. Its own `openai-responses-api/pyproject.toml` declares:

```toml
requires-python = ">=3.12"
```

The README's `uv` client path runs:

```bash
uv venv
uv pip install openai
```

`uv venv` selects an interpreter that satisfies the project's `requires-python`, so a reader who follows the stated "Python >= 3.10" prerequisite on Python 3.10 or 3.11 hits a version mismatch against the project's own metadata (no compatible interpreter for `>=3.12`).

## What changed

Align the prerequisite with the project's actual requirement:

```diff
-- Python >= 3.10
+- Python >= 3.12
```

This is the direct sibling of #543, which fixes the identical drift in the `openai_sdk` recipe. Note #537 also touches this recipe's README (a separate prose fix on a non-overlapping line).