### PR TITLE
Fix chunking file_format placement: Markdown-aware chunking was never enabled

### DIFF
--- a/azure_openai/spicepod.yaml
+++ b/azure_openai/spicepod.yaml
@@ -72,6 +72,7 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       include: "docs/**/*.md"
+      file_format: md
     acceleration:
       enabled: true
     columns:
@@ -83,4 +84,3 @@ datasets:
               enabled: true
               target_chunk_size: 256
               overlap_size: 64
-              file_format: md

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -25,6 +25,7 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       include: "docs/**/*.md"
+      file_format: md
     acceleration:
       enabled: true
     columns:
@@ -37,7 +38,6 @@ datasets:
               enabled: true
               target_chunk_size: 256
               overlap_size: 64
-              file_format: md
 
 embeddings:
   - from: openai:text-embedding-3-small

--- a/models/openai/spicepod.yaml
+++ b/models/openai/spicepod.yaml
@@ -9,6 +9,7 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       include: 'docs/**/*.md'
+      file_format: md
     acceleration:
       enabled: true
     columns:
@@ -21,7 +22,6 @@ datasets:
               enabled: true
               target_chunk_size: 256
               overlap_size: 64
-              file_format: md
 
 embeddings:
   - from: openai:text-embedding-3-small

--- a/search_github_files/spicepod.yaml
+++ b/search_github_files/spicepod.yaml
@@ -8,6 +8,9 @@ datasets:
     params:
       github_token: ${secrets:GITHUB_TOKEN}
       include: "docs/**/*.md"
+      # Uncomment together with the embeddings block below for
+      # Markdown-aware chunking.
+      # file_format: md
     acceleration:
       enabled: true
     columns:
@@ -19,7 +22,6 @@ datasets:
       #        enabled: true
       #        target_chunk_size: 256
       #        overlap_size: 64
-      #        file_format: md
 
   # - from: github:github.com/spiceai/docs/pulls
   #   name: doc.pulls


### PR DESCRIPTION
## Summary

Three recipes set `file_format: md` **inside** the `chunking:` block of a column embedding:

```yaml
chunking:
  enabled: true
  target_chunk_size: 256
  overlap_size: 64
  file_format: md      # <-- silently ignored here
```

`chunking:` deserializes into `EmbeddingChunkConfig`, which has exactly four fields — `enabled`, `target_chunk_size`, `overlap_size`, `trim_whitespace` — and no `file_format`. The struct does **not** carry `#[serde(deny_unknown_fields)]`, so the key is silently dropped rather than reported: the recipes look like they enable Markdown-aware chunking, but every one of them has been chunking with the plain text splitter.

The runtime reads `file_format` from the **dataset's `params`**, not from the chunking block. This PR moves the key up into `params:`, which is also the placement used by the `file` recipe (`file/README.md`) and by spiceai's own test spicepods (`test/models/spicepod_openai.yml`).

Recipes fixed:

- `models/openai` (`spicepod.yaml` + the README's copy of the same block)
- `azure_openai` (`spicepod.yaml`)
- `search_github_files` (`spicepod.yaml`, commented-out example)

## Verified against

spiceai/spiceai at `v2.1.1`:

- [`crates/spicepod/src/component/embeddings.rs`](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/spicepod/src/component/embeddings.rs) — `EmbeddingChunkConfig` has only `enabled` / `target_chunk_size` / `overlap_size` / `trim_whitespace`; no `deny_unknown_fields`.
- [`crates/runtime-search/src/embeddings/table.rs`](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime-search/src/embeddings/table.rs) — `from_spicepod_columns` builds `ChunkingConfig` from the per-column chunk config for the three size fields, and takes `file_format` from a separate argument.
- [`crates/runtime/src/embeddings/connector.rs`](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/embeddings/connector.rs) — that argument is `dataset.params.get("file_format")`.
- [`crates/runtime/src/component/dataset/builder.rs`](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/runtime/src/component/dataset/builder.rs) — `Dataset.params` is the raw spicepod params map, so the chunker sees the key regardless of connector parameter specs.
- [`crates/chunking/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.1.1/crates/chunking/src/lib.rs) — `match cfg.file_format { Some("md" | ".md" | "mdx" | ".mdx") => Splitter::Markdown(...), _ => Splitter::Text(...) }`.

`git log -S file_format` confirms the misplacement predates #508 and #136, which only flipped `chunking.enabled` from `false` to `true` — so this is not reverting a deliberate choice.

## One thing for reviewers to weigh

The `github` connector does not list `file_format` in its `PARAMETERS` spec, so it will log one line at startup:

> `Ignoring parameter file_format: not supported for github.`

This is cosmetic — the chunker reads the raw params map, so Markdown chunking does take effect — but if you would rather not have the warning, the alternative is to drop the `file_format` line entirely and accept plain-text chunking (which is what these recipes have actually been doing all along). Happy to switch to that if preferred.

## Evidence

Static review only — these recipes need a `GITHUB_TOKEN` plus OpenAI/Azure credentials, so they were not run. The config path is traced end-to-end in the source links above, and all three files were re-parsed as valid YAML after the change.