### PR TITLE
Fix http recipe: two-term people search returns 20 rows, not 40

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -139,7 +139,7 @@ WHERE request_path = '/search/people'
   AND request_query IN ('q=michael', 'q=luke');
 ```
 
-This executes two separate API calls (one for each query parameter) and combines the results:
+This executes two separate API calls (one for each query parameter) and combines the results — 10 results per search term, for 20 rows in total:
 
 ```console
 +----------------+---------------+--------------+------------------------------------+
@@ -152,7 +152,7 @@ This executes two separate API calls (one for each query parameter) and combines
 | /search/people | q=luke        |              | {"score":0.5,"person":{...}}       |
 +----------------+---------------+--------------+------------------------------------+
 
-Time: 0.336182833 seconds. 40 rows.
+Time: 0.336182833 seconds. 20 rows.
 ```
 
 ## Advanced Usage


### PR DESCRIPTION
## Summary

The HTTP connector recipe's "Query multiple search terms" example claims the two-term
`/search/people` query returns **40 rows**. It returns **20** — the TVMaze API returns 10
results per search term, which the README itself states two paragraphs earlier ("Returns 10
results by default"), so the recipe contradicted itself.

Corrected the row count and made the arithmetic explicit (10 per term → 20 total).

## Verified against

spiceai/spiceai at `v2.1.3` (current stable), run against the recipe's own `spicepod.yaml`.

## Evidence

Ran the recipe (`spice run` in `http/`, then `spice sql`) on v2.1.3:

```console
sql> SELECT count(*) FROM tvmaze WHERE request_path = '/search/people' AND request_query IN ('q=michael', 'q=luke');
+----------+
| count(*) |
|   int64  |
+----------+
| 20       |
+----------+

sql> SELECT count(*) FROM tvmaze WHERE request_path = '/search/people' AND request_query = 'q=michael';
+----------+
| count(*) |
|   int64  |
+----------+
| 10       |
+----------+
```

Confirmed directly against the upstream API as well — `GET https://api.tvmaze.com/search/people?q=michael`
returns 10 results, as does `q=luke`.

The rest of the recipe verified correct on v2.1.3: the `/shows/169` and `/shows/82` JSON-function
queries return the documented values, and the pagination example still returns exactly 194 products
across 7 pages.