### PR TITLE
Fix views recipe: correct refresh_cron registration output

### DIFF
--- a/views/README.md
+++ b/views/README.md
@@ -19,13 +19,12 @@ spice run
 Example output:
 
 ```bash
-2025-05-18T19:55:04.208627Z  INFO spiced: Starting runtime v1.2.2+models.metal
-2025-05-18T19:55:04.720993Z  INFO runtime::init::results_cache: Initialized results cache; max size: 128.00 MiB, item ttl: 1s
-2025-05-18T19:55:04.721098Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
-2025-05-18T19:55:04.721210Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2025-05-18T19:55:04.208627Z  INFO spiced: Starting runtime v2.1.4+models.metal
+2025-05-18T19:55:04.720993Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2025-05-18T19:55:04.721098Z  INFO runtime: No datasets or catalogs were configured. If this is unexpected, check the Spicepod configuration.
+2025-05-18T19:55:04.721210Z  INFO runtime: All components are loaded. Spice runtime is ready!
 2025-05-18T19:55:04.721306Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-05-18T19:55:04.721346Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
-2025-05-18T19:55:04.823688Z  INFO runtime: All components are loaded. Spice runtime is ready!
+2025-05-18T19:55:04.823688Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 ```
 
 ## Step 2: Add the TPC-H Benchmark Spicepod
@@ -281,7 +280,7 @@ spice run
 Example output:
 
 ```bash
-2025-05-18T20:20:11.150665Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb, 3600s refresh).
+2025-05-18T20:20:11.150665Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb).
 2025-05-18T20:20:11.151971Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
 2025-05-18T20:20:12.414223Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
 2025-05-18T20:21:00.151971Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits


### PR DESCRIPTION
## Summary

Step 5 of the Accelerated Views recipe has the reader replace the view's
`acceleration.refresh_check_interval: 1h` with `refresh_cron: "* * * * *"`, then
says "observe scheduled refreshes". Its example output, however, was copied
verbatim from Step 3 and still shows:

```
INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb, 3600s refresh).
```

That interval belongs to the Step 3 config the reader just removed. With
`refresh_cron` configured, the runtime omits the interval from the registration
line, so the reader sees `acceleration (duckdb).` and is left wondering whether
the cron setting took effect at all.

This PR corrects that line to what the runtime actually prints.

While in the file, the Step 1 startup transcript was also refreshed — it was
captured on v1.2.2 and three of its seven lines no longer match v2.x:

| Step 1 line | v2.1.4 |
| --- | --- |
| `runtime::init::results_cache: Initialized results cache; …` | `runtime::init::caching: Initialized sql results cache; … hashing algorithm: XXH3, encoding: none` |
| `runtime::init::dataset: No datasets were configured.` | `runtime: No datasets or catalogs were configured.` |
| `runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052` | no longer emitted — the listener was removed in v2.x |

The Flight/HTTP lines are also now logged after "runtime is ready", so the
ordering was corrected to match.

## Verified against

spiceai/spiceai at `v2.1.4` — ran the recipe end-to-end with the current stable
release (`CLI v2.1.4`, `Runtime v2.1.4+models.metal`).

Everything else in the recipe checks out: `spice add spiceai/tpch` loads the same
row counts, the view materializes 10,000 rows (481.43 kiB — identical to the
README), the documented Q21 rows match exactly, the view query is still ~30x
faster than the direct query, and the cron schedule does fire every minute.

## Evidence

Step 3 (`refresh_check_interval: 1h`) — interval present, matching the README:

```
2026-08-07T12:06:27.734343Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb, 3600s refresh).
2026-08-07T12:06:28.748590Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 11ms.
```

Step 5 (`refresh_cron: "* * * * *"`) — no interval, and the cron refresh fires on
the minute boundary:

```
2026-08-07T12:07:36.305898Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb).
2026-08-07T12:07:36.307487Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
2026-08-07T12:07:37.359084Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 51ms.
2026-08-07T12:08:00.363630Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
2026-08-07T12:08:01.304303Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 940ms.
```

Step 1 startup, as emitted by v2.1.4:

```
2026-08-07T12:04:53.582343Z  INFO spiced: Starting runtime v2.1.4+models.metal
2026-08-07T12:04:53.641543Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
2026-08-07T12:04:53.793664Z  INFO runtime: No datasets or catalogs were configured. If this is unexpected, check the Spicepod configuration.
2026-08-07T12:04:53.793714Z  INFO runtime: All components are loaded. Spice runtime is ready!
2026-08-07T12:04:53.868700Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
2026-08-07T12:04:53.871885Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
```