### PR TITLE
Fix mismatched Spicepod names in sqlite and cdc-debezium/sasl-scram recipes

### DIFF
--- a/cdc-debezium/sasl-scram/spicepod.yaml
+++ b/cdc-debezium/sasl-scram/spicepod.yaml
@@ -1,6 +1,6 @@
 version: v1
 kind: Spicepod
-name: cdc-debezium
+name: cdc-debezium-sasl-scram
 datasets:
   - from: debezium:cdc.inventory.customer_addresses
     name: cdc

--- a/sqlite/accelerator/README.md
+++ b/sqlite/accelerator/README.md
@@ -80,7 +80,7 @@ Before:
 ```yaml
 version: v1
 kind: Spicepod
-name: spice_app
+name: sqlite
 datasets:
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips
@@ -98,7 +98,7 @@ After:
 ```yaml
 version: v1
 kind: Spicepod
-name: spice_app
+name: sqlite
 datasets:
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips


### PR DESCRIPTION
## Summary

Both recipes are clone-and-run (`git clone … && cd cookbook/<recipe>`), so the
YAML in the README is meant to show the `spicepod.yaml` the reader already has
checked out. In each case the `name:` differs from the shipped file, so a reader
comparing the two sees a config that doesn't look like theirs:

| Recipe | Shipped `spicepod.yaml` | README YAML |
| --- | --- | --- |
| `sqlite/accelerator` | `name: sqlite` | `name: spice_app` (Before *and* After blocks) |
| `cdc-debezium/sasl-scram` | `name: cdc-debezium` | `name: cdc-debezium-sasl-scram` |

In `sqlite/accelerator` the README is the stale side — Step 3 says "Use text
editor to open `spicepod.yaml`" and then shows a `spice_app` placeholder, so the
README was corrected.

In `cdc-debezium/sasl-scram` the shipped file is the stale side — it carries
`name: cdc-debezium`, copy-pasted from the sibling PLAINTEXT recipe at
`cdc-debezium/spicepod.yaml`, while its own README and directory both use the
descriptive `cdc-debezium-sasl-scram`. So the spicepod was corrected.

Either way the descriptive name wins, which matches the fix direction taken in
#559 for the same defect in `hashed_partitioning`. After this change each
README's YAML block matches its shipped `spicepod.yaml` exactly, name and params
included.

## Verified against

spiceai/spiceai at `v2.1.4`. The `name:` field is the Spicepod's own identifier
and is not referenced anywhere else in either recipe (checked the READMEs,
`Makefile`, `docker-compose.yaml`, and `.env` files), so this is a
documentation-consistency fix with no behavioral effect.

## Evidence

`sqlite/accelerator` was run end-to-end on current stable and is otherwise
accurate — the shipped `name: sqlite` is what the runtime loads, the documented
`trip_distance`/`total_amount` rows match exactly, and enabling the accelerator
behaves as described:

```
2026-08-07T12:11:33.046776Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
2026-08-07T12:12:02.025349Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (sqlite:file), results cache enabled.
2026-08-07T12:12:08.723187Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 6s 696ms.
```

Query before acceleration `3.41s` → after `0.29s`, with the documented values
(`312722.3 / 22.15`, `97793.92 / 36.31`, …) matching row for row.

`cdc-debezium/sasl-scram` is static review only — it needs Docker plus a Kafka +
Debezium + MySQL stack — but the mismatch is visible by reading the two files.