### PR TITLE
Fix snowflake/dml recipe: correct Spice Workers docs link

### DIFF
--- a/snowflake/dml/README.md
+++ b/snowflake/dml/README.md
@@ -173,5 +173,5 @@ Time: 0.678913675 seconds. 10 rows.
 
 - [Snowflake Data Connector](https://spiceai.org/docs/components/data-connectors/snowflake)
 - [HTTP(s) Data Connector](https://docs.spiceai.org/components/data-connectors/https)
-- [Spice Workers](https://docs.spiceai.org/components/workers)
+- [Spice Workers](https://docs.spiceai.org/features/workers)
 - [TVMaze API](https://www.tvmaze.com/api)


### PR DESCRIPTION
## What the recipe said

`snowflake/dml/README.md` linked Spice Workers at:

```
https://docs.spiceai.org/components/workers
```

## What the docs do

That path 404s. The Workers documentation lives under `/features/` in the current docs — `/components/workers` only exists in the archived v1.10 / v1.11 versioned docs (confirmed in https://spiceai.org/sitemap.xml, which lists `/docs/v1.10/components/workers` and `/docs/v1.11/components/workers` but `/docs/features/workers` for current).

```console
$ curl -s -o /dev/null -w '%{http_code}' -L https://docs.spiceai.org/components/workers
404
$ curl -s -o /dev/null -w '%{http_code}' -L https://docs.spiceai.org/features/workers
200
```

## What changed

Repointed the link to `https://docs.spiceai.org/features/workers`.

Verified against current stable Spice `v2.1.1`. This was the only `components/workers` reference in the cookbook — a full sweep of all 119 Spice doc URLs across every README found no other broken paths beyond the one fixed separately in `postgres/accelerator`.