### PR TITLE
Fix ducklake catalog recipe: correct avg_balance type and document write-preview warning

### DIFF
--- a/catalogs/ducklake/README.md
+++ b/catalogs/ducklake/README.md
@@ -172,17 +172,20 @@ LIMIT 5;
 ```
 
 ```text
-+---------+---------------+-------------+
-|  nation | num_customers | avg_balance |
-| varchar |     int64     |   float64   |
-+---------+---------------+-------------+
-| MOROCCO | 72            | 5484.47     |
-| IRAN    | 72            | 4206.76     |
-| CANADA  | 69            | 4116.12     |
-| BRAZIL  | 68            | 3635.3      |
-| JAPAN   | 67            | 4962.46     |
-+---------+---------------+-------------+
++---------+---------------+---------------+
+|  nation | num_customers |  avg_balance  |
+| varchar |     int64     | decimal(19,6) |
++---------+---------------+---------------+
+| MOROCCO | 72            | 5484.470000   |
+| IRAN    | 72            | 4206.760000   |
+| CANADA  | 69            | 4116.120000   |
+| BRAZIL  | 68            | 3635.300000   |
+| JAPAN   | 67            | 4962.460000   |
++---------+---------------+---------------+
 ```
+
+`c_acctbal` is a `decimal(15,2)` column, so `AVG` and `ROUND` return a decimal
+rather than a float — the values print with the full decimal scale.
 
 ## Step 6. Enable read-write access (optional)
 
@@ -205,6 +208,12 @@ Restart Spice and insert data:
 spice run
 ```
 
+Spice logs a warning noting that catalog write access is a preview feature:
+
+```bash
+2026-03-02T10:00:00.000000Z  WARN runtime::datafusion: Access mode 'read_write' is enabled for catalog my_lakehouse. This feature is currently in preview.
+```
+
 ```bash
 spice sql
 ```
@@ -215,11 +224,12 @@ VALUES (5, 'ANTARCTICA', 'A cold and remote region');
 ```
 
 ```text
-+-------+
-| count |
-+-------+
-| 1     |
-+-------+
++--------+
+|  count |
+| uint64 |
++--------+
+| 1      |
++--------+
 ```
 
 Verify the insert:


### PR DESCRIPTION
## Summary

Ran the DuckLake catalog recipe end-to-end on current stable. It works — catalog
discovery, queries, and the read-write insert all behave as described — but three
pieces of documented output don't match what the runtime prints:

1. **`avg_balance` is a decimal, not a float.** Step 5's cross-table query types
   the column as `float64` and shows trimmed values (`5484.47`, `3635.3`).
   `c_acctbal` is `decimal(15,2)`, so `AVG(...)` and `ROUND(..., 2)` return a
   decimal — the runtime reports `decimal(19,6)` and prints the full scale
   (`5484.470000`, `3635.300000`). The row values themselves were correct.

2. **Step 6 doesn't mention the write-access preview warning.** Setting
   `access: read_write` makes Spice log a `WARN` on startup. The recipe presents
   read-write as an ordinary option, so a reader hitting an unexplained warning
   can't tell whether they misconfigured something. Added the line.

3. **The `INSERT` result block is missing its data-type row.** Every other output
   block in this README includes one (this recipe was written for v2's typed
   output); `count` is `uint64`.

## Verified against

spiceai/spiceai at `v2.1.4` (`Runtime v2.1.4+models.metal`), DuckDB CLI `v1.5.5`
— which satisfies the recipe's documented `v1.5.2 or later` prerequisite.

## Evidence

Steps 1–4 match the README exactly, including both catalog log lines:

```
2026-08-07T12:19:43.896551Z  INFO runtime::init::catalog: Registering catalog 'my_lakehouse' for ducklake
2026-08-07T12:19:43.994945Z  INFO runtime::init::catalog: Registered catalog 'my_lakehouse' with 1 schema and 8 tables
```

`SHOW TABLES` returns the documented 9 rows, and the `customer` query matches row
for row. The cross-table query:

```
+---------+---------------+---------------+
|  nation | num_customers |  avg_balance  |
| varchar |     int64     | decimal(19,6) |
+---------+---------------+---------------+
| MOROCCO | 72            | 5484.470000   |
| IRAN    | 72            | 4206.760000   |
| CANADA  | 69            | 4116.120000   |
| BRAZIL  | 68            | 3635.300000   |
| JAPAN   | 67            | 4962.460000   |
+---------+---------------+---------------+
```

Nations and counts match the README; only the type and formatting differed.

Step 6 with `access: read_write`:

```
2026-08-07T12:20:16.374745Z  INFO runtime::init::catalog: Registering catalog 'my_lakehouse' for ducklake
2026-08-07T12:20:16.448891Z  WARN runtime::datafusion: Access mode 'read_write' is enabled for catalog my_lakehouse. This feature is currently in preview.
2026-08-07T12:20:16.448926Z  INFO runtime::init::catalog: Registered catalog 'my_lakehouse' with 1 schema and 8 tables
```

```
> INSERT INTO my_lakehouse.main.region (r_regionkey, r_name, r_comment) VALUES (5, 'ANTARCTICA', 'A cold and remote region');
+--------+
|  count |
| uint64 |
+--------+
| 1      |
+--------+
```

And the insert persists, as the recipe's verification step promises:

```
| 4           | MIDDLE EAST |  foxes boost furiously along the carefully dogged tithes… |
| 5           | ANTARCTICA  | A cold and remote region                                 |
```