### PR TITLE
Fix mcp-server recipe: correct GitHub MCP server link and note upstream deprecation

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -2,7 +2,9 @@
 
 Works with `v2.0+`
 
-Run Spice as an MCP server and connect your AI assistant (Claude Desktop, Cursor, VS Code, or any MCP client) to it. This recipe loads GitHub issues, pull requests, and commits as accelerated, in-memory datasets and exposes the [GitHub MCP server](https://github.com/modelcontextprotocol/servers/tree/main/src/github) through a single unified endpoint at `/v1/mcp`.
+Run Spice as an MCP server and connect your AI assistant (Claude Desktop, Cursor, VS Code, or any MCP client) to it. This recipe loads GitHub issues, pull requests, and commits as accelerated, in-memory datasets and exposes the [GitHub MCP server](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github) through a single unified endpoint at `/v1/mcp`.
+
+> **Note:** This recipe proxies the reference `@modelcontextprotocol/server-github` package, which has been moved to [`modelcontextprotocol/servers-archived`](https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github) and is marked deprecated on npm. It still installs and runs via `npx`, so the recipe works as written. For new work, GitHub now maintains [`github/github-mcp-server`](https://github.com/github/github-mcp-server) as the supported replacement.
 
 Your AI assistant gets one connection point that gives it:
 


### PR DESCRIPTION
## What the recipe said

`mcp-server/README.md` links the GitHub MCP server it proxies at:

```
https://github.com/modelcontextprotocol/servers/tree/main/src/github
```

## What upstream did

The reference GitHub server was moved out of `modelcontextprotocol/servers` into `modelcontextprotocol/servers-archived`, so that tree URL now 404s:

```console
$ curl -s -o /dev/null -w '%{http_code}' -L https://github.com/modelcontextprotocol/servers/tree/main/src/github
404
$ curl -s -o /dev/null -w '%{http_code}' -L https://github.com/modelcontextprotocol/servers-archived/tree/main/src/github
200
```

The npm package the recipe actually runs — `spicepod.yaml` sets `mcp_args: -y @modelcontextprotocol/server-github` — is correspondingly marked deprecated:

```console
$ curl -s https://registry.npmjs.org/@modelcontextprotocol%2Fserver-github | jq -r '."dist-tags".latest, .versions[."dist-tags".latest].deprecated'
2025.4.8
Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
```

## What changed

- Repointed the link to the archived location, which is where the code the recipe runs actually lives.
- Added a short note that the package is deprecated-but-functional, and that `github/github-mcp-server` is GitHub's supported replacement.

**Deliberately left the `spicepod.yaml` alone.** `npx -y @modelcontextprotocol/server-github` still resolves and runs — deprecated is not removed — so the recipe is not broken today, and migrating is not a like-for-like swap: `github/github-mcp-server` ships as a Go binary / Docker image rather than an npx package, so `from: mcp:npx` with `mcp_args` would need rethinking along with the `github/*` tool names in Steps 4–6. That is a maintainer call about the recipe's direction, not a mechanical accuracy fix — flagging it here rather than making it.

Verified against current stable Spice `v2.1.1`. Link checks are live; the recipe itself was not executed (needs a GitHub PAT).