### PR TITLE
Fix stale startup transcripts: remove phantom OpenTelemetry and metrics listener lines

### DIFF
--- a/acceleration/cron/README.md
+++ b/acceleration/cron/README.md
@@ -70,7 +70,6 @@ After the initial load, observe that the `taxi_trips` dataset refreshes on every
 ```console
 2025-06-09T06:27:32.836137Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-06-09T06:27:32.836265Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
-2025-06-09T06:27:33.626524Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-06-09T06:27:33.626530Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-06-09T06:27:33.627071Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
 2025-06-09T06:27:33.630576Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090

--- a/acceleration/indexes/README.md
+++ b/acceleration/indexes/README.md
@@ -30,8 +30,6 @@ spice run
 ```console
 2024-09-30T18:04:26.070605Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-09-30T18:04:26.070827Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-30T18:04:26.070596Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2024-09-30T18:04:26.078670Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-30T18:04:26.270747Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-30T18:04:26.286500Z  INFO runtime: Dataset traces registered (file:large_eth_traces.parquet), acceleration (duckdb:file), results cache enabled.
 2024-09-30T18:04:26.287326Z  INFO runtime: Dataset traces_no_index registered (file:large_eth_traces.parquet), acceleration (duckdb:file), results cache enabled.

--- a/acceleration/partitioning/README.md
+++ b/acceleration/partitioning/README.md
@@ -45,10 +45,8 @@ Confirm in the terminal output the `taxi_trips` dataset has been loaded and acce
 
 ```bash
 Spice.ai runtime starting...
-2024-09-16T21:25:43.305988Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-16T21:25:43.306009Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-09-16T21:25:43.309474Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-16T21:25:43.311587Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-16T21:25:43.507974Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-16T21:25:44.101055Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled.
 2024-09-16T21:25:45.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
@@ -125,10 +123,8 @@ The `bucket(50, PULocationID)` function hashes the `PULocationID` column and dis
 
 ```bash
 2024-09-12T23:08:53.964728Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-09-12T23:08:53.964845Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-12T23:08:53.965420Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-09-12T23:08:53.966168Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-12T23:08:55.308963Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled.
 2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
 2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 24s 380ms.

--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -67,9 +67,7 @@ Result:
 2024/12/12 14:10:00 INFO Checking for latest Spice runtime release...
 2024/12/12 14:10:00 INFO Spice.ai runtime starting...
 2024-12-12T22:10:00.770177Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-12-12T22:10:00.770235Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-12-12T22:10:00.770385Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-12-12T22:10:00.771411Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-12-12T22:10:01.248755Z  INFO runtime::init::embedding: Embedding [embeddings-model] ready to embed
 2024-12-12T22:10:01.248915Z  INFO runtime::init::dataset: Initializing dataset spiceai.files
 2024-12-12T22:10:01.248921Z  INFO runtime::init::dataset: Initializing dataset taxi_trips

--- a/catalogs/iceberg-hadoop/README.md
+++ b/catalogs/iceberg-hadoop/README.md
@@ -42,7 +42,6 @@ The Runtime should start and register the TPCH catalog. Example output:
 2025-08-07T02:51:43.379862Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-08-07T02:51:43.380067Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-08-07T02:51:44.179771Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-08-07T02:51:44.179840Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-07T02:51:44.181135Z  INFO runtime::init::catalog: Registering catalog 'hadoop' for iceberg
 2025-08-07T02:51:44.182557Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-07T02:51:44.350073Z  INFO runtime::init::catalog: Registered catalog 'hadoop' with 1 schema and 8 tables

--- a/catalogs/iceberg/README.md
+++ b/catalogs/iceberg/README.md
@@ -56,10 +56,8 @@ spice run
 2025/01/27 11:08:37 INFO Spice.ai runtime starting...
 2025-01-27T19:08:37.494155Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
 2025-01-27T19:08:37.494905Z  INFO runtime::init::catalog: Registering catalog 'ice' for iceberg
-2025-01-27T19:08:37.499162Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-27T19:08:37.499174Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-01-27T19:08:37.500689Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-27T19:08:37.503376Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-27T19:08:37.696469Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:08:37.697178Z  INFO runtime::init::catalog: Registered catalog 'ice' with 1 schema and 8 tables
 ```

--- a/cayenne/README.md
+++ b/cayenne/README.md
@@ -41,10 +41,8 @@ Confirm in the terminal output the `taxi_trips` dataset has been loaded:
 
 ```bash
 Spice.ai runtime starting...
-2024-09-16T21:25:43.305988Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-16T21:25:43.306009Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-09-16T21:25:43.309474Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-16T21:25:43.311587Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-16T21:25:43.507974Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-16T21:25:44.101055Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
 ```
@@ -104,10 +102,8 @@ datasets:
 
 ```bash
 2024-09-12T23:08:53.964728Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-09-12T23:08:53.964845Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-12T23:08:53.965420Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-09-12T23:08:53.966168Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-12T23:08:55.308963Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled.
 2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
 2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 167ms.

--- a/cdc-debezium/README.md
+++ b/cdc-debezium/README.md
@@ -129,10 +129,8 @@ Observe that it doesn't replay the changes and the data is still there. Only new
 ```bash
 Spice.ai runtime starting...
 2024-07-29T23:22:04.303861Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-07-29T23:22:04.303925Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-07-29T23:22:04.304011Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-29T23:22:04.303850Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-07-29T23:22:04.306271Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-07-29T23:22:04.331209Z  INFO runtime: Dataset cdc registered (debezium:cdc.public.customer_addresses), acceleration (sqlite:file, changes), results cache enabled.
 ```
 

--- a/cdc-debezium/sasl-scram/README.md
+++ b/cdc-debezium/sasl-scram/README.md
@@ -140,10 +140,8 @@ Observe that it doesn't replay the changes and the data is still there. Only new
 ```bash
 Spice.ai runtime starting...
 2024-07-29T23:22:04.303861Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-07-29T23:22:04.303925Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-07-29T23:22:04.304011Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-29T23:22:04.303850Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-07-29T23:22:04.306271Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-07-29T23:22:04.331209Z  INFO runtime: Dataset cdc registered (debezium:cdc.inventory.customer_addresses), acceleration (sqlite:file, changes), results cache enabled.
 ```
 

--- a/client-sdk/gospice-sdk-sample/README.md
+++ b/client-sdk/gospice-sdk-sample/README.md
@@ -34,9 +34,7 @@ Sample runtime logs:
 2024/11/27 16:24:27 INFO Spice.ai runtime starting...
 2024-11-28T00:24:28.411072Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
 2024-11-28T00:24:28.416797Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-11-28T00:24:28.416827Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-11-28T00:24:28.419672Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-11-28T00:24:28.421199Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-11-28T00:24:28.607738Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-28T00:24:29.247902Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2024-11-28T00:24:29.249355Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips

--- a/client-sdk/spice-dotnet-sdk-sample/README.md
+++ b/client-sdk/spice-dotnet-sdk-sample/README.md
@@ -34,7 +34,6 @@ Sample runtime logs:
 2025-08-28T21:08:10.675513Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-08-28T21:08:10.675671Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-08-28T21:08:11.148956Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-08-28T21:08:11.149031Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-28T21:08:11.151175Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
 2025-08-28T21:08:11.162604Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-28T21:08:12.336410Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.

--- a/client-sdk/spice-java-sdk-sample/README.md
+++ b/client-sdk/spice-java-sdk-sample/README.md
@@ -32,8 +32,6 @@ Sample runtime logs:
 
 ```text
 Spice.ai runtime starting...
-2024-07-16T19:16:34.192387Z  INFO spiced: Metrics listening on 127.0.0.1:9090
-2024-07-16T19:16:34.195177Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-07-16T19:16:34.197072Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-07-16T19:16:34.197759Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-16T19:16:34.197770Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051

--- a/client-sdk/spice-rs-sdk-sample/README.md
+++ b/client-sdk/spice-rs-sdk-sample/README.md
@@ -25,10 +25,8 @@ spice run
 2024/11/27 12:46:10 INFO Checking for latest Spice runtime release...
 2024/11/27 12:46:10 INFO Spice.ai runtime starting...
 2024-11-27T20:46:11.343825Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
-2024-11-27T20:46:11.346211Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-11-27T20:46:11.346574Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-11-27T20:46:11.346653Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-11-27T20:46:11.353386Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-11-27T20:46:11.544488Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-27T20:46:12.286180Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2024-11-27T20:46:12.287391Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips

--- a/client-sdk/spicepy-sdk-sample/README.md
+++ b/client-sdk/spicepy-sdk-sample/README.md
@@ -39,9 +39,7 @@ Sample runtime logs:
 2025/01/27 11:54:01 INFO Spice.ai runtime starting...
 2025-01-27T19:54:01.956890Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
 2025-01-27T19:54:01.957325Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-27T19:54:01.957341Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-27T19:54:01.958254Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-27T19:54:01.959596Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-27T19:54:02.157072Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:54:02.866819Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2025-01-27T19:54:02.868324Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips

--- a/deepseek/README.md
+++ b/deepseek/README.md
@@ -56,9 +56,7 @@ Result:
 2025-01-21T22:48:40.569250Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
 2025-01-21T22:48:40.569580Z  INFO runtime::init::model: Loading model [deepseek] from openai:deepseek-chat...
 2025-01-21T22:48:40.569646Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-21T22:48:40.569701Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-21T22:48:40.570139Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-21T22:48:40.572365Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-21T22:48:40.769265Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-21T22:48:41.380306Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2025-01-21T22:48:41.381620Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips

--- a/duckdb/accelerator/README.md
+++ b/duckdb/accelerator/README.md
@@ -43,10 +43,8 @@ Confirm in the terminal output the `taxi_trips` dataset has been loaded:
 
 ```bash
 Spice.ai runtime starting...
-2024-09-16T21:25:43.305988Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-16T21:25:43.306009Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-09-16T21:25:43.309474Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-16T21:25:43.311587Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-16T21:25:43.507974Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-16T21:25:44.101055Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
 ```
@@ -106,10 +104,8 @@ datasets:
 
 ```bash
 2024-09-12T23:08:53.964728Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-09-12T23:08:53.964845Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-12T23:08:53.965420Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-09-12T23:08:53.966168Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-12T23:08:55.308963Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file), results cache enabled.
 2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
 2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 167ms.

--- a/federation/README.md
+++ b/federation/README.md
@@ -46,9 +46,7 @@ spice run
 2025-01-27T19:36:43.199709Z  INFO runtime::init::dataset: Initializing dataset dremio_source_accelerated
 2025-01-27T19:36:43.199537Z  INFO runtime::init::dataset: Initializing dataset s3_source_accelerated
 2025-01-27T19:36:43.201310Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-27T19:36:43.201625Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-27T19:36:43.205435Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-27T19:36:43.209349Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-27T19:36:43.401179Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:36:43.624011Z  INFO runtime::init::dataset: Dataset dremio_source_accelerated registered (dremio:datasets.taxi_trips), acceleration (arrow), results cache enabled.
 2025-01-27T19:36:43.625619Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset dremio_source_accelerated

--- a/ftp/README.md
+++ b/ftp/README.md
@@ -38,7 +38,6 @@ Output:
 2025-06-09T17:59:19.961855Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-06-09T17:59:19.962011Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-06-09T17:59:21.486798Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-06-09T17:59:21.486881Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-06-09T17:59:21.491284Z  INFO runtime::init::dataset: Initializing dataset customers
 2025-06-09T17:59:21.492025Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-06-09T17:59:21.633945Z  INFO runtime::init::dataset: Dataset customers registered (ftp://localhost/customers.csv), acceleration (arrow, 10s refresh), results cache enabled.

--- a/github/README.md
+++ b/github/README.md
@@ -43,7 +43,6 @@ spice run
 2025/07/16 08:17:13 INFO Spice.ai runtime starting...
 2025-07-16T15:17:13.713677Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-07-16T15:17:13.713846Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
-2025-07-16T15:17:14.160058Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-07-16T15:17:14.160281Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-07-16T15:17:14.162142Z  INFO runtime::init::dataset: Initializing dataset spiceai.issues
 2025-07-16T15:17:14.162164Z  INFO runtime::init::dataset: Initializing dataset spiceai.pulls

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -77,7 +77,6 @@ Example output:
 2025-07-07T18:32:50.374154Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-07-07T18:32:50.374183Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-07-07T18:32:50.761270Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-07-07T18:32:50.761326Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-07-07T18:32:50.761704Z  INFO runtime::init::dataset: Initializing dataset stargazers
 2025-07-07T18:32:50.761790Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-07-07T18:32:52.129189Z  INFO runtime::init::dataset: Dataset stargazers registered (graphql:https://api.github.com/graphql), acceleration (arrow), results cache enabled.

--- a/http/README.md
+++ b/http/README.md
@@ -87,7 +87,6 @@ Example output:
 2025-11-09T22:51:05.792981Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s
 2025-11-09T22:51:05.793020Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
 2025-11-09T22:51:05.793031Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
-2025-11-09T22:51:06.136639Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-11-09T22:51:06.137090Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
 2025-11-09T22:51:06.137446Z  INFO runtime::init::dataset: Dataset tvmaze initializing...
 2025-11-09T22:51:06.137756Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090

--- a/imap/README.md
+++ b/imap/README.md
@@ -42,7 +42,6 @@ IMAP_PASSWORD=my_password
 Once started, the mailbox should be registered in the Spice Runtime logs:
 
 ```console
-2025-02-02T23:25:23.876322Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-02-02T23:25:23.876386Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-02-02T23:25:23.877307Z  INFO runtime::init::dataset: Initializing dataset awesome_mailbox
 2025-02-02T23:25:23.877477Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -53,7 +53,6 @@ Output:
 ```bash
 2024-11-27T21:55:48.116059Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 0.0.0.0:9090
 2024-11-27T21:55:48.116119Z  INFO runtime::flight: Spice Runtime Flight listening on 0.0.0.0:50051
-2024-11-27T21:55:48.116053Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 0.0.0.0:50052
 2024-11-27T21:55:48.116548Z  INFO runtime::http: Spice Runtime HTTP listening on 0.0.0.0:8090
 2024-11-27T21:55:48.116578Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```

--- a/llm-memory/README.md
+++ b/llm-memory/README.md
@@ -33,10 +33,8 @@ spice run
 2025-01-27T19:29:50.856594Z  INFO runtime::init::dataset: Initializing dataset llm_memory
 2025-01-27T19:29:50.857758Z  INFO runtime::init::model: Loading model [chat_model] from openai:gpt-4o...
 2025-01-27T19:29:50.858938Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-27T19:29:50.859020Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-27T19:29:50.859210Z  INFO runtime::init::dataset: Dataset llm_memory registered (memory:store).
 2025-01-27T19:29:50.865516Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-27T19:29:50.869294Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-27T19:29:51.058851Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:29:52.248966Z  INFO runtime::init::model: Model [chat_model] deployed, ready for inferencing
 ```

--- a/models/filesystem/README.md
+++ b/models/filesystem/README.md
@@ -63,10 +63,8 @@ spice run
 2025-01-31T07:53:12.600614Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
 2025-01-31T07:53:12.600965Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-31T07:53:12.601384Z  INFO runtime::init::model: Loading model [local_model] from file:phi-3-mini...
-2025-01-31T07:53:12.601668Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-31T07:53:12.601718Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-01-31T07:53:12.604584Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-31T07:53:12.610797Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-31T07:53:20.388313Z  INFO runtime::init::model: Model [local_model] deployed, ready for inferencing
 ```
 

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -66,10 +66,8 @@ Result:
 ```shell
 2025/01/21 01:19:43 INFO Checking for latest Spice runtime release...
 2025/01/21 01:19:44 INFO Spice.ai runtime starting...
-2025-01-20T16:19:45.056778Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-20T16:19:45.057495Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-20T16:19:45.057562Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-20T16:19:45.061178Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-20T16:19:45.544466Z  INFO runtime::init::embedding: Embedding [embeddings-model] ready to embed
 2025-01-20T16:19:45.544649Z  INFO runtime::init::dataset: Initializing dataset spiceai.docs
 2025-01-20T16:19:45.544669Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none

--- a/mssql/README.md
+++ b/mssql/README.md
@@ -32,10 +32,8 @@ instances are accessible from within Spice to demonstrate that you can query acr
    ```shell
    Checking for latest Spice runtime release...
    Spice.ai runtime starting...
-   2024-09-23T19:43:29.074453Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
    2024-09-23T19:43:29.074284Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
    2024-09-23T19:43:29.075193Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-   2024-09-23T19:43:29.091737Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
    2024-09-23T19:43:29.274085Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
    2024-09-23T19:43:29.280949Z  WARN tiberius::client::tls_stream::rustls_tls_stream: Trusting the server certificate without validation.
    2024-09-23T19:43:29.281023Z  WARN tiberius::client::tls_stream::rustls_tls_stream: Trusting the server certificate without validation.

--- a/mysql/connector/README.md
+++ b/mysql/connector/README.md
@@ -180,10 +180,8 @@ Confirm in the terminal output the `sample_data` dataset has been loaded:
 ```bash
 2025/01/13 11:52:51 INFO Spice.ai runtime starting...
 2025-01-13T19:52:51.473621Z  INFO runtime::init::dataset: Initializing dataset sample_data
-2025-01-13T19:52:51.474059Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-13T19:52:51.474795Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-13T19:52:51.474869Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-13T19:52:51.481201Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-13T19:52:51.491591Z  INFO runtime::init::dataset: Dataset sample_data registered (mysql:spice_demo.sample_data).
 2025-01-13T19:52:51.673260Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```

--- a/nvidia-nim/ec2/README.md
+++ b/nvidia-nim/ec2/README.md
@@ -128,10 +128,8 @@ spice run
 2025/01/17 12:09:53 INFO Spice.ai runtime starting...
 2025-01-17T03:09:54.439824Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
 2025-01-17T03:09:54.440000Z  INFO runtime::init::model: Loading model [phi] from openai:microsoft/phi-3-mini-4k-instruct...
-2025-01-17T03:09:54.440281Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-17T03:09:54.440275Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-01-17T03:09:54.440520Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-17T03:09:54.441354Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-17T03:09:54.639962Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-17T03:09:56.431766Z  INFO runtime::init::model: Model [phi] deployed, ready for inferencing
 ```

--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -33,7 +33,6 @@ spice run
 2025-08-25T23:34:31.163684Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-08-25T23:34:31.164965Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
 2025-08-25T23:34:31.165957Z  INFO runtime::init::model: Loading model [gpt-4o-responses] from openai:gpt-4o...
-2025-08-25T23:34:31.163684Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-25T23:34:31.177013Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-25T23:34:31.992304Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2025-08-25T23:34:31.993720Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips

--- a/openai_sdk/README.md
+++ b/openai_sdk/README.md
@@ -29,11 +29,9 @@ Output:
 ```bash
 2025/01/13 13:27:41 INFO Spice.ai runtime starting...
 2025-01-13T21:27:41.702275Z  INFO runtime::init::dataset: Initializing dataset taxi_trips
-2025-01-13T21:27:41.703569Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-13T21:27:41.704347Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-13T21:27:41.704514Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-01-13T21:27:41.703575Z  INFO runtime::init::model: Loading model [openai] from openai:gpt-4o...
-2025-01-13T21:27:41.713543Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-13T21:27:41.902271Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-13T21:27:42.242310Z  INFO runtime::init::model: Model [openai] deployed, ready for inferencing
 2025-01-13T21:27:42.576976Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -56,7 +56,6 @@ This will start the Spice runtime, which will connect to Oracle and load the TPC
 2025-07-07T20:41:42.884157Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-07-07T20:41:42.884197Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-07-07T20:41:43.431896Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-07-07T20:41:43.431929Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-07-07T20:41:43.432215Z  INFO runtime::init::dataset: Initializing dataset lineitem
 2025-07-07T20:41:43.432253Z  INFO runtime::init::dataset: Initializing dataset orders
 2025-07-07T20:41:43.432218Z  INFO runtime::init::dataset: Initializing dataset customer

--- a/postgres/connector/README.md
+++ b/postgres/connector/README.md
@@ -153,8 +153,6 @@ spice run
 2025-03-31T18:58:05.268188Z  INFO runtime::init::dataset: Initializing dataset sample_data
 2025-03-31T18:58:05.269626Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-03-31T18:58:05.272079Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-03-31T18:58:05.272103Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
-2025-03-31T18:58:05.272500Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-03-31T18:58:05.278168Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-03-31T18:58:05.315178Z  INFO runtime::init::dataset: Dataset sample_data registered (postgres:sample_data), results cache enabled.
 2025-03-31T18:58:05.416584Z  INFO runtime: All components are loaded. Spice runtime is ready!

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -60,7 +60,6 @@ You should see this output in your terminal window:
 2025-08-01T01:15:06.022725Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-08-01T01:15:06.022949Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
 2025-08-01T01:15:06.438166Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-08-01T01:15:06.438359Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-01T01:15:06.441831Z  INFO runtime::init::dataset: Dataset region initializing...
 2025-08-01T01:15:06.441851Z  INFO runtime::init::dataset: Dataset orders initializing...
 2025-08-01T01:15:06.441912Z  INFO runtime::init::dataset: Dataset supplier initializing...
@@ -210,7 +209,6 @@ You should see this output in your terminal window:
 2025-08-01T01:15:40.066625Z  INFO spiced: Starting runtime v1.6.0-unstable-build.184ebb772
 2025-08-01T01:15:40.069247Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-08-01T01:15:40.069468Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
-2025-08-01T01:15:40.306607Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-08-01T01:15:40.306719Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-08-01T01:15:40.308188Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-01T01:15:40.308507Z  INFO runtime::init::dataset: Dataset orders initializing...

--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -40,10 +40,8 @@ datasets:
 ```bash
 Spice.ai runtime starting...
 2024-08-05T14:35:55.354700Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-08-05T14:35:55.354775Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-08-05T14:35:55.354672Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-08-05T14:35:55.354940Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-08-05T14:35:55.362078Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-08-05T14:35:56.584438Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2024-08-05T14:35:56.585614Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
 2024-08-05T14:36:06.654548Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 10s 68ms.

--- a/s3/README.md
+++ b/s3/README.md
@@ -23,10 +23,8 @@ The following output is shown in the terminal:
 2024/11/27 15:00:11 INFO Checking for latest Spice runtime release...
 2024/11/27 15:00:11 INFO Spice.ai runtime starting...
 2024-11-27T23:00:11.849307Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
-2024-11-27T23:00:11.850273Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-11-27T23:00:11.850338Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-11-27T23:00:11.850888Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-11-27T23:00:11.858487Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-11-27T23:00:12.052740Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```
 
@@ -278,8 +276,6 @@ If the login credentials were entered correctly, the dataset will have loaded in
 
 ```bash
 Spice.ai runtime starting...
-2024-07-23T00:33:50.544366Z  INFO spiced: Metrics listening on 127.0.0.1:9090
-2024-07-23T00:33:50.547612Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-07-23T00:33:50.549731Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-07-23T00:33:50.552016Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-23T00:33:50.552044Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051

--- a/search/README.md
+++ b/search/README.md
@@ -82,7 +82,6 @@ You should see this output:
 2025-09-26T15:21:38.225135Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-09-26T15:21:38.229824Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
 2025-09-26T15:21:38.230575Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
-2025-09-26T15:21:38.658824Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-09-26T15:21:38.658888Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-09-26T15:21:38.678694Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-09-26T15:21:47.550688Z  INFO runtime::init::embedding: Embedding Model potion_128m ready

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -54,10 +54,8 @@ The following output is shown in the Spice runtime terminal:
 
 ```bash
 Spice.ai runtime starting...
-2024-07-23T00:20:01.012063Z  INFO spiced: Metrics listening on 127.0.0.1:9090
 2024-07-23T00:20:01.044050Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-23T00:20:01.044108Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-07-23T00:20:01.045430Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-07-23T00:20:01.047970Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```
 

--- a/spark/README.md
+++ b/spark/README.md
@@ -87,9 +87,7 @@ spice run
 2025/01/14 02:52:59 INFO Spice.ai runtime starting...
 2025-01-13T17:53:00.171638Z  INFO runtime::init::dataset: No datasets were configured. If this is unexpected, check the Spicepod configuration.
 2025-01-13T17:53:00.181202Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-01-13T17:53:00.181420Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2025-01-13T17:53:00.185632Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-01-13T17:53:00.185712Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-01-13T17:53:00.196585Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 ```
 
@@ -235,7 +233,6 @@ Spice.ai OSS CLI v1.4.0-unstable-build.8eee8ad4b
 2025-06-10T01:46:32.725076Z  INFO spiced: Starting runtime v1.4.0-unstable-build.8eee8ad4b+models
 2025-06-10T01:46:32.742491Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-06-10T01:46:32.744098Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
-2025-06-10T01:46:33.592583Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2025-06-10T01:46:33.592555Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2025-06-10T01:46:33.599924Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-06-10T01:46:33.602360Z  INFO runtime::init::dataset: Initializing dataset nyc_taxis

--- a/sqlite/accelerator/README.md
+++ b/sqlite/accelerator/README.md
@@ -28,10 +28,8 @@ spice run
 Output:
 
 ```bash
-2024-09-10T06:54:36.184935Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-09-10T06:54:36.185086Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-09-10T06:54:36.187305Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-10T06:54:36.193225Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-09-10T06:54:36.385124Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-10T06:54:37.020990Z  INFO runtime: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
 ```

--- a/tls/README.md
+++ b/tls/README.md
@@ -134,12 +134,10 @@ spice run -- --tls-enabled true --tls-certificate-file ./spiced.crt --tls-key-fi
 ```
 
 ```bash
-2024-08-05T19:59:09.203647Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
 2024-08-05T19:59:09.203554Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-08-05T19:59:09.204194Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-08-05T19:59:09.205240Z  INFO runtime: Endpoints secured with TLS using certificate: CN=spiced.localhost, OU=IT, O=Widgets, Inc., L=Seattle, S=Washington, C=US
 2024-08-05T19:59:09.205622Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-08-05T19:59:09.211074Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 2024-08-05T19:59:09.286775Z  INFO runtime: Dataset customer_addresses registered (postgres:customer_addresses), results cache enabled.
 ```
 


### PR DESCRIPTION
## Summary

41 recipe READMEs print a startup transcript containing one or both of these lines:

```
INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090
```

Neither appears when a reader follows the recipe on current stable:

- **OpenTelemetry line** — the string `OpenTelemetry listening` does not exist anywhere in the `v2.1.5` source tree, and `--open_telemetry` is now a deprecated no-op (`bin/spiced/src/lib.rs:673` logs "`--open_telemetry` is deprecated and has no effect"). There is no 50052 listener to report.
- **Metrics line** — the Prometheus metrics server is opt-in. `crates/runtime/src/metrics_server/mod.rs:97` emits it, but only via `with_metrics_server_opt(args.metrics, ...)` (`bin/spiced/src/lib.rs:598`), and `spiced --help` documents `--metrics <BIND_ADDRESS>` as "(disabled by default)". A plain `spice run` never prints it.

Three READMEs also carried the older `INFO spiced: Metrics listening on ...` wording, which is stale on both counts (target and opt-in).

**Deliberately left in place:**

- `docker/` — its `Dockerfile` runs `spiced ... --metrics 0.0.0.0:9090`, so the metrics line is real there.
- `kubernetes/` — the published Helm chart (`spiceai-2.1.5`) has a default `command:` of `spiced --http 0.0.0.0:8090 --metrics 0.0.0.0:9090 --flight 0.0.0.0:50051`, so the metrics line is real there too. Its phantom OpenTelemetry line was removed.

These transcripts carry other pre-v2 staleness (old timestamps, `runtime:` vs `runtime::init::dataset` targets) that is being refreshed recipe-by-recipe; this PR is limited to lines that are never emitted at all.

## Verified against

spiceai/spiceai at `v2.1.5`:

- `crates/runtime/src/metrics_server/mod.rs:97` — the only `Metrics listening` emitter
- `bin/spiced/src/lib.rs:598` — `with_metrics_server_opt(args.metrics, ...)`
- `bin/spiced/src/lib.rs:673` — `--open_telemetry` deprecated, no effect
- `git grep "OpenTelemetry listening" v2.1.5` — no matches
- Helm chart `spiceai-2.1.5` from https://helm.spiceai.org — `templates/deployment.yaml` default command

## Evidence

Ran two recipes end-to-end on Spice `v2.1.5` (macOS, `spice run`). Full startup output for `sqlite/accelerator`:

```
INFO spiced: Starting runtime v2.1.5+models.metal
INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
INFO runtime::init::dataset: Dataset taxi_trips initializing...
INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled. duration_ms=1
INFO runtime: All components are loaded. Spice runtime is ready!
```

No metrics or OpenTelemetry line. Re-running the same binary with `spiced --metrics 127.0.0.1:9090` does print `INFO runtime::metrics_server: Spice Runtime Metrics listening on 127.0.0.1:9090`, confirming the line is opt-in rather than removed — which is why the `docker/` and `kubernetes/` occurrences were kept.