### PR TITLE
Fix localpod recipe: child dataset never picked up parent data

### DIFF
--- a/localpod/README.md
+++ b/localpod/README.md
@@ -25,6 +25,7 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_check_interval: 10s
 ```
 
 :::note
@@ -41,28 +42,23 @@ You should see terminal output like so:
 
 ```shell
 $ spice run
-2024/10/29 18:31:38 INFO Checking for latest Spice runtime release...
-2024/10/29 18:31:38 INFO Spice.ai runtime starting...
-2024-10-30T01:31:38.912802Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-10-30T01:31:38.913151Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-10-30T01:31:38.913247Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-10-30T01:31:38.921580Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
-2024-10-30T01:31:39.112883Z  INFO runtime: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
-2024-10-30T01:31:39.123137Z  INFO runtime: Tool [search] ready to use
-2024-10-30T01:31:39.123166Z  INFO runtime: Tool [table_schema] ready to use
-2024-10-30T01:31:39.123172Z  INFO runtime: Tool [sql] ready to use
-2024-10-30T01:31:39.123180Z  INFO runtime: Tool [list_datasets] ready to use
-2024-10-30T01:31:39.123183Z  INFO runtime: Tool [get_readiness] ready to use
-2024-10-30T01:31:39.123187Z  INFO runtime: Tool [random_sample] ready to use
-2024-10-30T01:31:39.123193Z  INFO runtime: Tool [sample_distinct_columns] ready to use
-2024-10-30T01:31:39.123197Z  INFO runtime: Tool [top_n_sample] ready to use
-2024-10-30T01:31:39.125295Z  INFO runtime: Dataset time_series registered (file:data.csv), acceleration (arrow, 15s refresh), results cache enabled.
-2024-10-30T01:31:39.126352Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset time_series
-2024-10-30T01:31:39.128337Z  INFO runtime::accelerated_table::refresh_task: Loaded 0 rows for dataset time_series in 1ms.
-2024-10-30T01:31:39.136703Z  INFO runtime::datafusion: Localpod dataset local_time_series synchronizing refreshes with parent table time_series
-2024-10-30T01:31:39.136764Z  INFO runtime: Dataset local_time_series registered (localpod:time_series), acceleration (duckdb:file, 10s refresh), results cache enabled.
-2024-10-30T01:31:39.137955Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset local_time_series
-2024-10-30T01:31:39.139139Z  INFO runtime::accelerated_table::refresh_task: Loaded 0 rows for dataset local_time_series in 1ms.
+2026/08/02 12:24:38 INFO Checking for latest Spice runtime release...
+2026/08/02 12:24:38 INFO Spice.ai runtime starting...
+2026-08-02T12:24:38.441060Z  INFO spiced: Starting runtime v2.1.2+models
+2026-08-02T12:24:38.442600Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-02T12:24:38.442643Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-08-02T12:24:38.442658Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-08-02T12:24:38.444400Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-08-02T12:24:38.444761Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-08-02T12:24:38.452860Z  INFO runtime::init::dataset: Loading datasets: 1 tasks dispatched, 0 skipped at accelerator init (of 2 total; localpod datasets may be chained).
+2026-08-02T12:24:38.452891Z  INFO runtime::init::dataset: Dataset local_time_series initializing...
+2026-08-02T12:24:38.453637Z  INFO runtime::init::dataset: Dataset time_series registered (file:data.csv), acceleration (arrow, 15s refresh), results cache enabled. duration_ms=0
+2026-08-02T12:24:38.454943Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset time_series
+2026-08-02T12:24:38.455886Z  INFO runtime::accelerated_table::refresh_task: Loaded 0 rows for dataset time_series in 0s.
+2026-08-02T12:24:38.458522Z  INFO runtime::init::dataset: Dataset local_time_series registered (localpod:time_series), acceleration (duckdb:file, 10s refresh), results cache enabled. duration_ms=3
+2026-08-02T12:24:38.459791Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset local_time_series
+2026-08-02T12:24:38.463429Z  INFO runtime::accelerated_table::refresh_task: Loaded 0 rows for dataset local_time_series in 3ms.
+2026-08-02T12:24:38.561540Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 ### Querying the `localpod`
@@ -75,20 +71,21 @@ $ spice sql
 sql> SELECT COUNT(*) FROM time_series;
 +----------+
 | count(*) |
+|   int64  |
 +----------+
 | 0        |
 +----------+
 
-Time: 0.004800375 seconds. 1 rows.
+Time: 0.001709125 seconds. 1 rows.
 sql> SELECT COUNT(*) FROM local_time_series;
 +----------+
 | count(*) |
+|   int64  |
 +----------+
 | 0        |
 +----------+
 
-
-Time: 0.005054417 seconds. 1 rows.
+Time: 0.001861500 seconds. 1 rows.
 ```
 
 ### Updating the parent dataset
@@ -102,8 +99,8 @@ Let's insert new data into the parent dataset and see the `localpod` update. In 
 In the terminal where `spice run` is running, you should see a message indicating the new data is loaded:
 
 ```shell
-2024-10-30T01:37:24.266411Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (48.16 kiB) for dataset time_series in 3ms.
-2024-10-30T01:37:24.266422Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (48.16 kiB) for dataset local_time_series in 3ms.
+2026-08-02T12:25:23.471503Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset time_series in 4ms.
+2026-08-02T12:25:28.564207Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset local_time_series in 15ms.
 ```
 
 And the same SQL queries as above will give updated results:
@@ -112,19 +109,21 @@ And the same SQL queries as above will give updated results:
 sql> SELECT COUNT(*) FROM time_series;
 +----------+
 | count(*) |
+|   int64  |
 +----------+
 | 1000     |
 +----------+
 
-Time: 0.006115708 seconds. 1 rows.
+Time: 0.001220625 seconds. 1 rows.
 sql> SELECT COUNT(*) FROM local_time_series;
 +----------+
 | count(*) |
+|   int64  |
 +----------+
 | 1000     |
 +----------+
 
-Time: 0.005385625 seconds. 1 rows.
+Time: 0.002321541 seconds. 1 rows.
 ```
 
 The `local_time_series` dataset is faster because it's accelerated locally using [DuckDB](https://docs.spiceai.org/components/data-accelerators/duckdb)

--- a/localpod/spicepod.yaml
+++ b/localpod/spicepod.yaml
@@ -18,3 +18,4 @@ datasets:
       enabled: true
       engine: duckdb
       mode: file
+      refresh_check_interval: 10s


### PR DESCRIPTION
## Summary

The `localpod` recipe does not produce its documented result on v2.1.2. After running `./generate_data.sh`, the README says both datasets return 1,000 rows. In reality the parent reaches 1,000 and **the localpod child stays at 0 indefinitely** — which is precisely the behaviour the recipe exists to demonstrate.

**Why.** The child has no refresh trigger at all:

1. Localpod refresh synchronization fails during startup. The runtime logs (at DEBUG) `Could not synchronize refreshes with parent table time_series. Parent table is not an accelerated table.`, and the success line the README shows — `Localpod dataset local_time_series synchronizing refreshes with parent table time_series` — never appears.
2. The shipped `spicepod.yaml` gives the child no `refresh_check_interval`, so with synchronization skipped it refreshes once at boot and never again. Over a 2-minute run the parent refreshed 12 times and the child exactly twice (both at t=0).

**The fix.** Add `refresh_check_interval: 10s` to the child. This is not an invention — it is what the README's own expected output has always implied was configured:

```
INFO runtime: Dataset local_time_series registered (localpod:time_series), acceleration (duckdb:file, 10s refresh), ...
```

The shipped spicepod produces `acceleration (duckdb:file)` with no interval; with the setting restored the runtime prints `acceleration (duckdb:file, 10s refresh)`, matching the README exactly, and the recipe produces its documented 1,000 / 1,000 result.

Also replaced the run transcripts, captured in **October 2024** on a v1.x runtime, with real v2.1.2 output. They contained four lines that no longer exist: `runtime::metrics_server: Spice Runtime Metrics listening`, `runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052`, `Initialized results cache;` (now three separate `runtime::init::caching` lines), and eight `Tool [...] ready to use` lines. Dataset registration also moved from `runtime:` to `runtime::init::dataset`, and SQL results now render with a data-type row.

## Verified against

spiceai/spiceai at `v2.1.2` — [`crates/runtime/src/datafusion/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.1.2/crates/runtime/src/datafusion/mod.rs#L3355-L3374): the `synchronize_with` helper emits the "Parent table is not an accelerated table" debug line and returns early, skipping the `tracing::info!` sync confirmation.

## Evidence

Ran the recipe as written on v2.1.2. Before the fix — parent loads, child does not:

```console
$ ./generate_data.sh && sleep 35
$ printf 'SELECT COUNT(*) FROM time_series;\nSELECT COUNT(*) FROM local_time_series;\n' | spice sql
| 1000     |     <- time_series
| 0        |     <- local_time_series
```

Refresh counts over the same run — the child never refreshes after boot:

```console
$ grep refresh_task spice.log | grep -c "dataset time_series"        # 12
$ grep refresh_task spice.log | grep -c "dataset local_time_series"  # 2  (both at t=0)
```

The synchronization failure is deterministic, 3/3 clean starts, and is **not** specific to the Arrow accelerator — it reproduces with `engine: duckdb` on the parent too:

```console
run 1: Could not synchronize refreshes with parent table time_series. Parent table is not an accelerated table.
run 2: Could not synchronize refreshes with parent table time_series. Parent table is not an accelerated table.
run 3: Could not synchronize refreshes with parent table time_series. Parent table is not an accelerated table.
```

After the fix — the child registers with the interval the README documents, and propagation works:

```console
INFO runtime::init::dataset: Dataset local_time_series registered (localpod:time_series), acceleration (duckdb:file, 10s refresh), results cache enabled. duration_ms=3
...
INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset time_series in 4ms.
INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset local_time_series in 15ms.

$ printf 'SELECT COUNT(*) FROM time_series;\nSELECT COUNT(*) FROM local_time_series;\n' | spice sql
| 1000     |
| 1000     |
```

Every transcript in the updated README is copied from this run.

## Note for reviewers

This PR restores the recipe's documented outcome, but the underlying synchronization failure looks like a **runtime bug worth filing separately**. The parent is plainly an accelerated table — the runtime logs `acceleration (arrow, 15s refresh)` for it moments earlier — yet the downcast to `AcceleratedTable` in `synchronize_with` fails. The code comment there specifically anticipates the bare-`AcceleratedTable` (Arrow) case, so something else is now wrapping the parent's provider. Since the failure is logged at DEBUG and the child still registers successfully, a user sees no warning at all — the recipe just quietly returns stale data.

If synchronization is repaired upstream, the added `refresh_check_interval` remains harmless (the child simply also polls on its own schedule), but the recipe would then be a better demo of synchronized refreshes without it.