### PR TITLE
Fix docker recipe: use the maintained spiceai/spiceai:latest image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM spiceai/spiceai:latest-models
+FROM spiceai/spiceai:latest
 
 # Copy the Spicepod configuration file
 COPY spicepod.yaml /app/spicepod.yaml

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # Running in Docker
 
-Works with `v1.0+`
+Works with `v2.0+`
 
 This recipe demonstrates how to run Spice.ai OSS in a container using the official [spiceai/spiceai](https://hub.docker.com/r/spiceai/spiceai) Docker image. It shows how to:
 
@@ -25,7 +25,7 @@ cat Dockerfile
 Output:
 
 ```shell
-FROM spiceai/spiceai:latest-models
+FROM spiceai/spiceai:latest
 
 # Copy the Spicepod configuration file
 COPY spicepod.yaml /app/spicepod.yaml
@@ -43,6 +43,8 @@ EXPOSE 50051
 # Start the Spicepod
 
 ```
+
+> **Note:** Model and embedding support is built into the default `spiceai/spiceai` image from Spice `v2.0.0` onwards, which this recipe needs for the local `hf_minilm` embedding. Spice `v1.x` published this support as a separate `-models` image variant instead (for example `spiceai/spiceai:1.11.6-models`); that variant is no longer published for `v2.x`, so use the plain `latest` tag.
 
 Use Docker Compose to build and run the Docker image:
 


### PR DESCRIPTION
## What the recipe said

`docker/Dockerfile` (and the mirrored `cat Dockerfile` output in the README) built from:

```dockerfile
FROM spiceai/spiceai:latest-models
```

The recipe is titled "Running in Docker" and declares `Works with v1.0+`, so a reader reasonably expects `latest-models` to give them current Spice.

## What the code does

**The `-models` image variant is no longer published.** The release matrix dropped it in v2.x:

- v1.11.6 — [`.github/workflows/build_and_release.yml`](https://github.com/spiceai/spiceai/blob/v1.11.6/.github/workflows/build_and_release.yml#L99): `tags: ["default", "models", "odbc"]`
- v2.1.1 — [`.github/workflows/build_and_release.yml`](https://github.com/spiceai/spiceai/blob/v2.1.1/.github/workflows/build_and_release.yml#L108): `tags: ["default", "odbc"]` — no `models` entry

Instead, the **default** v2.x build now compiles model support in ([v2.1.1 line 244](https://github.com/spiceai/spiceai/blob/v2.1.1/.github/workflows/build_and_release.yml#L244)):

```
cargo build --profile ${{ env.RUST_PROFILE }} --features release,models -p spiced -p spice
```

**So `latest-models` is frozen on v1.11.6.** From the Docker Hub tag API:

| tag | last pushed | digest |
| --- | --- | --- |
| `latest` | 2026-07-21 | `sha256:87076addee02a4d8bfdee99…` |
| `2.1.1` | 2026-07-21 | `sha256:87076addee02a4d8bfdee99…` |
| `latest-models` | 2026-05-07 | `sha256:fa2dc9322359a6825a186d6…` |
| `1.11.6-models` | 2026-05-07 | `sha256:fa2dc9322359a6825a186d6…` |

`latest-models` and `1.11.6-models` are byte-identical, and were last pushed a month before v2.0.0 shipped (2026-06-05). No `2.0.0-models`, `2.0.1-models`, `2.1.0-models`, or `2.1.1-models` tag exists.

The net effect: anyone running this recipe silently gets a **v1.11.6** runtime while believing they are on "latest", and that will never change as the tag is no longer updated.

## What changed

- `docker/Dockerfile`: `FROM spiceai/spiceai:latest-models` → `FROM spiceai/spiceai:latest`
- `docker/README.md`: mirrored the same change in the `cat Dockerfile` output block so the recipe stays self-consistent
- Added a note explaining that model/embedding support — which this recipe needs for its local `hf_minilm` embedding (`spicepod.yaml`) — is in the default image from v2.0, and that `v1.x` used the separate `-models` variant
- Corrected the version floor `v1.0+` → `v2.0+`, since the plain `latest` tag only carries model support from v2.0

## Notes for reviewers

- **Not run end-to-end.** Docker was unavailable in the environment where this was audited, so this is verified from the release workflow and the Docker Hub tag digests rather than a live build.
- The README's sample **log output and `spice status` table are still v1.x-era** (`Initialized results cache;`, an `opentelemetry 127.0.0.1:50052` row). Those were consistent with the v1.11.6 image the recipe was pinned to, and become stale with this change. I deliberately left them alone rather than hand-writing v2.x output I could not actually observe — happy to follow up with real output if someone can run it, or if you would prefer I take the best-effort edit here.
- The version floor bump is the conservative reading. If you would rather keep `v1.0+` and document both tags, say so and I will adjust.

Verified against `spiceai/spiceai` at tag `v2.1.1` (current stable) and `v1.11.6`.
