### PR TITLE
Fix github recipe: document required token scopes and cap comments at 75

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -9,6 +9,14 @@ This recipe will use the [spiceai/spiceai](https://github.com/spiceai/spiceai) r
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 - GitHub personal access token, [Learn more](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) how to create one.
 
+  Grant the token both of these scopes:
+
+  - `repo` — for the `files`, `issues`, `pulls`, and `commits` datasets.
+  - `read:user` (or `user:email`) — the `stargazers` and `members` datasets select
+    the user `email` field, which GitHub only returns for tokens with one of these
+    scopes. Without it those two datasets fail to load with `Your token has not
+    been granted the required scopes to execute this query`.
+
   [![Watch the Spice.ai local GitHub connector demo](https://img.youtube.com/vi/mxwt0HEF1VQ/hqdefault.jpg)](https://www.youtube.com/embed/mxwt0HEF1VQ)
 
 **Step 0.** Clone the repository if not already cloned.
@@ -24,7 +32,7 @@ cd cookbook/github
 GITHUB_TOKEN=<your_github_token>
 ```
 
-**Setp 2.** Run the Spice runtime with `spice run` from the directory with the `spicepod.yaml` file.
+**Step 2.** Run the Spice runtime with `spice run` from the directory with the `spicepod.yaml` file.
 
 ```bash
 spice run

--- a/github/spicepod.yaml
+++ b/github/spicepod.yaml
@@ -27,7 +27,7 @@ datasets:
       github_query_mode: search
       github_token: ${secrets:GITHUB_TOKEN}
       github_include_comments: all
-      github_max_comments_fetched: 100
+      github_max_comments_fetched: 75 # 75 is the maximum; higher values are clamped
     time_column: updated_at
     acceleration:
       enabled: true


### PR DESCRIPTION
## Summary

Running this recipe as written leaves two of its six datasets permanently
unhealthy, and one configured parameter never takes effect.

**1. `stargazers` and `members` need a scope the README never mentions.**

The prerequisite just says "GitHub personal access token" and links to the
classic-PAT docs. But `spiceai.stargazers` and `apache.members` both select the
user `email` field, and GitHub only returns that for tokens granted `read:user`
or `user:email`. With a `repo`-scoped token — everything else in the recipe
needs no more than that — both datasets fail at load:

```
WARN runtime::init::dataset: Failed to load the dataset spiceai.stargazers (github). Server returned an error: Your token has not been granted the required scopes to execute this query. The 'email' field requires one of the following scopes: ['user:email', 'read:user'], but your token has only been granted the: ['gist', 'read:org', 'repo', 'workflow'] scopes.
```

The prerequisite now lists both scopes and says which datasets need which.

**2. `github_max_comments_fetched: 100` is above the connector's hard cap.**

`MAX_COMMENTS_FETCHED` is 75, and values above it are clamped, so the
configured 100 never applied — the runtime just warns:

```
WARN runtime::dataconnector::github: Due to GitHub API rate limits, the number of comments fetched for dataset spiceai.pulls per pull request is limited to 75.
```

Set to 75, the real maximum, with a comment noting the clamp.

Also fixes a `Setp 2.` typo.

## Verified against

`spiceai/spiceai` at `trunk`:

- `crates/data-connectors/connector-github/src/stargazers.rs:59` and
  `members.rs:52` — both request `email` in the GraphQL selection.
- `crates/data-connectors/connector-github/src/lib.rs:1029` —
  `const MAX_COMMENTS_FETCHED: u32 = 75;`, documented as a "Hard upper bound on
  `github_max_comments_fetched`. Values above this cap are clamped".
- `lib.rs:1189` — the clamp warning text quoted above.

Runtime: Spice v2.1.4 (current stable).

## Evidence

Ran the recipe from its own directory with a `repo`-scoped token. Both warnings
above are verbatim from that run. The datasets that do not need `email` loaded
fine:

```
Loaded 272 rows (3.60 MiB) for dataset spiceai.files in 5s 704ms.
Loaded 305 rows (4.32 MiB) for dataset spiceai.issues in 22s 593ms.
Loaded 300 rows (2.19 MiB) for dataset spiceai.commits in 23s 936ms.
Dataset load summary (after 30s): 5/7 ready, 2 unhealthy, 0 still initializing.
```

The two unhealthy datasets are exactly `spiceai.stargazers` and
`apache.members`. Step 3's issues query ran correctly against the loaded data.

Separately, and **not** changed here: with `github_include_comments: all`,
`spiceai.pulls` did not finish its initial load within ~10 minutes on this run
(the README shows 3s). No error was logged, so this may just be GitHub
secondary rate limiting on the test token rather than a recipe defect — noting
it in case it reproduces for a reviewer.