### PR TITLE
Fix SHOW TABLES row counts left stale by the runtime.metrics removal

### DIFF
--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -186,7 +186,7 @@ show tables;
 | spice         | public       | sample_data  | BASE TABLE |
 +---------------+--------------+--------------+------------+
 
-Time: 0.004413208 seconds. 3 rows.
+Time: 0.004413208 seconds. 2 rows.
 ```
 
 You can now now query `sample_data` in the runtime.

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -107,7 +107,7 @@ sql> show tables;
 | spice         | runtime      | task_history  | BASE TABLE |
 +---------------+--------------+---------------+------------+
 
-Time: 0.032075708 seconds. 3 rows.
+Time: 0.032075708 seconds. 2 rows.
 ```
 
 Run _Pricing Summary Report Query (Q1)_. More information about TPC-H and all the queries involved can be found in the official [TPC Benchmark H Standard Specification](https://www.tpc.org/tpc_documents_current_versions/pdf/tpc-h_v2.17.1.pdf).

--- a/spark/README.md
+++ b/spark/README.md
@@ -134,7 +134,7 @@ sql> show tables;
 | spice         | public       | nyc_taxis    | BASE TABLE |
 +---------------+--------------+--------------+------------+
 
-Time: 0.031211 seconds. 3 rows.
+Time: 0.031211 seconds. 2 rows.
 ```
 
 7. Check the table structure of `nyc_taxis`.


### PR DESCRIPTION
## What the recipes say

Three recipes show `SHOW TABLES` output that lists **two** tables but reports **3 rows**:

- [`snowflake/README.md`](https://github.com/spiceai/cookbook/blob/trunk/snowflake/README.md) — lists `lineitem`, `task_history` → `Time: 0.032075708 seconds. 3 rows.`
- [`spark/README.md`](https://github.com/spiceai/cookbook/blob/trunk/spark/README.md) — lists `task_history`, `nyc_taxis` → `Time: 0.031211 seconds. 3 rows.`
- [`postgres/connector/README.md`](https://github.com/spiceai/cookbook/blob/trunk/postgres/connector/README.md) — lists `task_history`, `sample_data` → `Time: 0.004413208 seconds. 3 rows.`

## What happened

The counts were correct when the output also listed a `spice | runtime | metrics` row. That row is not emitted on v2.0+ and was removed from the expected output, but the trailing row count was never decremented:

- snowflake, spark — removed in c51b6bb (#541)
- postgres/connector — removed in 42c9a24 ("Remove metrics table entry")

So each block has been internally inconsistent since: the table shows 2 rows, the summary line claims 3.

## What changed

`3 rows.` → `2 rows.` in the three blocks, matching the tables actually listed. No other content touched.

Verified against `spiceai/spiceai` at [`v2.1.1`](https://github.com/spiceai/spiceai/tree/v2.1.1) (current stable). Found by a repo-wide sweep comparing every `N rows.` claim in the cookbook against the rows actually shown in the preceding table.