### PR TITLE
Fix broken external links in clients, vectors/s3, and dotnet SDK recipes

### DIFF
--- a/client-sdk/spice-dotnet-sdk-sample/README.md
+++ b/client-sdk/spice-dotnet-sdk-sample/README.md
@@ -85,6 +85,6 @@ The cloud snippet keeps an inline API key placeholder by design. Replace the API
 ## Links
 
 - [Spice .NET SDK](https://github.com/spiceai/spice-dotnet)
-- [NuGet package](https://www.nuget.org/packages/SpiceAI.Client)
+- [NuGet package](https://www.nuget.org/packages/SpiceAI)
 - [Spice.ai Cloud](https://spice.ai)
 - [Spice.ai documentation](https://docs.spiceai.org)

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -61,4 +61,4 @@ addon10
 ## Learn more
 
 - [Spice OSS Documentation](https://docs.spiceai.org/)
-- [Apache Arrow Flight SQL JDBC](https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/sql/FlightSqlClient.html)
+- [Apache Arrow Flight SQL JDBC](https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html)

--- a/clients/scala/README.md
+++ b/clients/scala/README.md
@@ -62,4 +62,4 @@ Expected output:
 ## Learn more
 
 - [Spice OSS Documentation](https://docs.spiceai.org/)
-- [Apache Arrow Flight SQL JDBC](https://arrow.apache.org/docs/java/reference/org/apache/arrow/flight/sql/FlightSqlClient.html)
+- [Apache Arrow Flight SQL JDBC](https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html)

--- a/vectors/s3/README.md
+++ b/vectors/s3/README.md
@@ -415,4 +415,4 @@ curl --request POST \
 
 - [S3 Vectors documentation](https://spiceai.org/docs/components/vectors/s3_vectors)
 - [Spice.ai S3 Vectors blog post](https://spiceai.org/blog/amazon-s3-vectors-with-spice)
-- [Amazon S3 Vectors](https://aws.amazon.com/s3/vectors/)
+- [Amazon S3 Vectors](https://aws.amazon.com/s3/features/vectors/)


### PR DESCRIPTION
Found by HTTP-checking every URL in every cookbook README (460 unique URLs; 297 non-Spice). Four returned a genuine 404. Grouped into one PR because they are one issue class — an external target that moved — and each fix is a single line.

| Recipe | Link | Status |
|---|---|---|
| `clients/java`, `clients/scala` | `arrow.apache.org/docs/java/reference/.../FlightSqlClient.html` | 404 |
| `vectors/s3` | `aws.amazon.com/s3/vectors/` | 404 |
| `client-sdk/spice-dotnet-sdk-sample` | `nuget.org/packages/SpiceAI.Client` | 404 |

### Apache Arrow — `clients/java`, `clients/scala`

Arrow retired the `/docs/java/` tree; Java docs now live at `/java/`. The old link also pointed at the `FlightSqlClient` javadoc while the link text reads "Apache Arrow Flight SQL JDBC" — and both recipes actually depend on the JDBC driver, not the Java client:

- `clients/java/pom.xml` → `org.apache.arrow:flight-sql-jdbc-driver`
- `clients/scala/build.sbt` → `"org.apache.arrow" % "flight-sql-jdbc-driver" % "19.0.0"`

Repointed both to `https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html`, which matches the link text and the dependency.

### Amazon S3 Vectors — `vectors/s3`

AWS moved the page under `/s3/features/`. Repointed to `https://aws.amazon.com/s3/features/vectors/`. (The other S3 Vectors links in this recipe point at `spiceai.org/docs/components/vectors/s3_vectors` and already resolve.)

### NuGet package — `client-sdk/spice-dotnet-sdk-sample`

The README links `SpiceAI.Client`, which does not exist on NuGet. The sample's own project file already references the real package:

```xml
<!-- spice-dotnet-sdk-sample.csproj:12 -->
<PackageReference Include="SpiceAI" Version="0.3.0" />
```

```console
$ curl -s 'https://azuresearch-usnc.nuget.org/query?q=spiceai' | jq -r '.data[].id'
SpiceAI
```

Repointed to `https://www.nuget.org/packages/SpiceAI`.

### Verification

```console
$ for u in https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html \
           https://aws.amazon.com/s3/features/vectors/ \
           https://www.nuget.org/packages/SpiceAI; do
    echo "$(curl -s -o /dev/null -w '%{http_code}' -L "$u") $u"
  done
200 https://arrow.apache.org/java/current/flight_sql_jdbc_driver.html
200 https://aws.amazon.com/s3/features/vectors/
200 https://www.nuget.org/packages/SpiceAI
```

Remaining non-200s in the sweep were all checked and are not defects: bot-blocked hosts returning 403 (`dev.mysql.com`, `platform.openai.com`, `x.ai`, `npmjs.com`, `timeanddate.com`), and intentional placeholders or non-browsable endpoints (`api.company.com`, `your-org.atlassian.net`, `github.com/user/repo/...`, `api.tvmaze.com/premium`, `helm.ngc.nvidia.com/nvidia`, the `huggingface.co/.../resolve/main` `BASE_URL` variable, and URLs embedded in sample JSON output).