### PR TITLE
Fix json_strings recipe: refresh output captured on Spice v1.x

### DIFF
--- a/json_strings/README.md
+++ b/json_strings/README.md
@@ -66,44 +66,55 @@ spice run
 Result:
 
 ```console
-2024/12/22 16:15:42 INFO Checking for latest Spice runtime release...
-2024/12/22 16:15:42 INFO Spice.ai runtime starting...
-2024-12-23T00:15:42.923112Z  INFO runtime::init::dataset: Initializing dataset products
-2024-12-23T00:15:42.925812Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-12-23T00:15:42.926466Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-12-23T00:15:42.929730Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-12-23T00:15:42.936005Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
-2024-12-23T00:15:42.937855Z  INFO runtime::init::dataset: Dataset products registered (file://tshirts.csv).
-2024-12-23T00:15:43.123000Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
+ INFO Spice.ai runtime starting...
+2026-08-01T12:22:17.791116Z  INFO spiced: Starting runtime v2.1.2+models
+2026-08-01T12:22:17.792634Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-01T12:22:17.792680Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-08-01T12:22:17.792697Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-08-01T12:22:17.793678Z  INFO runtime::datafusion: Cayenne global encode-concurrency budget active (caps aggregate write-encode shards across all tables) encode_budget=6
+2026-08-01T12:22:17.793719Z  INFO runtime::datafusion: Cayenne dynamic-tuning memory budget active (cgroup-aware) memory_budget=8589934592
+2026-08-01T12:22:17.794005Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
+2026-08-01T12:22:17.794127Z  INFO runtime::init::dataset: Loading datasets: 1 tasks dispatched, 0 skipped at accelerator init (of 1 total; localpod datasets may be chained).
+2026-08-01T12:22:17.794149Z  INFO runtime::init::dataset: Dataset products initializing...
+2026-08-01T12:22:17.794478Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-08-01T12:22:17.794970Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-08-01T12:22:17.796959Z  INFO runtime::init::dataset: Dataset products registered (file://tshirts.csv), acceleration (arrow), results cache enabled. duration_ms=0
+2026-08-01T12:22:17.797065Z  INFO runtime::datafusion: Initializing view products_with_color
+2026-08-01T12:22:17.798404Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset products
+2026-08-01T12:22:17.799379Z  INFO runtime::accelerated_table::refresh_task: Loaded 8 rows (3.46 kiB) for dataset products in 0s.
+2026-08-01T12:22:18.721572Z  INFO runtime::datafusion: View products_with_color registered.
+2026-08-01T12:22:18.820636Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 Run `spice sql` in another window and review the `products` dataset structure. You will observe that the `products.properties` field represents JSON data stored as a string (Utf8).
 
 ```console
 sql> describe products;
-+-------------+-----------+-------------+
-| column_name | data_type | is_nullable |
-+-------------+-----------+-------------+
-| id          | Int64     | YES         |
-| name        | Utf8      | YES         |
-| properties  | Utf8      | YES         |
-+-------------+-----------+-------------+
++--------------+-------------+-----------+-------------+
+| table_schema | column_name | data_type | is_nullable |
+|    varchar   |   varchar   |  varchar  |   varchar   |
++--------------+-------------+-----------+-------------+
+| public       | id          | Int64     | YES         |
+| public       | name        | Utf8      | YES         |
+| public       | properties  | Utf8      | YES         |
++--------------+-------------+-----------+-------------+
 ```
 
 ```console
 sql> select * from products;
-+----+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| id | name                    | properties                                                                                                                                                 |
-+----+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| 1  | Ink Fusion T-Shirt      | {"size": ["S", "M", "L", "XL"], "color": "white", "inventory": {"stock": {"S": 12, "M": 20, "L": 10, "XL": 4}, "locations": ["warehouse_1", "store_1"]}}   |
-| 2  | ThreadVerse T-Shirt     | {"size": ["S", "M", "L", "XL"], "color": "black", "inventory": {"stock": {"S": 7, "M": 15, "L": 9, "XL": 3}, "locations": ["warehouse_2", "store_2"]}}     |
-| 3  | Design Dynamo T-Shirt   | {"size": ["M", "L", "XL"], "color": "blue", "inventory": {"stock": {"M": 10, "L": 7, "XL": 2}, "locations": ["warehouse_3", "store_3"]}}                   |
-| 4  | Artistry Apex T-Shirt   | {"size": ["M", "L", "XL"], "color": "red", "inventory": {"stock": {"M": 10, "L": 8, "XL": 5}, "locations": ["warehouse_1", "store_4"]}}                    |
-| 5  | Graphite Glow T-Shirt   | {"size": ["S", "M", "L", "XL"], "color": "gray", "inventory": {"stock": {"S": 10, "M": 8, "L": 6, "XL": 3}, "locations": ["warehouse_2", "store_5"]}}      |
-| 6  | Sunburst Shine T-Shirt  | {"size": ["S", "M", "L", "XL"], "color": "yellow", "inventory": {"stock": {"S": 20, "M": 25, "L": 15, "XL": 10}, "locations": ["warehouse_1", "store_6"]}} |
-| 7  | Oceanic Opal T-Shirt    | {"size": ["S", "M", "L", "XL"], "color": "teal", "inventory": {"stock": {"S": 5, "M": 7, "L": 4, "XL": 2}, "locations": ["warehouse_3", "store_7"]}}       |
-| 8  | Crimson Cascade T-Shirt | {"size": ["S", "M", "L", "XL"], "color": "maroon", "inventory": {"stock": {"S": 8, "M": 12, "L": 9, "XL": 3}, "locations": ["warehouse_4", "store_8"]}}    |
-+----+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
++-------+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+|   id  |           name          |                                                                         properties                                                                         |
+| int64 |         varchar         |                                                                           varchar                                                                          |
++-------+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| 1     | Ink Fusion T-Shirt      | {"size": ["S", "M", "L", "XL"], "color": "white", "inventory": {"stock": {"S": 12, "M": 20, "L": 10, "XL": 4}, "locations": ["warehouse_1", "store_1"]}}   |
+| 2     | ThreadVerse T-Shirt     | {"size": ["S", "M", "L", "XL"], "color": "black", "inventory": {"stock": {"S": 7, "M": 15, "L": 9, "XL": 3}, "locations": ["warehouse_2", "store_2"]}}     |
+| 3     | Design Dynamo T-Shirt   | {"size": ["M", "L", "XL"], "color": "blue", "inventory": {"stock": {"M": 10, "L": 7, "XL": 2}, "locations": ["warehouse_3", "store_3"]}}                   |
+| 4     | Artistry Apex T-Shirt   | {"size": ["M", "L", "XL"], "color": "red", "inventory": {"stock": {"M": 10, "L": 8, "XL": 5}, "locations": ["warehouse_1", "store_4"]}}                    |
+| 5     | Graphite Glow T-Shirt   | {"size": ["S", "M", "L", "XL"], "color": "gray", "inventory": {"stock": {"S": 10, "M": 8, "L": 6, "XL": 3}, "locations": ["warehouse_2", "store_5"]}}      |
+| 6     | Sunburst Shine T-Shirt  | {"size": ["S", "M", "L", "XL"], "color": "yellow", "inventory": {"stock": {"S": 20, "M": 25, "L": 15, "XL": 10}, "locations": ["warehouse_1", "store_6"]}} |
+| 7     | Oceanic Opal T-Shirt    | {"size": ["S", "M", "L", "XL"], "color": "teal", "inventory": {"stock": {"S": 5, "M": 7, "L": 4, "XL": 2}, "locations": ["warehouse_3", "store_7"]}}       |
+| 8     | Crimson Cascade T-Shirt | {"size": ["S", "M", "L", "XL"], "color": "maroon", "inventory": {"stock": {"S": 8, "M": 12, "L": 9, "XL": 3}, "locations": ["warehouse_4", "store_8"]}}    |
++-------+-------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------+
 ```
 
 ## Working with JSON strings
@@ -112,18 +123,19 @@ Use the `->>` operator to retrieve a JSON property as text. For example, to extr
 
 ```console
 sql> select name, properties->>'color' color from products;
-+-------------------------+--------+
-| name                    | color  |
-+-------------------------+--------+
-| Ink Fusion T-Shirt      | white  |
-| ThreadVerse T-Shirt     | black  |
-| Design Dynamo T-Shirt   | blue   |
-| Artistry Apex T-Shirt   | red    |
-| Graphite Glow T-Shirt   | gray   |
-| Sunburst Shine T-Shirt  | yellow |
-| Oceanic Opal T-Shirt    | teal   |
-| Crimson Cascade T-Shirt | maroon |
-+-------------------------+--------+
++-------------------------+---------+
+|           name          |  color  |
+|         varchar         | varchar |
++-------------------------+---------+
+| Ink Fusion T-Shirt      | white   |
+| ThreadVerse T-Shirt     | black   |
+| Design Dynamo T-Shirt   | blue    |
+| Artistry Apex T-Shirt   | red     |
+| Graphite Glow T-Shirt   | gray    |
+| Sunburst Shine T-Shirt  | yellow  |
+| Oceanic Opal T-Shirt    | teal    |
+| Crimson Cascade T-Shirt | maroon  |
++-------------------------+---------+
 ```
 
 Use the `->` operator to retrieve a JSON property as a JSON object.
@@ -131,7 +143,8 @@ Use the `->` operator to retrieve a JSON property as a JSON object.
 ```console
 sql> select name, properties->'inventory' from products;
 +-------------------------+----------------------------------------------------------------------------------------------------+
-| name                    | products.properties -> Utf8("inventory")                                                           |
+|           name          |                                      properties -> 'inventory'                                     |
+|         varchar         |                                                union                                               |
 +-------------------------+----------------------------------------------------------------------------------------------------+
 | Ink Fusion T-Shirt      | {object={"stock": {"S": 12, "M": 20, "L": 10, "XL": 4}, "locations": ["warehouse_1", "store_1"]}}  |
 | ThreadVerse T-Shirt     | {object={"stock": {"S": 7, "M": 15, "L": 9, "XL": 3}, "locations": ["warehouse_2", "store_2"]}}    |
@@ -149,7 +162,8 @@ You can combine the `->` and `->>` operators to retrieve nested JSON properties.
 ```console
 sql> select name, properties->'inventory'->'stock'->>'S' "available S size" from products;
 +-------------------------+------------------+
-| name                    | available S size |
+|           name          | available S size |
+|         varchar         |      varchar     |
 +-------------------------+------------------+
 | Ink Fusion T-Shirt      | 12               |
 | ThreadVerse T-Shirt     | 7                |
@@ -167,7 +181,8 @@ Use an index to retrieve a specific element from a JSON array. For example, this
 ```console
 sql> select name, properties->'inventory'->'locations'->>0 "Store" from products;
 +-------------------------+-------------+
-| name                    | Store       |
+|           name          |    Store    |
+|         varchar         |   varchar   |
 +-------------------------+-------------+
 | Ink Fusion T-Shirt      | warehouse_1 |
 | ThreadVerse T-Shirt     | warehouse_2 |
@@ -185,12 +200,13 @@ Retrieve the products with the colors black and white using the `->>` operator i
 ```console
 sql> SELECT name, properties ->> 'color' color FROM products
 WHERE properties ->> 'color' IN ('black', 'white');
-+---------------------+-------+
-| name                | color |
-+---------------------+-------+
-| Ink Fusion T-Shirt  | white |
-| ThreadVerse T-Shirt | black |
-+---------------------+-------+
++---------------------+---------+
+|         name        |  color  |
+|       varchar       | varchar |
++---------------------+---------+
+| Ink Fusion T-Shirt  | white   |
+| ThreadVerse T-Shirt | black   |
++---------------------+---------+
 ```
 
 ## Using views to simplify working with JSON columns
@@ -208,30 +224,32 @@ Query products and their colors using the created view:
 
 ```console
 sql> describe products_with_color;
-+-------------+-----------+-------------+
-| column_name | data_type | is_nullable |
-+-------------+-----------+-------------+
-| id          | Int64     | YES         |
-| name        | Utf8      | YES         |
-| properties  | Utf8      | YES         |
-| color       | Utf8      | YES         |
-+-------------+-----------+-------------+
++--------------+-------------+-----------+-------------+
+| table_schema | column_name | data_type | is_nullable |
+|    varchar   |   varchar   |  varchar  |   varchar   |
++--------------+-------------+-----------+-------------+
+| public       | id          | Int64     | YES         |
+| public       | name        | Utf8      | YES         |
+| public       | properties  | Utf8      | YES         |
+| public       | color       | Utf8      | YES         |
++--------------+-------------+-----------+-------------+
 ```
 
 ```console
 sql> select id, name, color from products_with_color;
-+----+-------------------------+--------+
-| id | name                    | color  |
-+----+-------------------------+--------+
-| 1  | Ink Fusion T-Shirt      | white  |
-| 2  | ThreadVerse T-Shirt     | black  |
-| 3  | Design Dynamo T-Shirt   | blue   |
-| 4  | Artistry Apex T-Shirt   | red    |
-| 5  | Graphite Glow T-Shirt   | gray   |
-| 6  | Sunburst Shine T-Shirt  | yellow |
-| 7  | Oceanic Opal T-Shirt    | teal   |
-| 8  | Crimson Cascade T-Shirt | maroon |
-+----+-------------------------+--------+
++-------+-------------------------+---------+
+|   id  |           name          |  color  |
+| int64 |         varchar         | varchar |
++-------+-------------------------+---------+
+| 1     | Ink Fusion T-Shirt      | white   |
+| 2     | ThreadVerse T-Shirt     | black   |
+| 3     | Design Dynamo T-Shirt   | blue    |
+| 4     | Artistry Apex T-Shirt   | red     |
+| 5     | Graphite Glow T-Shirt   | gray    |
+| 6     | Sunburst Shine T-Shirt  | yellow  |
+| 7     | Oceanic Opal T-Shirt    | teal    |
+| 8     | Crimson Cascade T-Shirt | maroon  |
++-------+-------------------------+---------+
 ```
 
 ## Further Reading


### PR DESCRIPTION
## Summary

Every console block in this recipe was captured on a v1.x runtime in December 2024. I re-ran the recipe end to end against stable **v2.1.2** and replaced the blocks with what it actually prints today. Values and row counts are unchanged — only the output shape drifted.

- **SQL results carry a data-type row.** Since v2.0.0 the SQL REPL formats results with `format_batches_with_types`, which prints the column types under the names and centers the header. The recipe showed the older untyped, left-aligned header.
- **`describe` returns four columns.** It gained a leading `table_schema`; the recipe showed three.
- **The `->` derived column name changed.** `properties->'inventory'` now projects as `properties -> 'inventory'`, not `products.properties -> Utf8("inventory")`.
- **The startup log is stale.** It advertised a metrics listener on `127.0.0.1:9090` and an OpenTelemetry listener on `127.0.0.1:50052` — neither is emitted by a default v2.1.2 run — and `Initialized results cache;` is now three separate `sql`/`search`/`embeddings` cache lines.

## Verified against

`spiceai/spiceai` at `v2.1.2` — [`crates/repl/src/pretty.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/repl/src/pretty.rs) (`format_batches_with_types`, unconditional in non-expanded mode) and [`crates/repl/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/repl/src/lib.rs#L994).

## Evidence

Ran it. Official `v2.1.2` release binaries, this recipe's own `spicepod.yaml`, this recipe's own queries in README order:

```console
$ spice sql
sql> describe products;
+--------------+-------------+-----------+-------------+
| table_schema | column_name | data_type | is_nullable |
|    varchar   |   varchar   |  varchar  |   varchar   |
+--------------+-------------+-----------+-------------+
| public       | id          | Int64     | YES         |
| public       | name        | Utf8      | YES         |
| public       | properties  | Utf8      | YES         |
+--------------+-------------+-----------+-------------+

Time: 0.00167675 seconds. 3 rows.
```

Every table in the diff is pasted from that session (the per-query `Time:` lines are dropped, matching the recipe's existing style).

## Note for maintainers

The missing type row is not specific to this recipe — **74 of the cookbook's READMEs** show the pre-v2.0 untyped header. Two recipes captured on v2.x (`catalogs/unity_catalog`, `elasticsearch/connector`) already show the typed form, so the repo is currently inconsistent. This PR fixes one recipe that runs locally with no Docker or secrets; the rest need a run each to regenerate honestly. Happy to work through them if that is wanted — or to hold off, if the type row is considered noise that should change on the CLI side instead.