### PR TITLE
Fix async-queries recipe: correct row counts, JSON shape, and dead parameter example

### DIFF
--- a/async-queries/README.md
+++ b/async-queries/README.md
@@ -64,7 +64,7 @@ The scheduler starts and registers the `data` dataset:
 
 ```console
 2026-03-02T12:00:00.000000Z  INFO spiced: Starting runtime
-2026-03-02T12:00:01.000000Z  INFO runtime::cluster: Starting Ballista scheduler on 0.0.0.0:50052
+2026-03-02T12:00:01.000000Z  INFO runtime::cluster: Starting Ballista scheduler on 127.0.0.1:50052 (shuffle_format=arrow_ipc, shuffle_location=disk (temp_directory))
 2026-03-02T12:00:01.000000Z  INFO runtime::init::dataset: Dataset data initializing...
 2026-03-02T12:00:01.000000Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-03-02T12:00:01.000000Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
@@ -109,11 +109,13 @@ The API returns immediately with a query ID and status URLs:
 {
   "query_id": "01ABC-DEF-456-7890AB",
   "status": "PENDING",
-  "error": null,
   "status_url": "/v1/queries/01ABC-DEF-456-7890AB/status",
   "results_url": "/v1/queries/01ABC-DEF-456-7890AB/results"
 }
 ```
+
+Optional fields are omitted rather than returned as `null`, so an `error` field only
+appears when a query actually fails.
 
 ### Step 6: Poll for Completion
 
@@ -127,8 +129,7 @@ While still running:
 
 ```json
 {
-  "status": "RUNNING",
-  "error": null
+  "status": "RUNNING"
 }
 ```
 
@@ -136,8 +137,7 @@ Once completed:
 
 ```json
 {
-  "status": "SUCCEEDED",
-  "error": null
+  "status": "SUCCEEDED"
 }
 ```
 
@@ -153,15 +153,17 @@ curl -s http://127.0.0.1:8090/v1/queries/01ABC-DEF-456-7890AB/results | jq .
 {
   "chunk_index": 0,
   "row_offset": 0,
-  "row_count": 100,
-  "next_chunk_index": null,
-  "next_chunk_url": null,
+  "row_count": 50,
   "data_array": [
     { "id": 30, "value": "value_0" },
     { "id": 31, "value": "value_1" }
   ]
 }
 ```
+
+The `data` dataset holds 50 rows, so `LIMIT 100` returns all 50 in a single chunk. Results
+are written in chunks of 10,000 rows; because this result fits in one chunk, the
+`next_chunk_index` and `next_chunk_url` fields are omitted.
 
 For queries with more than 10,000 rows, follow the `next_chunk_url` to paginate through results:
 
@@ -182,23 +184,24 @@ spice query "SELECT * FROM data LIMIT 10;"
 ```console
 Submitted query: 01ABC-DEF-456-7890AB (PENDING)
 Waiting for completion... (Ctrl+C to stop waiting)
-✓ SUCCEEDED (3.2s)
-+----+---------+
-| id | value   |
-+----+---------+
-| 30 | value_0 |
-| 31 | value_1 |
-| 32 | value_2 |
-| 33 | value_3 |
-| 34 | value_4 |
-| 35 | value_5 |
-| 36 | value_6 |
-| 37 | value_7 |
-| 38 | value_8 |
-| 39 | value_9 |
-+----+---------+
+✓ SUCCEEDED (1.5s)
++-------+---------+
+|   id  |  value  |
+| int64 | varchar |
++-------+---------+
+| 0     | value_0 |
+| 1     | value_1 |
+| 2     | value_2 |
+| 3     | value_3 |
+| 4     | value_4 |
+| 5     | value_5 |
+| 6     | value_6 |
+| 7     | value_7 |
+| 8     | value_8 |
+| 9     | value_9 |
++-------+---------+
 
-Time: 3.20000000 seconds. 10 rows.
+Time: 1.50488558 seconds. 10 rows.
 ```
 
 ### Submit Without Waiting
@@ -220,8 +223,8 @@ spice query list --status running
 ```
 
 ```console
-QUERY ID                STATE     CREATED                    SQL PREVIEW
-01ABC-DEF-456-7890AB    RUNNING   2026-03-02T12:00:00+00:00  SELECT * FROM data
+ QUERY ID              STATE    CREATED                        SQL PREVIEW
+ 01ABC-DEF-456-7890AB  RUNNING  2026-03-02T12:00:00.000+00:00  SELECT * FROM data;
 
 Total: 1 queries
 ```
@@ -251,33 +254,36 @@ Type SQL to submit a query, or .help for commands.
 query> SELECT COUNT(*) FROM data;
 Submitted query: 01ABC-DEF-456-7890AB (PENDING)
 Press Ctrl+C to stop waiting (query continues in background)
-✓ SUCCEEDED (2.8s)
+✓ SUCCEEDED (1.0s)
 +----------+
 | count(*) |
+|   int64  |
 +----------+
-| 100      |
+| 50       |
 +----------+
 
-Time: 2.80000000 seconds. 1 rows.
+Time: 1.00419104 seconds. 1 rows.
 
 query> .list
-QUERY ID                STATUS      SUBMITTED  SQL
-01ABC-DEF-456-7890AB    SUCCEEDED   3s ago     SELECT COUNT(*) FROM data;
+ QUERY ID              STATUS     SUBMITTED  SQL
+ 01ABC-DEF-456-7890AB  SUCCEEDED  1s ago     SELECT COUNT(*) FROM data;
 
 query> .exit
 ```
 
 ### REPL Commands
 
-| Command         | Description                            |
-| --------------- | -------------------------------------- |
-| `.list`         | List tracked queries from this session |
-| `.status <id>`  | Show query status                      |
-| `.results <id>` | Fetch and display results              |
-| `.wait <id>`    | Resume waiting for a query             |
-| `.cancel <id>`  | Cancel a running query                 |
-| `.help`         | Show all commands                      |
-| `.exit`         | Exit the REPL                          |
+| Command             | Description                            |
+| ------------------- | -------------------------------------- |
+| `.list`             | List tracked queries from this session |
+| `.status <id>`      | Show query status                      |
+| `.results <id>`     | Fetch and display results              |
+| `.wait <id>`        | Resume waiting for a query             |
+| `.cancel <id>`      | Cancel a running query                 |
+| `.clear`            | Clear tracked queries from local list  |
+| `.clear history`    | Clear command history                  |
+| `.help`             | Show all commands                      |
+| `.exit`, `.quit`, `.q` | Exit the REPL                       |
 
 Partial query IDs are supported — `01ABC` resolves to the full ID if it uniquely matches one tracked query.
 
@@ -290,8 +296,23 @@ curl -s http://127.0.0.1:8090/v1/queries \
   -H "Content-Type: application/json" \
   -d '{
     "sql": "SELECT * FROM data WHERE id > $1 LIMIT $2",
-    "parameters": [50, 10]
+    "parameters": [40, 10]
   }' | jq .
+```
+
+Fetching the results of that query shows the bound values applied — ids above `40`, capped
+at 10 rows:
+
+```json
+{
+  "chunk_index": 0,
+  "row_offset": 0,
+  "row_count": 9,
+  "data_array": [
+    { "id": 41, "value": "value_1" },
+    { "id": 42, "value": "value_2" }
+  ]
+}
 ```
 
 ## Advanced: Timeouts and Size Limits


### PR DESCRIPTION
## Summary

Ran the `async-queries` recipe end-to-end against **v2.1.2** and corrected every claim that did not match the runtime. The recipe's flow itself is sound — every command, endpoint, flag and REPL command exists and works — but several documented outputs were wrong.

| # | What the recipe said | What the runtime does |
| - | - | - |
| 1 | `LIMIT 100` → `"row_count": 100`; REPL `SELECT COUNT(*) FROM data` → `100` | The `data` dataset holds **50** rows (ids 0–49), so both return **50** |
| 2 | Submit + status responses include `"error": null` | `error` is `skip_serializing_if = "Option::is_none"` — the key is absent unless the query fails |
| 3 | Step 7 sample includes `"next_chunk_index": null, "next_chunk_url": null` | Both are also `skip_serializing_if` — absent for single-chunk results |
| 4 | Parameterized example binds `[50, 10]` to `WHERE id > $1 LIMIT $2` | Max id is 49, so the example **returns zero rows** — it demonstrates nothing |
| 5 | REPL command table lists 7 commands | `.help` also lists `.clear`, `.clear history`, and the `.quit` / `.q` aliases |
| 6 | Step 3 log: `Starting Ballista scheduler on 0.0.0.0:50052` | `127.0.0.1:50052 (shuffle_format=arrow_ipc, shuffle_location=disk (temp_directory))` — the documented command binds `127.0.0.1` |
| 7 | `spice query` result tables have no data-type row | v2.0+ renders results with a type row under centred column names |

Item 4 is the one that actually misleads: the "Advanced: Parameterized Queries" section is the recipe's only demonstration of bind parameters, and as written it succeeds with an empty result, so a reader cannot tell whether their parameters were applied at all. Changed to `[40, 10]` and added the real response so the binding is visible.

Verified as correct and left unchanged: the `spice query` / `spice cluster tls` CLI surface, `--no-wait`, `list --status`, `cancel`, every REPL command, the three "Advanced" request bodies, and both "How It Works" constants — results are chunked at 10,000 rows (`DEFAULT_CHUNK_SIZE`) and retained for 12 hours (`DEFAULT_RESULT_TTL`).

## Verified against

spiceai/spiceai at `v2.1.2`:

- [`crates/runtime/src/http/v1/queries.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/runtime/src/http/v1/queries.rs) — `SubmitQueryResponse.error`, `QueryResponse.error`, `ChunkResponse.next_chunk_index` / `next_chunk_url` all carry `#[serde(skip_serializing_if = "Option::is_none")]`
- [`crates/runtime/src/jobs/state.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/runtime/src/jobs/state.rs) — `DEFAULT_CHUNK_SIZE: usize = 10_000`, `DEFAULT_RESULT_TTL: Duration = Duration::from_hours(12)`

## Evidence

Scheduler + executor started with mTLS exactly as documented, `spice version` → `Runtime version: v2.1.2+models`.

Submit and status — no `error` key:

```console
$ curl -s http://127.0.0.1:8090/v1/queries -H "Content-Type: application/json" \
    -d '{"sql": "SELECT * FROM data LIMIT 100"}' | jq .
{
  "query_id": "019FC-266-471-B3CB8F",
  "status": "PENDING",
  "status_url": "/v1/queries/019FC-266-471-B3CB8F/status",
  "results_url": "/v1/queries/019FC-266-471-B3CB8F/results"
}

$ curl -s http://127.0.0.1:8090/v1/queries/019FC-266-471-B3CB8F/status | jq .
{
  "status": "SUCCEEDED"
}
```

Results — 50 rows for `LIMIT 100`, and no `next_chunk_*` keys:

```console
$ curl -s http://127.0.0.1:8090/v1/queries/019FC-266-471-B3CB8F/results | jq '{chunk_index,row_offset,row_count,data_array:.data_array[0:2]}'
{
  "chunk_index": 0,
  "row_offset": 0,
  "row_count": 50,
  "data_array": [ { "id": 40, "value": "value_0" }, { "id": 41, "value": "value_1" } ]
}
```

The dataset really does hold 50 rows:

```console
$ printf 'SELECT COUNT(*) as n, MIN(id) as min_id, MAX(id) as max_id FROM data;\n' | spice sql
+-------+--------+--------+
|   n   | min_id | max_id |
| int64 |  int64 |  int64 |
+-------+--------+--------+
| 50    | 0      | 49     |
+-------+--------+--------+
```

The parameterized example as documented (`[50, 10]`) — succeeds with nothing to show:

```console
$ curl -s .../results | jq -c '{row_count, sample: .data_array[0:3]}'
{"row_count":null,"sample":null}
```

With `[40, 10]` the binding is visible — this is the response now pasted into the README:

```console
{
  "chunk_index": 0,
  "row_offset": 0,
  "row_count": 9,
  "data_array": [ { "id": 41, "value": "value_1" }, { "id": 42, "value": "value_2" } ]
}
```

Row counts, timings and table renderings in the README are copied from this run. Query IDs in the README were left as the existing placeholders.

## Related

[#562](https://github.com/spiceai/cookbook/pull/562) fixes the sibling `distributed` recipe, whose Step 5 does not distribute on v2.0+ — found during the same run.