### PR TITLE
Fix docker recipe: correct the spice status transcript

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -68,7 +68,6 @@ spiceai-mysql-sakila  | 2024-12-19T01:36:24.416215Z 0 [System] [MY-015015] [Serv
 spiceai-mysql-sakila  | 2024-12-19T01:36:24.544874Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.1.0) starting as process 7
 spiceai-mysql-sakila  | 2024-12-19T01:36:24.547827Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
 ...
-spiced-container      | 2024-12-19T01:36:24.772197Z  INFO runtime::opentelemetry: Spice Runtime OpenTelemetry listening on 127.0.0.1:50052
 spiced-container      | 2024-12-19T01:36:24.772246Z  INFO runtime::metrics_server: Spice Runtime Metrics listening on 0.0.0.0:9090
 spiced-container      | 2024-12-19T01:36:24.772267Z  INFO runtime::flight: Spice Runtime Flight listening on 0.0.0.0:50051
 spiced-container      | 2024-12-19T01:36:24.772389Z  INFO runtime::http: Spice Runtime HTTP listening on 0.0.0.0:8090
@@ -90,12 +89,13 @@ Dataset films registered (mysql:film), acceleration (arrow), results cache enabl
 You now have Spice running as a Docker container with Flight and HTTP ports exposed on ports `50051` and `8090`. Run `spice status` to access Spice.ai runtime information.
 
 ```shell
-NAME          ENDPOINT        STATUS
-http          0.0.0.0:8090    Ready
-flight        0.0.0.0:50051   Ready
-metrics       0.0.0.0:9090    Ready
-opentelemetry 127.0.0.1:50052 Ready
+http                 0.0.0.0:8090                   Ready
+flight               0.0.0.0:50051                  Ready
+metrics              0.0.0.0:9090                   Ready
+opentelemetry        0.0.0.0:50051                  Ready
 ```
+
+> **Note:** OpenTelemetry is served on the same gRPC port as Flight, so both rows report the Flight endpoint.
 
 ### SQL Search
 


### PR DESCRIPTION
## Summary

The recipe tells the reader to run `spice status` and shows this output:

```
NAME          ENDPOINT        STATUS
http          0.0.0.0:8090    Ready
flight        0.0.0.0:50051   Ready
metrics       0.0.0.0:9090    Ready
opentelemetry 127.0.0.1:50052 Ready
```

Two things are wrong on current stable:

1. **There is no header row.** `bin/spice/src/commands/status.rs:76` prints one line per component with `println!("{:<20} {:<30} {}", c.name, c.endpoint, c.status)` — nothing else. The transcript's column widths don't match the padded output either.
2. **The `opentelemetry` row does not report a 50052 listener.** `crates/runtime/src/http/v1/status.rs` builds that row with a comment — "OpenTelemetry is served on the same gRPC port as Flight" — and sets `endpoint: flight_url`. For this recipe that's `0.0.0.0:50051`. The `127.0.0.1:50052` value is also internally inconsistent with the rest of the block, which binds `0.0.0.0`.

Also removed the startup line claiming `Spice Runtime OpenTelemetry listening on 127.0.0.1:50052`; that string no longer exists in the runtime and `--open_telemetry` is a deprecated no-op. The `Spice Runtime Metrics listening on 0.0.0.0:9090` line is kept — this recipe's `Dockerfile` passes `--metrics 0.0.0.0:9090`, so it is real here.

## Verified against

spiceai/spiceai at `v2.1.5`:

- `bin/spice/src/commands/status.rs:76` — row printing, no header
- `crates/runtime/src/http/v1/status.rs` — `name: "opentelemetry" ... endpoint: flight_url`
- `git grep "OpenTelemetry listening" v2.1.5` — no matches

## Evidence

Ran `spiced --http 127.0.0.1:8090 --metrics 127.0.0.1:9090 --flight 127.0.0.1:50051` on Spice `v2.1.5`, then `spice status`:

```
http                 127.0.0.1:8090                 Ready
flight               127.0.0.1:50051                Ready
metrics              127.0.0.1:9090                 Ready
opentelemetry        127.0.0.1:50051                Ready
```

No header, and `opentelemetry` mirrors the Flight endpoint. The recipe's block is updated to the same layout with this recipe's `0.0.0.0` bind addresses.

Docker was not available in this environment, so the surrounding compose output was not re-captured; this PR is limited to the `spice status` block and the phantom listener line, both verified against source and a live `v2.1.5` runtime.