### PR TITLE
Fix api_key recipe: correct CLI auth error strings and /v1/sql response headers

### DIFF
--- a/api_key/README.md
+++ b/api_key/README.md
@@ -52,8 +52,9 @@ Output:
 ```shell
 curl -H "x-api-key: foobar" -H 'Content-Type: text/plain' -XPOST -i http://localhost:8090/v1/sql -d 'SELECT 1'
 HTTP/1.1 200 OK
-content-type: text/plain; charset=utf-8
+content-type: application/json
 x-cache: Miss from spiceai
+results-cache-status: MISS
 content-length: 16
 date: Thu, 07 Nov 2024 01:53:20 GMT
 
@@ -67,7 +68,7 @@ date: Thu, 07 Nov 2024 01:53:20 GMT
 
 ```bash
 $ spice pods
-2025/06/16 12:45:49 ERROR listing spiced pods error="unauthorized: invalid or missing Spice API key"
+ERROR unauthorized: invalid or missing Spice API key. Run `spice login` or set SPICE_API_KEY.
 ```
 
 1. Now, run `spice pods` with the API key
@@ -88,7 +89,7 @@ api_key v1      0        0      0
 $ spice sql
 
 sql> select 1;
-Authentication Error Access denied. Invalid credentials.
+Authentication Failed: Invalid credentials. Verify credentials and try again.
 ```
 
 1. Re-open the SQL REPL with the API key and try the query again:
@@ -99,6 +100,7 @@ $ spice sql --api-key foobar
 sql> select 1;
 +----------+
 | Int64(1) |
+|   int64  |
 +----------+
 | 1        |
 +----------+


### PR DESCRIPTION
## Summary

Ran the `api_key` recipe end to end on current stable. The auth behaviour it demonstrates is
correct — HTTP 401 without a key, 200 with one, CLI rejected then accepted — but four pieces of
expected output no longer match what the reader sees.

**What the recipe said → what the runtime/CLI actually prints:**

1. `spice pods` without a key showed a Go-style logger line:
   `2025/06/16 12:45:49 ERROR listing spiced pods error="unauthorized: invalid or missing Spice API key"`.
   The Rust CLI prints no timestamp prefix and no `listing spiced pods error=` wrapper, and adds a
   remediation hint:
   `ERROR unauthorized: invalid or missing Spice API key. Run `spice login` or set SPICE_API_KEY.`
2. `spice sql` without a key showed `Authentication Error Access denied. Invalid credentials.`
   The actual message is `Authentication Failed: Invalid credentials. Verify credentials and try again.`
3. The successful `/v1/sql` response was shown as `content-type: text/plain; charset=utf-8`. It is
   `application/json` (the body `[{"Int64(1)":1}]` is unchanged, as is the `Content-Type: text/plain`
   *request* header added in #302). Added the `results-cache-status` header that accompanies `x-cache`.
4. The `spice sql --api-key` result table was missing the data-type row that `spice sql` prints
   under the column names.

Same class of drift as #560, which corrected pre-v2 CLI transcripts in `spice search` and
`spice trace`; #519 had already fixed this recipe's `spice pods` *columns* but not its error line.
The `api-key:` spelling in the shipped `spicepod.yaml` versus `api_key:` in the README prose was
checked and is fine — `Auth` carries `#[serde(alias = "api-key")]`, so both parse.

## Verified against

spiceai/spiceai at `v2.1.4` (current stable) — [`Auth` / `ApiKeyAuth`](https://github.com/spiceai/spiceai/blob/v2.1.4/crates/spicepod/src/component/runtime.rs#L760)

## Evidence

Ran the recipe with `API_KEY=foobar` in `.env` on v2.1.4:

```console
2026-08-06T12:15:40.649621Z  INFO runtime::http::routes: Enabled API key authentication on HTTP routes

$ curl -XPOST -i http://localhost:8090/v1/sql -d 'SELECT 1'
HTTP/1.1 401 Unauthorized
content-length: 12

Unauthorized

$ curl -H "Content-Type: text/plain" -H "x-api-key: foobar" -XPOST -i http://localhost:8090/v1/sql -d 'SELECT 1'
HTTP/1.1 200 OK
content-type: application/json
x-cache: Miss from spiceai
results-cache-status: MISS
content-length: 16

[{"Int64(1)":1}]

$ spice pods
ERROR unauthorized: invalid or missing Spice API key. Run `spice login` or set SPICE_API_KEY.

$ spice pods --api-key foobar
 NAME     VERSION  DATASETS  MODELS  DEPENDENCIES
 api_key  v1       0         0       0

$ spice sql
sql> select 1;
Authentication Failed: Invalid credentials. Verify credentials and try again.

$ spice sql --api-key foobar
sql> select 1;
+----------+
| Int64(1) |
|   int64  |
+----------+
| 1        |
+----------+
```