### PR TITLE
Fix full-text-search recipe: correct /v1/search response shape

### DIFF
--- a/full-text-search/README.md
+++ b/full-text-search/README.md
@@ -73,10 +73,11 @@ show tables;
 
 ```
 +---------------+--------------+----------------+------------+
-| table_catalog | table_schema | table_name     | table_type |
+| table_catalog | table_schema |   table_name   | table_type |
+|    varchar    |    varchar   |     varchar    |   varchar  |
 +---------------+--------------+----------------+------------+
-| spice         | public       | cookbook_files | BASE TABLE |
 | spice         | runtime      | task_history   | BASE TABLE |
+| spice         | public       | cookbook_files | BASE TABLE |
 +---------------+--------------+----------------+------------+
 ```
 
@@ -91,16 +92,19 @@ ORDER BY _score DESC
 LIMIT 5;
 ```
 
-Results (scores may vary):
+Results (paths and scores vary as the cookbook changes):
 
 ```
-+-------------------------------+--------------------+
-| path                          | _score              |
-+-------------------------------+--------------------+
-| vectors/README.md             | 6.82               |
-| search/README.md              | 6.51               |
-| search_github_files/README.md | 6.47               |
-+-------------------------------+--------------------+
++--------------------------------+-------------------+
+|              path              |       _score      |
+|             varchar            |      float64      |
++--------------------------------+-------------------+
+| search/elasticsearch/README.md | 7.372053146362305 |
+| vectors/s3/README.md           | 7.359576225280762 |
+| search/README.md               | 7.14163875579834  |
+| ai/WHEN_TO_USE.md              | 7.056568145751953 |
+| full-text-search/README.md     | 6.641867637634277 |
++--------------------------------+-------------------+
 ```
 
 ### Search for Specific Topics
@@ -163,21 +167,31 @@ Response (truncated):
   "results": [
     {
       "matches": {
-        "content": "... Follow these steps to get started with ..."
-      },
-      "data": {
-        "path": "postgres/rds/README.md"
+        "content": ["# AWS RDS for PostgreSQL\n\nWorks with `v1.0+`\n\nFollow these steps to ge..."]
       },
       "primary_key": {
         "path": "postgres/rds/README.md"
       },
-      "_score": 1.41,
+      "_score": 1.12,
       "dataset": "cookbook_files"
     }
   ],
-  "duration_ms": 12
+  "duration_ms": 4
 }
 ```
+
+Each result contains:
+
+- **`matches`**: the indexed column(s) that matched, mapping column name to an array of matching text.
+- **`primary_key`**: the `full_text_search.row_id` column(s) — `path` for this dataset.
+- **`_score`**: the BM25 relevance score.
+- **`data`**: any `additional_columns` that are _not_ part of the primary key. Requesting only
+  `path` (the row_id) returns no `data` object, because that value is already in `primary_key`.
+  Requesting `["name", "size"]` instead adds:
+
+  ```json
+  "data": { "name": "README.md", "size": 2437 }
+  ```
 
 ## When to Use Full-Text Search
 


### PR DESCRIPTION
## Summary

Ran the `full-text-search` recipe end to end on current stable. The configuration and the
`text_search()` SQL path are correct, but the documented `/v1/search` response does not match
what the endpoint returns.

**What the recipe said** — a `data` object holding the requested `path`, and `matches` as a string:

```json
{
  "matches": { "content": "... Follow these steps to get started with ..." },
  "data": { "path": "postgres/rds/README.md" },
  "primary_key": { "path": "postgres/rds/README.md" },
  "_score": 1.41,
  "dataset": "cookbook_files"
}
```

**What the endpoint returns** — no `data` key at all for this request, and `matches` maps each
indexed column to an **array** of matching text:

```json
{
  "matches": { "content": ["# AWS RDS for PostgreSQL\n\nWorks with `v1.0+`\n\nFollow these steps to ge..."] },
  "primary_key": { "path": "postgres/rds/README.md" },
  "_score": 1.12,
  "dataset": "cookbook_files"
}
```

The reason is worth documenting rather than just patching the JSON: `data` carries only those
`additional_columns` that are **not** part of the primary key. Because `path` is this dataset's
`full_text_search.row_id`, requesting it returns the value under `primary_key` and emits no
`data` object. Requesting non-key columns does produce one — confirmed with
`"additional_columns": ["size", "name"]`, which returns
`"data": { "name": "README.md", "size": 2437 }`. Added a short field-by-field list covering this.

Also corrected in the same pass:

- The first SQL example claimed `LIMIT 5` but showed only **3** result rows, and its top hit was
  `vectors/README.md` — a path that does not exist in the repo (the recipe is `vectors/s3`).
  Replaced with the real five-row result and relabelled it "paths and scores vary", since the
  indexed source is the live cookbook repo.
- `show tables;` and the search result table now include the data-type row that `spice sql` prints.

## Verified against

spiceai/spiceai at `v2.1.4` (current stable)

## Evidence

Ran with `GITHUB_TOKEN` set, per the recipe's prerequisites:

```console
2026-08-06T12:18:14.265810Z  INFO runtime::init::dataset: Dataset cookbook_files registered (github:github.com/spiceai/cookbook/files/trunk), acceleration (arrow), results cache enabled.
2026-08-06T12:18:18.614284Z  INFO runtime::accelerated_table::refresh_task: Loaded 124 rows (1.33 MiB) for dataset cookbook_files in 4s 347ms.
```

```console
$ curl -sS -X POST http://localhost:8090/v1/search -H 'Content-Type: application/json' \
    -d '{"datasets":["cookbook_files"],"text":"getting started","additional_columns":["path"],"limit":5}'
# result keys: ['matches', 'primary_key', '_score', 'dataset']      <- no "data"

$ # same call with "additional_columns": ["size","name"]
# result keys: ['matches', 'data', 'primary_key', '_score', 'dataset']
# data: {'name': 'README.md', 'size': 2437}
```

The `text_search()` SQL examples all ran successfully and `_score` is correct throughout.