### PR TITLE
Fix file recipe: replace Markdown downloads that now 404

### DIFF
--- a/file/README.md
+++ b/file/README.md
@@ -97,9 +97,9 @@ base_url="https://raw.githubusercontent.com/spiceai/docs/refs/heads/trunk/websit
 
 files=(
   "clickhouse.md"
-  "databricks.md"
   "debezium.md"
-  "delta-lake.md"
+  "ducklake.md"
+  "iceberg.md"
 )
 
 for file in "${files[@]}"; do
@@ -153,9 +153,9 @@ Expected output:
 | location                   |
 +----------------------------+
 | path/to/file/clickhouse.md |
-| path/to/file/databricks.md |
 | path/to/file/debezium.md   |
-| path/to/file/delta-lake.md |
+| path/to/file/ducklake.md   |
+| path/to/file/iceberg.md    |
 +----------------------------+
 ```
 


### PR DESCRIPTION
## What the recipe said

`file/README.md` Step 1 of the *Query Markdown Documents* walkthrough downloads four docs pages:

```shell
files=(
  "clickhouse.md"
  "databricks.md"
  "debezium.md"
  "delta-lake.md"
)
for file in "${files[@]}"; do
  curl -O "$base_url/$file"
done
```

## What actually happens

`databricks` and `delta-lake` are now **directories** in `spiceai/docs` (`website/docs/components/data-connectors/`), not flat `.md` files, so those two URLs 404. Because the script uses `curl -O` without `-f`, the 404 body is written to disk instead of failing — the reader silently ends up with two junk files:

```console
$ for f in clickhouse.md databricks.md debezium.md delta-lake.md; do curl -sO "$base_url/$f"; done
$ ls -l *.md | awk '{print $5, $9}'
8088 clickhouse.md
14 databricks.md
17917 debezium.md
14 delta-lake.md

$ cat databricks.md
404: Not Found
```

The dataset still loads with 4 rows, so Step 4's output looks right — but two of the four "documents" contain the string `404: Not Found`, which quietly defeats the point of the recipe.

## What changed

Swapped the two dead entries for `ducklake.md` and `iceberg.md` — both still flat `.md` files in the same directory, and both keep the lakehouse-connector flavour of the originals. Updated the Step 4 expected output to match.

Verified all four download real content:

```console
clickhouse.md      8088 bytes  --- title: 'ClickHouse Data Connector' …
debezium.md       17917 bytes  --- title: 'Debezium Data Connector' …
ducklake.md        8161 bytes  --- title: 'DuckLake Data Connector' …
iceberg.md        19050 bytes  --- title: 'Iceberg Data Connector' …
```

Checked against current stable Spice `v2.1.1`. The download step is confirmed by running it; the `spice run` / `spice sql` steps were not re-run (no CLI in the audit environment), but nothing about them changes — only the four filenames do.

Note for reviewers: adding `-f` (or `--fail`) to the `curl` would make a future breakage loud instead of silent. Left out here to keep the diff to the actual drift, happy to add it if wanted.