### PR TITLE
Fix postgres/accelerator recipe: correct broken Enterprise feature link

### DIFF
--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -1,6 +1,6 @@
 # PostgreSQL Data Accelerator
 
-Works with `v1.0+`. As of Spice `v2.0`, the PostgreSQL Data Accelerator is an [Enterprise feature](https://spiceai.org/docs/enterprise) and requires an enterprise build of `spiced`. Community builds will log `The accelerator engine postgres is not available` and refuse to load the dataset.
+Works with `v1.0+`. As of Spice `v2.0`, the PostgreSQL Data Accelerator is an [Enterprise feature](https://spiceai.org/docs/components/data-accelerators/postgres) and requires an enterprise build of `spiced`. Community builds will log `The accelerator engine postgres is not available` and refuse to load the dataset.
 
 Follow these steps to get started with PostgreSQL as a Data Accelerator.
 


### PR DESCRIPTION
## What the recipe said

`postgres/accelerator/README.md` line 3 linked the Enterprise requirement at:

```
https://spiceai.org/docs/enterprise
```

## What the docs do

That path 404s, and no `enterprise` landing page exists under `/docs` (checked `/docs/enterprise`, `/docs/features/enterprise`, `/docs/enterprise/introduction`, `/docs/getting-started/enterprise` — all 404).

The canonical page for this claim is the PostgreSQL Data Accelerator component page, which opens with the Enterprise callout:

> **Spice.ai Enterprise** — The PostgreSQL Data Accelerator is available only in Spice.ai Enterprise.

```console
$ curl -s -o /dev/null -w '%{http_code}' -L https://spiceai.org/docs/enterprise
404
$ curl -s -o /dev/null -w '%{http_code}' -L https://spiceai.org/docs/components/data-accelerators/postgres
200
```

## What changed

Repointed the link to `https://spiceai.org/docs/components/data-accelerators/postgres`.

The surrounding claim is unchanged and stays accurate against current stable `v2.1.1`: `engine: postgres` parses fine, then dataset init calls `get_accelerator_engine`, which returns `None` on a community build and surfaces `The accelerator engine postgres is not available` ([crates/runtime/src/init/dataset.rs#L1316-L1320](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/init/dataset.rs#L1316-L1320), message at [crates/runtime/src/lib.rs#L324-L328](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/lib.rs#L324-L328)).