### PR TITLE
Fix redshift recipe: correct the community-build accelerator error message

### DIFF
--- a/redshift/README.md
+++ b/redshift/README.md
@@ -44,7 +44,7 @@ PG_PASS=hGG3ellothere$$$$
 
 ## Step 3: Writing Data into Redshift
 
-> **Note:** The `write` spicepod accelerates data into Redshift using the PostgreSQL data accelerator (`engine: postgresql`). This accelerator is _not_ included in the released Spice binaries — tagged releases are built without the `postgres-accel` feature, so a stock-installed runtime rejects it with `Unknown engine: postgres`. Build and run Spice with the feature enabled, e.g. `cargo run --release --features release,models,postgres-accel -p spiced`. (The `read` spicepod in Step 4 uses the default in-memory `arrow` accelerator and runs on the standard binary.)
+> **Note:** The `write` spicepod accelerates data into Redshift using the PostgreSQL data accelerator (`engine: postgresql`). This accelerator is _not_ included in the released Spice binaries — tagged releases are built without the `postgres-accel` feature, so a stock-installed runtime rejects the dataset with `The accelerator engine postgres is not available. Valid engines are arrow, cayenne, duckdb, and sqlite.` Build and run Spice with the feature enabled, e.g. `cargo run --release --features release,models,postgres-accel -p spiced`. (The `read` spicepod in Step 4 uses the default in-memory `arrow` accelerator and runs on the standard binary.)
 
 To write data into Redshift, navigate to the `write` directory and start Spice using the following command:
 


### PR DESCRIPTION
## What the recipe said

`redshift/README.md` Step 3 tells readers what a stock-installed runtime does with the `write` spicepod's `engine: postgresql`:

> a stock-installed runtime rejects it with `Unknown engine: postgres`

## What the code does

`Unknown engine: {engine}` exists, but it is not the message a reader hits here. It lives in `DataAccelerator::create_accelerated_table` ([crates/runtime/src/dataaccelerator/mod.rs#L266-L271](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/dataaccelerator/mod.rs#L266-L271)) — reached only *after* dataset init, which performs its own availability check first and fails there:

```rust
// crates/runtime/src/init/dataset.rs#L1312-L1320
self.accelerator_engine_registry
    .get_accelerator_engine(acceleration_settings.engine)
    .await
    .context(AcceleratorEngineNotAvailableSnafu {
        name: accelerator_engine.to_string(),
    })?;
```

`engine: postgresql` parses successfully — `Engine::try_from` accepts both `postgres` and `postgresql` ([crates/runtime-acceleration/src/engine.rs#L57-L73](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime-acceleration/src/engine.rs#L57-L73)) — so the engine is never "unknown". It is simply not registered when the binary is built without `postgres-accel`, and `AcceleratorEngineNotAvailable` is `cfg`-gated to render the community variant ([crates/runtime/src/lib.rs#L318-L328](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/lib.rs#L318-L328)):

```rust
#[cfg(not(feature = "postgres-accel"))]
#[snafu(display(
    "The accelerator engine {name} is not available. Valid engines are arrow, cayenne, duckdb, and sqlite."
))]
AcceleratorEngineNotAvailable { name: String },
```

`Engine::PostgreSQL` renders as `postgres` via `Display`, so the reader sees:

```
The accelerator engine postgres is not available. Valid engines are arrow, cayenne, duckdb, and sqlite.
```

This also matches what `postgres/accelerator/README.md` already says, so the two recipes now agree.

## What changed

Quoted the actual error message. The rest of the note is unchanged and verified against `v2.1.1`: `postgres-accel` is still a real, non-default `spiced` feature ([bin/spiced/Cargo.toml#L152](https://github.com/spiceai/spiceai/blob/v2.1.1/bin/spiced/Cargo.toml#L152)), and `release` and `models` in the suggested `cargo run` line both exist.

Static verification only — confirming at runtime would require provisioning a Redshift cluster.