### PR TITLE
Fix dual-dataset-registration recipe: correct /v1/datasets status API response shape

### DIFF
--- a/acceleration/dual-dataset-registration/README.md
+++ b/acceleration/dual-dataset-registration/README.md
@@ -86,7 +86,7 @@ Shortly after startup you will see both datasets register. The federated table i
 
 ```bash
 2025-03-24T10:00:01.123456Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
-2025-03-24T10:00:01.234567Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file), results cache enabled.
+2025-03-24T10:00:01.234567Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file, 1800s refresh), results cache enabled.
 2025-03-24T10:00:01.234890Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips_accelerated
 ```
 
@@ -107,6 +107,7 @@ SELECT COUNT(*) AS total_trips FROM taxi_trips;
 ```output
 +-------------+
 | total_trips |
+|    int64    |
 +-------------+
 | 2964624     |
 +-------------+
@@ -129,29 +130,53 @@ While still loading:
   {
     "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips",
-    "status": "Ready"
+    "replication_enabled": false,
+    "acceleration_enabled": false,
+    "status": "Ready",
+    "properties": {
+      "search": "unsupported",
+      "vector_search": "unsupported"
+    }
   },
   {
     "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips_accelerated",
-    "status": "Refreshing"
+    "replication_enabled": false,
+    "acceleration_enabled": true,
+    "status": "Refreshing",
+    "properties": {
+      "search": "unsupported",
+      "vector_search": "unsupported"
+    }
   }
 ]
 ```
 
-When the acceleration finishes:
+When the acceleration finishes, `taxi_trips_accelerated` reports `Ready`:
 
 ```json
 [
   {
     "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips",
-    "status": "Ready"
+    "replication_enabled": false,
+    "acceleration_enabled": false,
+    "status": "Ready",
+    "properties": {
+      "search": "unsupported",
+      "vector_search": "unsupported"
+    }
   },
   {
     "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
     "name": "taxi_trips_accelerated",
-    "status": "Ready"
+    "replication_enabled": false,
+    "acceleration_enabled": true,
+    "status": "Ready",
+    "properties": {
+      "search": "unsupported",
+      "vector_search": "unsupported"
+    }
   }
 ]
 ```
@@ -159,7 +184,7 @@ When the acceleration finishes:
 The Spice runtime logs also confirm when the load completes:
 
 ```bash
-2025-03-24T10:03:45.678901Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows () for dataset taxi_trips_accelerated in 3m 44s.
+2025-03-24T10:03:45.678901Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips_accelerated in 3m 44s.
 ```
 
 ## Step 6. Switch to the accelerated table
@@ -173,6 +198,7 @@ SELECT COUNT(*) AS total_trips FROM taxi_trips_accelerated;
 ```output
 +-------------+
 | total_trips |
+|    int64    |
 +-------------+
 | 2964624     |
 +-------------+


### PR DESCRIPTION
## Summary

Step 5 of the `acceleration/dual-dataset-registration` recipe tells the reader to poll the
datasets status API and shows the response. The documented JSON is missing three fields the
runtime actually returns, so the reader's output does not match the recipe:

**What the recipe said** — three keys per dataset:

```json
{
  "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
  "name": "taxi_trips_accelerated",
  "status": "Refreshing"
}
```

**What the runtime returns** — also `replication_enabled`, `acceleration_enabled`, and a
`properties` object:

```json
{
  "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
  "name": "taxi_trips_accelerated",
  "replication_enabled": false,
  "acceleration_enabled": true,
  "status": "Refreshing",
  "properties": { "search": "unsupported", "vector_search": "unsupported" }
}
```

Both status snapshots (mid-load and after load) are corrected. The `status` values themselves
(`Refreshing` → `Ready`) were confirmed correct and are unchanged, as is the Step 7 polling
script — its `jq` filter selects by `.name` and reads `.status`, so it still works.

While rewriting those blocks from the live run, also corrected:

- **Step 5 log line**: `Loaded 2,964,624 rows () for dataset …` — the size was empty. The
  runtime logs `(399.38 MiB)`. (Load *duration* is network-dependent, so the recipe's `3m 44s`
  is left as written.)
- **Step 3 transcript**: the accelerated dataset registers as
  `acceleration (duckdb:file, 1800s refresh)` — the runtime appends the interval because this
  recipe sets `refresh_check_interval: 30m`.
- **Steps 4 and 6**: `spice sql` prints a data-type row under the column names.

Row counts (2,964,624 on both tables) and all config in the recipe were confirmed correct and
are unchanged.

## Verified against

spiceai/spiceai at `v2.1.4` (current stable) — [`/v1/datasets` handler](https://github.com/spiceai/spiceai/blob/v2.1.4/crates/runtime/src/http/v1/datasets.rs)

## Evidence

Ran the recipe end to end on v2.1.4. Mid-load, exactly as Step 5 instructs:

```console
$ curl -s "http://localhost:8090/v1/datasets?status=true" | jq
[
  {
    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
    "name": "taxi_trips",
    "replication_enabled": false,
    "acceleration_enabled": false,
    "status": "Ready",
    "properties": { "search": "unsupported", "vector_search": "unsupported" }
  },
  {
    "from": "s3://spiceai-demo-datasets/taxi_trips/2024/",
    "name": "taxi_trips_accelerated",
    "replication_enabled": false,
    "acceleration_enabled": true,
    "status": "Refreshing",
    "properties": { "search": "unsupported", "vector_search": "unsupported" }
  }
]
```

Startup and load transcript:

```console
2026-08-06T12:11:04.573470Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file, 1800s refresh), results cache enabled.
2026-08-06T12:11:08.171065Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips_accelerated in 3s 596ms.
```

Both queries returned `2964624`, and `taxi_trips_accelerated` flipped to `Ready` after the load.