### PR TITLE
fix(localpod,duckdb): correct a truncated CSV header and a typo

### DIFF
--- a/duckdb/connector/README.md
+++ b/duckdb/connector/README.md
@@ -68,7 +68,7 @@ Output:
 └──────────┘
 ```
 
-Quit the DuckDB CLI by excuting `.exit`.
+Quit the DuckDB CLI by executing `.exit`.
 
 **Step 3.** Configure the dataset to use the DuckDB database file. Copy and paste the YAML below to `duckdb-qs/spicepod.yaml`.
 

--- a/localpod/data.csv
+++ b/localpod/data.csv
@@ -1,1 +1,1 @@
-timestamp,val1,val
+timestamp,val1,val2


### PR DESCRIPTION
Two small fixes found by actually running the recipes end to end against Spice CLI/runtime **v2.1.1**, as part of a QA pass over `localpod`, `duckdb/connector`, and `json_strings`.

Both were re-verified against `trunk` before including them here — a third finding turned out to be already fixed upstream (see below).

## Fixes

**`localpod/data.csv` — truncated header.** The committed header is `timestamp,val1,val`; the trailing `2` is missing, so the third column loads as `val`. `generate_data.sh` writes `timestamp,val1,val2` and appends rows with two values, so the committed file is simply truncated. The script's own header branch never runs, because the file is committed — which is why this has gone unnoticed.

**`duckdb/connector/README.md`** — "excuting" → "executing".

## Not fixed here: the localpod recipe does not currently work

Worth flagging prominently, because this PR does **not** make `localpod` pass.

On v2.1.1, localpod's synchronized refresh propagation is broken: the child dataset is populated once at startup and never re-syncs. The recipe's final step asks you to confirm 1000 rows in both `time_series` and `local_time_series`; you get **1000 and 0**.

Isolated with two controls:

- **Restart with data already present** → both datasets load 1000 rows. So the localpod connector reads the parent correctly; it's specifically propagation that's dead.
- **Append 1000 more rows to a live runtime** → parent climbs to 2000 across repeated refresh cycles, child stays at 1000 with `MAX(timestamp)` frozen at the boot-time batch.

Corroborating: the README's documented startup line `Localpod dataset local_time_series synchronizing refreshes with parent table time_series` is never emitted on v2.1.1.

That is a runtime defect, not a cookbook one, so it needs an issue against `spiceai/spiceai` rather than a doc change here. Synchronized refresh is the entire point of the recipe, so it will keep failing until that lands.

## Also observed, deliberately not fixed

**`localpod` README step order yields an all-NULL parent.** Starting the runtime against the committed header-only `data.csv` makes the runtime infer all three columns as Arrow `Null`, so the parent's "1,000 rows" are 1,000 NULLs — the tell is `Loaded 1,000 rows (24.00 B)` against the README's documented `48.16 kiB`. Arguably the README should have you generate data before first start, but that reorders the recipe's narrative (the 0/0 query is a deliberate teaching step), so it's a content decision rather than a typo.

**Sample-output drift across all three READMEs.** The captured logs and query results are v1-era: `Loaded dataset: X` instead of `Dataset X registered (...)`, missing/renamed listener lines, `describe` now returning an extra leading `table_schema` column and a type row under each header, and `->` derived columns rendering as `properties -> 'inventory'` rather than `products.properties -> Utf8("inventory")`. All cosmetic, none affect correctness. Refreshing them is a larger change that will re-stale on the next release, so it seemed better left to a deliberate sweep than smuggled in here.

**`duckdb/connector` Step 3 pastes `version: v1`** while `spice init` now scaffolds `version: v2`. v1 still parses fine, so this is drift rather than breakage, and changing it is a judgment call about which version the recipe should teach.

## Already fixed on trunk

The QA run also flagged `localpod/README.md` specifying `file_format: parquet` for a `.csv` source — copy-pasting the README's YAML would break the recipe. That is already corrected on `trunk`; it only reproduced because the run was against a branch 157 commits behind. Nothing to do, noted so the finding isn't re-reported.

## Verification

`localpod` and `duckdb/connector` were both run to completion against these files; `duckdb/connector` passes (TPC-H sf=1, 150,000 customer rows federated through Spice, README query byte-identical). `json_strings` also passes in full and needed no changes.
