### PR TITLE
Fix hashed_partitioning recipe: correct copy-pasted Spicepod name

### DIFF
--- a/hashed_partitioning/spicepod.yaml
+++ b/hashed_partitioning/spicepod.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: duckdb-acceleration-qs
+name: hashed-partitioning
 datasets:
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips


### PR DESCRIPTION
## Summary

`hashed_partitioning/spicepod.yaml` declares `name: duckdb-acceleration-qs` — a leftover copied from the `duckdb/accelerator` recipe, which builds its app with `spice init duckdb-acceleration-qs`.

- **What the recipe said:** Step 2 presents the configuration as `name: hashed-partitioning`.
- **What actually loads:** Step 1 is `git clone` + `cd cookbook/hashed_partitioning`, and Step 3 is `spice run` — so the reader runs the *shipped* file, which announces itself as `duckdb-acceleration-qs`.
- **What changed:** the shipped pod name now matches the README. One line; no dataset, connector, or acceleration setting was touched.

The two files were otherwise byte-identical, so this was the only divergence between what the README shows and what the recipe runs.

## Verified against

`spiceai/spiceai` at `v2.1.2`. The pod `name` is a free-form label (`crates/spicepod`), so this is a naming/consistency fix rather than a runtime failure — the recipe's queries and partition-pruning plans are unaffected. The colliding name is legitimately owned by [`duckdb/accelerator/README.md:18`](https://github.com/spiceai/cookbook/blob/trunk/duckdb/accelerator/README.md#L18).

## Evidence

Static review only — confirmed by diffing the README's Step 2 YAML block against the committed `spicepod.yaml`; the pod name was the sole difference.