### PR TITLE
Fix caching/sql_results recipe: correct dataset names, log lines, and Q1 output

### DIFF
--- a/caching/sql_results/README.md
+++ b/caching/sql_results/README.md
@@ -32,22 +32,23 @@ spice add spiceai/tpch
 Observe the Spice runtime terminal for cache initialization. Example output:
 
 ```bash
-2024-08-05T05:25:10.627005Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-08-05T05:26:50.262092Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), results cache enabled.
-2024-08-05T05:26:51.569841Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), results cache enabled.
-2024-08-05T05:26:52.871013Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.
-2024-08-05T05:26:54.201229Z  INFO runtime: Dataset orders registered (s3://spiceai-demo-datasets/tpch/orders/), results cache enabled.
-2024-08-05T05:26:55.583954Z  INFO runtime: Dataset part registered (s3://spiceai-demo-datasets/tpch/part/), results cache enabled.
-2024-08-05T05:26:56.933827Z  INFO runtime: Dataset partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), results cache enabled.
-2024-08-05T05:26:58.182547Z  INFO runtime: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), results cache enabled.
-2024-08-05T05:26:59.501475Z  INFO runtime: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), results cache enabled.
+2026-08-13T12:05:35.255688Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-13T12:06:15.025355Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled. duration_ms=29
+2026-08-13T12:06:16.247663Z  INFO runtime::init::dataset: Dataset tpch.lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:06:17.029597Z  INFO runtime::init::dataset: Dataset tpch.nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb), results cache enabled. duration_ms=5
+2026-08-13T12:06:18.168273Z  INFO runtime::init::dataset: Dataset tpch.orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:06:19.339153Z  INFO runtime::init::dataset: Dataset tpch.part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:06:20.452807Z  INFO runtime::init::dataset: Dataset tpch.partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:06:21.209175Z  INFO runtime::init::dataset: Dataset tpch.region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (duckdb), results cache enabled. duration_ms=1
+2026-08-13T12:06:22.259362Z  INFO runtime::init::dataset: Dataset tpch.supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb), results cache enabled. duration_ms=2
 ```
+
+The `spiceai/tpch` Spicepod registers its datasets under the `tpch` schema (`tpch.lineitem`, `tpch.nation`, …) and accelerates them with DuckDB, which is why each line reports `acceleration (duckdb)`.
 
 Notice the following line confirming the default cache configuration with cached items expiration time of 1 second is loaded.
 
 ```bash
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-13T12:05:35.255688Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```
 
 ## Step 3: Update Cache Configuration
@@ -57,7 +58,7 @@ Stop the Spice runtime using `Ctrl-C`. Open the `spicepod.yaml` file and add a c
 **Before:**
 
 ```yaml
-version: v1
+version: v2
 kind: Spicepod
 name: cache-recipe
 dependencies:
@@ -67,7 +68,7 @@ dependencies:
 **After:**
 
 ```yaml
-version: v1
+version: v2
 kind: Spicepod
 name: cache-recipe
 
@@ -92,16 +93,15 @@ spice run
 Verify the following output is shown in the Spice runtime terminal, confirming that the updated in-memory caching settings (`Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s`) were applied:
 
 ```bash
-2024-08-05T05:29:06.876281Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:29:06.876579Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: XXH3, encoding: none
-2024-08-05T05:29:08.395163Z  INFO runtime: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), results cache enabled.
-2024-08-05T05:29:08.399137Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.
-2024-08-05T05:29:08.399887Z  INFO runtime: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), results cache enabled.
-2024-08-05T05:29:08.402294Z  INFO runtime: Dataset orders registered (s3://spiceai-demo-datasets/tpch/orders/), results cache enabled.
-2024-08-05T05:29:08.404676Z  INFO runtime: Dataset partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), results cache enabled.
-2024-08-05T05:29:08.533932Z  INFO runtime: Dataset part registered (s3://spiceai-demo-datasets/tpch/part/), results cache enabled.
-2024-08-05T05:29:08.573218Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), results cache enabled.
-2024-08-05T05:29:08.712402Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), results cache enabled.
+2026-08-13T12:08:09.299303Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: XXH3, encoding: none
+2026-08-13T12:08:47.417382Z  INFO runtime::init::dataset: Dataset tpch.region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (duckdb), results cache enabled. duration_ms=1
+2026-08-13T12:08:47.421355Z  INFO runtime::init::dataset: Dataset tpch.nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb), results cache enabled. duration_ms=5
+2026-08-13T12:08:47.422105Z  INFO runtime::init::dataset: Dataset tpch.supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:08:47.424512Z  INFO runtime::init::dataset: Dataset tpch.orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:08:47.426894Z  INFO runtime::init::dataset: Dataset tpch.partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:08:47.556150Z  INFO runtime::init::dataset: Dataset tpch.part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:08:47.595436Z  INFO runtime::init::dataset: Dataset tpch.lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:08:47.734620Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled. duration_ms=29
 ```
 
 ## Step 4: Run Queries
@@ -142,32 +142,36 @@ order by
 Observe the query execution time. First run:
 
 ```console
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
-| l_returnflag | l_linestatus | sum_qty     | sum_base_price  | sum_disc_price    | sum_charge          | avg_qty   | avg_price    | avg_disc | count_order |
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
-| A            | F            | 37734107.00 | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522005 | 38273.129734 | 0.049985 | 1478493     |
-| N            | F            | 991417.00   | 1487504710.38   | 1413082168.0541   | 1469649223.194375   | 25.516471 | 38284.467760 | 0.050093 | 38854       |
-| N            | O            | 73416597.00 | 110112303006.41 | 104608220776.3836 | 108796375788.183317 | 25.502437 | 38249.282778 | 0.049996 | 2878807     |
-| R            | F            | 37719753.00 | 56568041380.90  | 53741292684.6040  | 55889619119.831932  | 25.505793 | 38250.854626 | 0.050009 | 1478870     |
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
+| l_returnflag | l_linestatus |    sum_qty    |  sum_base_price |   sum_disc_price  |      sum_charge     |    avg_qty    |   avg_price   |    avg_disc   | count_order |
+|    varchar   |    varchar   | decimal(25,2) |  decimal(25,2)  |   decimal(38,4)   |    decimal(38,6)    | decimal(19,6) | decimal(19,6) | decimal(19,6) |    int64    |
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
+| A            | F            | 37734107.00   | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522006     | 38273.129735  | 0.049985      | 1478493     |
+| N            | F            | 991417.00     | 1487504710.38   | 1413082168.0541   | 1469649223.194375   | 25.516472     | 38284.467761  | 0.050093      | 38854       |
+| N            | O            | 73416597.00   | 110112303006.41 | 104608220776.3836 | 108796375788.183317 | 25.502438     | 38249.282778  | 0.049996      | 2878807     |
+| R            | F            | 37719753.00   | 56568041380.90  | 53741292684.6040  | 55889619119.831932  | 25.505794     | 38250.854626  | 0.050009      | 1478870     |
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
 
-Time: 4.178523666 seconds. 4 rows.
+Time: 0.055311500 seconds. 4 rows.
 ```
 
-Execute the same query again and observe a significant reduction in query execution time, from **4.178523666** to **0.004944792** seconds, due to the result being retrieved from the in-memory cache. The cached item will expire 5 minutes after the initial query execution. Cached run:
+Execute the same query again and observe a significant reduction in query execution time, from **0.055311500** to **0.001090834** seconds, due to the result being retrieved from the in-memory cache. The cached item will expire 5 minutes after the initial query execution. Cached run:
 
 ```console
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
-| l_returnflag | l_linestatus | sum_qty     | sum_base_price  | sum_disc_price    | sum_charge          | avg_qty   | avg_price    | avg_disc | count_order |
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
-| A            | F            | 37734107.00 | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522005 | 38273.129734 | 0.049985 | 1478493     |
-| N            | F            | 991417.00   | 1487504710.38   | 1413082168.0541   | 1469649223.194375   | 25.516471 | 38284.467760 | 0.050093 | 38854       |
-| N            | O            | 73416597.00 | 110112303006.41 | 104608220776.3836 | 108796375788.183317 | 25.502437 | 38249.282778 | 0.049996 | 2878807     |
-| R            | F            | 37719753.00 | 56568041380.90  | 53741292684.6040  | 55889619119.831932  | 25.505793 | 38250.854626 | 0.050009 | 1478870     |
-+--------------+--------------+-------------+-----------------+-------------------+---------------------+-----------+--------------+----------+-------------+
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
+| l_returnflag | l_linestatus |    sum_qty    |  sum_base_price |   sum_disc_price  |      sum_charge     |    avg_qty    |   avg_price   |    avg_disc   | count_order |
+|    varchar   |    varchar   | decimal(25,2) |  decimal(25,2)  |   decimal(38,4)   |    decimal(38,6)    | decimal(19,6) | decimal(19,6) | decimal(19,6) |    int64    |
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
+| A            | F            | 37734107.00   | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522006     | 38273.129735  | 0.049985      | 1478493     |
+| N            | F            | 991417.00     | 1487504710.38   | 1413082168.0541   | 1469649223.194375   | 25.516472     | 38284.467761  | 0.050093      | 38854       |
+| N            | O            | 73416597.00   | 110112303006.41 | 104608220776.3836 | 108796375788.183317 | 25.502438     | 38249.282778  | 0.049996      | 2878807     |
+| R            | F            | 37719753.00   | 56568041380.90  | 53741292684.6040  | 55889619119.831932  | 25.505794     | 38250.854626  | 0.050009      | 1478870     |
++--------------+--------------+---------------+-----------------+-------------------+---------------------+---------------+---------------+---------------+-------------+
 
-Time: 0.004944792 seconds. 4 rows (cached).
+Time: 0.001090834 seconds. 4 rows (cached).
 ```
+
+> **Note:** Because `spiceai/tpch` accelerates its datasets locally with DuckDB, the first (uncached) run already completes in tens of milliseconds. The cached run is still an order of magnitude faster, as the result is returned without planning or executing the query.
 
 The cached result will expire 5 minutes after the initial query execution.
 
@@ -196,16 +200,15 @@ spice run
 Observe the Spice runtime terminal for cache initialization. Example output:
 
 ```console
-2024-08-05T05:25:10.627005Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-08-05T05:25:10.628875Z  INFO runtime: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: Ahash, encoding: none
-2024-08-05T05:26:50.262092Z  INFO runtime: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), results cache enabled.
-2024-08-05T05:26:51.569841Z  INFO runtime: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), results cache enabled.
-2024-08-05T05:26:52.871013Z  INFO runtime: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), results cache enabled.
-2024-08-05T05:26:54.201229Z  INFO runtime: Dataset orders registered (s3://spiceai-demo-datasets/tpch/orders/), results cache enabled.
-2024-08-05T05:26:55.583954Z  INFO runtime: Dataset part registered (s3://spiceai-demo-datasets/tpch/part/), results cache enabled.
-2024-08-05T05:26:56.933827Z  INFO runtime: Dataset partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), results cache enabled.
-2024-08-05T05:26:58.182547Z  INFO runtime: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), results cache enabled.
-2024-08-05T05:26:59.501475Z  INFO runtime: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), results cache enabled.
+2026-08-13T12:10:12.236524Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 300s, hashing algorithm: Ahash, encoding: none
+2026-08-13T12:10:51.184227Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled. duration_ms=29
+2026-08-13T12:10:52.402518Z  INFO runtime::init::dataset: Dataset tpch.lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:10:53.188403Z  INFO runtime::init::dataset: Dataset tpch.nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb), results cache enabled. duration_ms=5
+2026-08-13T12:10:54.327196Z  INFO runtime::init::dataset: Dataset tpch.orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:10:55.498104Z  INFO runtime::init::dataset: Dataset tpch.part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:10:56.611758Z  INFO runtime::init::dataset: Dataset tpch.partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (duckdb), results cache enabled. duration_ms=2
+2026-08-13T12:10:57.368126Z  INFO runtime::init::dataset: Dataset tpch.region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (duckdb), results cache enabled. duration_ms=1
+2026-08-13T12:10:58.418313Z  INFO runtime::init::dataset: Dataset tpch.supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb), results cache enabled. duration_ms=2
 ```
 
 For more information about selecting an appropriate hashing algorithm, refer to the [Results Caching Documentation](https://docs.spiceai.org/features/caching)
@@ -249,11 +252,12 @@ SELECT COUNT(1) FROM tpch.nation;
 sql> SELECT COUNT(1) FROM tpch.nation;
 +-----------------+
 | count(Int64(1)) |
+|      int64      |
 +-----------------+
 | 25              |
 +-----------------+
 
-Time: 0.010650365 seconds. 1 rows.
+Time: 0.014152333 seconds. 1 rows.
 ```
 
 Perform the query again before 10 seconds pass, and the result will be returned from cache without a refresh:
@@ -262,11 +266,12 @@ Perform the query again before 10 seconds pass, and the result will be returned 
 sql> SELECT COUNT(1) FROM tpch.nation;
 +-----------------+
 | count(Int64(1)) |
+|      int64      |
 +-----------------+
 | 25              |
 +-----------------+
 
-Time: 0.002846184 seconds. 1 rows (cached).
+Time: 0.000771375 seconds. 1 rows (cached).
 ```
 
 After 10 seconds, but before 20 seconds, the result will still return from cache but the Spice Runtime will produce a debug log that a background refresh occurred:
@@ -275,25 +280,20 @@ After 10 seconds, but before 20 seconds, the result will still return from cache
 sql> SELECT COUNT(1) FROM tpch.nation;
 +-----------------+
 | count(Int64(1)) |
+|      int64      |
 +-----------------+
 | 25              |
 +-----------------+
 
-Time: 0.002767147 seconds. 1 rows (cached).
+Time: 0.001072708 seconds. 1 rows (cached).
 ```
 
 ```console
-2025-12-09T04:15:33.356304Z DEBUG runtime::datafusion::query::cache: Cache entry is stale (beyond TTL), triggering background revalidation for stale-while-revalidate
-2025-12-09T04:15:33.356535Z DEBUG runtime::datafusion::query::cache: Starting background revalidation task cache_key=4682376472860759847
-2025-12-09T04:15:33.356546Z DEBUG runtime::datafusion::query::cache: Background revalidation: re-executing query with existing plan
-2025-12-09T04:15:33.356946Z DEBUG datafusion_optimizer::analyzer: Analyzer took 0 ms
-2025-12-09T04:15:33.356978Z DEBUG datafusion_optimizer::analyzer: Analyzer took 0 ms
-2025-12-09T04:15:33.357554Z DEBUG datafusion_table_providers::sql::db_connection_pool::duckdbpool: DuckDB connection setup: SET order_by_non_integer_literal = true
-2025-12-09T04:15:33.357941Z DEBUG datafusion_table_providers::sql::db_connection_pool::duckdbpool: DuckDB connection setup: SET TimeZone = UTC
-2025-12-09T04:15:33.359580Z DEBUG runtime::datafusion::query::cache: Background query execution succeeded, collecting batches cache_key=4682376472860759847
-2025-12-09T04:15:33.365280Z DEBUG runtime::datafusion::query::cache: Collected batches, now caching cache_key=4682376472860759847 num_batches=1
-2025-12-09T04:15:33.365303Z DEBUG runtime::datafusion::query::cache: Background revalidation completed successfully and cached cache_key=4682376472860759847
-2025-12-09T04:15:33.365310Z DEBUG runtime::datafusion::query::cache: Background revalidation task completed cache_key=4682376472860759847
+2026-08-13T12:11:52.215396Z DEBUG runtime::datafusion::query::cache: Cache entry is stale (beyond TTL), triggering background revalidation for stale-while-revalidate
+2026-08-13T12:11:52.216617Z DEBUG runtime::datafusion::query::cache: Starting background revalidation task cache_key=8983958663055006108
+2026-08-13T12:11:52.216655Z DEBUG runtime::datafusion::query::cache: Background revalidation: re-executing query with existing plan
+2026-08-13T12:11:52.219391Z DEBUG runtime::datafusion::query::cache: Background revalidation completed successfully and cached cache_key=8983958663055006108
+2026-08-13T12:11:52.219590Z DEBUG runtime::datafusion::query::cache: Background revalidation task completed cache_key=8983958663055006108
 ```
 
 For more information about stale-while-revalidate caching, refer to the [Results Caching Documentation](https://spiceai.org/docs/features/caching)


### PR DESCRIPTION
## Summary

Ran this recipe end to end against Spice **v2.1.5** (current stable). The caching behaviour it teaches is correct — the second query really does return `4 rows (cached)` — but almost every block of expected output has drifted, because the recipe was captured before `spiceai/tpch` registered its datasets under the `tpch` schema and accelerated them with DuckDB.

What the recipe said → what v2.1.5 actually prints:

1. **Dataset registration lines** (3 blocks). The recipe shows `Dataset customer registered (…), results cache enabled.` The runtime prints the schema-qualified name, the acceleration engine, the emitting module, and a duration:
   `runtime::init::dataset: Dataset tpch.customer registered (…), acceleration (duckdb), results cache enabled. duration_ms=29`
   This matters beyond cosmetics: the bare names contradict the recipe's own queries, which correctly use `tpch.lineitem` / `tpch.nation`. Added one sentence explaining the `tpch` schema and DuckDB acceleration.

2. **Phantom metrics log line** (3 blocks). Every output block opened with `runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090`. The metrics server is off by default in v2.x — that line never appears in any of my runs. Removed.

3. **Q1 `avg_*` values are wrong for this recipe's engine.** The recipe shows `avg_qty = 25.522005`, `avg_price = 38273.129734`. On the DuckDB-accelerated path a reader actually gets `25.522006` / `38273.129735` — DuckDB rounds half-up where DataFusion truncates. I confirmed this is engine-specific, not a regression, by running the same Q1 against an unaccelerated `s3://spiceai-demo-datasets/tpch/lineitem/` dataset, which reproduces the recipe's original digits exactly. The `sum_*` and `count_order` values are unchanged and were already correct.

   *Deliberately scoped:* `catalogs/iceberg`, `snowflake`, and the `catalogs/{postgres,mysql,mssql}` recipes carry the same `25.522005` figures, but they compute Q1 through their own engines, so those values are most likely still right. I have not touched them.

4. **Missing data-type row** (5 blocks). `spice sql` on v2.0+ prints a type row under the header (`decimal(19,6)`, `int64`, …) and centres the header names. Added, since these blocks were being rewritten anyway.

5. **Timings.** The recipe narrates "from 4.178523666 to 0.004944792 seconds". Because the data is now DuckDB-accelerated locally, the uncached run completes in ~0.055s, so the dramatic first-run number no longer reproduces. Updated to measured values and added a note that the first run is already fast for this reason — the cached run is still an order of magnitude faster.

6. **`version: v1` → `v2`** in the Before/After spicepod blocks, which are presented as the file's contents. `spice init` on v2.1.5 emits `version: v2`. Both versions are accepted by the runtime, so this is the one cosmetic change in the PR — happy to drop it if you'd rather leave the blocks alone.

Verified as still correct and left unchanged: the `Works with v1.10+` floor (both `caching.sql_results` and `stale_while_revalidate_ttl` exist in `crates/spicepod/src/component/caching.rs` at `v1.10.0`), the default `item ttl: 1s`, `item ttl: 300s` after Step 3, `hashing algorithm: Ahash` after Step 5, the `count(Int64(1))` header and value `25`, the `(cached)` suffix, the stale-while-revalidate flow and its debug log strings, and all seven links.

## Verified against

spiceai/spiceai at `v2.1.5` — [`crates/spicepod/src/component/caching.rs`](https://github.com/spiceai/spiceai/blob/v2.1.5/crates/spicepod/src/component/caching.rs), [`crates/runtime/src/datafusion/query/cache.rs`](https://github.com/spiceai/spiceai/blob/v2.1.5/crates/runtime/src/datafusion/query/cache.rs)

## Evidence

Runtime `v2.1.5+models.metal`. Registration and cache-init lines:

```console
2026-08-13T12:05:35.255688Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
2026-08-13T12:06:15.025355Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled. duration_ms=29
```

Step 4, Q1 run twice in one REPL session with `item_ttl: 5m` (caching works; note the `avg_*` digits):

```console
| A            | F            | 37734107.00   | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522006     | 38273.129735  | 0.049985      | 1478493     |
Time: 0.055311500 seconds. 4 rows.
...
Time: 0.001090834 seconds. 4 rows (cached).
```

Same Q1 against an unaccelerated S3 dataset, reproducing the recipe's original digits and proving the difference is DuckDB vs DataFusion rather than a version regression:

```console
| A            | F            | 37734107.00   | 56586554400.73  | 53758257134.8700  | 55909065222.827692  | 25.522005     | 38273.129734  | 0.049985      | 1478493     |
Time: 5.287894833 seconds. 4 rows.
```

Step 6 stale-while-revalidate, confirming the documented behaviour and log strings:

```console
2026-08-13T12:11:52.215396Z DEBUG runtime::datafusion::query::cache: Cache entry is stale (beyond TTL), triggering background revalidation for stale-while-revalidate
2026-08-13T12:11:52.219590Z DEBUG runtime::datafusion::query::cache: Background revalidation task completed cache_key=8983958663055006108
```

I trimmed two DEBUG lines from that block (`Background query execution succeeded` / `Collected batches, now caching`) plus incidental DataFusion/DuckDB noise, as the existing-plan revalidation path doesn't emit them.