### PR TITLE
Fix cookbook index: repair two dangling recipe links

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ Welcome to the Spice.ai OSS Cookbook—a comprehensive collection of recipes for
 - [Apache Spark Data Connector](./spark/README.md) - Read data from an Apache Spark instance.
 - [Apache Kafka Data Connector](./kafka/README.md) - Stream data from Kafka with federated queries.
 - [IMAP Data Connector](./imap/README.md) - Connect to an IMAP email server.
-  - [Connecting to an Outlook mailbox](./imap/outlook.md)
 
 ### Connecting to Data Sources with Catalog Connectors
 
@@ -113,7 +112,7 @@ Welcome to the Spice.ai OSS Cookbook—a comprehensive collection of recipes for
 
 ### Using Vector Engines
 
-- [Amazon S3 Vectors](./vectors/s3-vectors/README.md) - Use S3 as a vector engine for embeddings and similarity search.
+- [Amazon S3 Vectors](./vectors/s3/README.md) - Use S3 as a vector engine for embeddings and similarity search.
 
 ## Search
 


### PR DESCRIPTION
Found by sweeping every relative Markdown link in the repo against the filesystem. Two entries in the root README index point at paths that do not exist, so both 404 on GitHub.

## `./imap/outlook.md`

```md
- [IMAP Data Connector](./imap/README.md) - Connect to an IMAP email server.
  - [Connecting to an Outlook mailbox](./imap/outlook.md)
```

The sub-page was added in #76 and then **deleted** in #139 (`docs: IMAP outlook`), which removed both `imap/outlook.md` and `imap/spicepod.outlook.yaml`:

```
$ git show --stat d9852c0
 imap/outlook.md            | 115 ---------------------------------------------
 imap/spicepod.outlook.yaml |   8 ----
```

`imap/` now contains only `README.md` and `spicepod.yaml`, and the README has no Outlook content to redirect the link to — so the dangling sub-bullet is removed.

## `./vectors/s3-vectors/README.md`

```md
- [Amazon S3 Vectors](./vectors/s3-vectors/README.md) - Use S3 as a vector engine for embeddings and similarity search.
```

`vectors/s3-vectors/` has never existed in the repo's history — the recipe is at `vectors/s3/`. The wrong path was introduced by the same commit that added the index entry, so this link has never resolved. Corrected to `./vectors/s3/README.md`.

## What changed

- Removed the dangling `imap/outlook.md` sub-bullet
- Repointed the Amazon S3 Vectors entry to `./vectors/s3/README.md`

After this change, every relative link in the root README resolves (verified by re-running the sweep: 0 remaining).

## Separate finding, not fixed here

The same sweep shows **16 recipe directories that have a README but are not linked from the root index**, so they are effectively undiscoverable:

```
acceleration/cron          catalogs/postgres     mongodb/change-streams   search/elasticsearch
catalogs/ducklake          elasticsearch/connector   mtls                 serializable-transactions
catalogs/mssql             mcp-server            mysql/cdc                snowflake/dml
catalogs/mysql             client-sdk/spice-dotnet-sdk-sample   postgres/cdc   vectors/s3 (fixed above)
```

I have not added these, because it is an editorial call I would rather leave to you — in particular `mysql/cdc` and `serializable-transactions` document features targeting the unreleased `v2.2.0+`, so they may be intentionally unlisted. Happy to open a follow-up adding the rest if you want them indexed.
