### PR TITLE
recipe(cloud-connect-dev): add a development-machine Cloud Connect tutorial

### DIFF
--- a/.github/workflows/validate-cloud-connect-dev.yml
+++ b/.github/workflows/validate-cloud-connect-dev.yml
@@ -1,0 +1,37 @@
+name: Validate cloud-connect-dev
+
+# Deterministic checks only: the cloud-connect-dev validation needs no Spice
+# Cloud account and no credentials, so it runs on forks and pull requests.
+# The cloud-backed steps of the recipe (enrollment, project creation,
+# deployment) are covered by the credentialed release gate, not here.
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - 'cloud-connect-dev/**'
+      - '.github/workflows/validate-cloud-connect-dev.yml'
+  pull_request:
+    paths:
+      - 'cloud-connect-dev/**'
+      - '.github/workflows/validate-cloud-connect-dev.yml'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Install the Spice CLI
+        run: |
+          curl -fsSL https://install.spiceai.org | /bin/bash
+          echo "$HOME/.spice/bin" >> "$GITHUB_PATH"
+
+      - name: Validate the recipe
+        run: ./cloud-connect-dev/validate.sh

--- a/.github/workflows/validate-cloud-connect-dev.yml
+++ b/.github/workflows/validate-cloud-connect-dev.yml
@@ -33,5 +33,17 @@ jobs:
           curl -fsSL https://install.spiceai.org | /bin/bash
           echo "$HOME/.spice/bin" >> "$GITHUB_PATH"
 
+      # Exit 2 means the installed CLI predates the flow this recipe documents,
+      # so nothing was asserted. Surface that as a notice rather than a pass or
+      # a failure: the release that ships the flow turns it into a real run.
       - name: Validate the recipe
-        run: ./cloud-connect-dev/validate.sh
+        run: |
+          set +e
+          ./cloud-connect-dev/validate.sh
+          code=$?
+          set -e
+          if [ "$code" -eq 2 ]; then
+            echo "::notice title=cloud-connect-dev not validated::The installed Spice CLI predates v2.2; the recipe's assertions did not run."
+            exit 0
+          fi
+          exit "$code"

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Welcome to the Spice.ai OSS Cookbook—a comprehensive collection of recipes for
 
 ### Deployment and Installation
 
+- [Cloud Connect on a Development Machine](./cloud-connect-dev/README.md) - Connect a directory to Spice Cloud with one command, deploy without restarting, and reconnect.
 - [Deploying to Kubernetes](./kubernetes/README.md)
 - [Running in Docker](./docker/README.md)
 - [Sidecar Deployment Architecture](./architectures/sidecar/README.md)

--- a/cloud-connect-dev/.gitignore
+++ b/cloud-connect-dev/.gitignore
@@ -1,0 +1,3 @@
+# Cloud Connect writes the enrolled instance identity and the cloud-managed
+# Spicepod here. Neither belongs in version control.
+.spice/

--- a/cloud-connect-dev/.gitignore
+++ b/cloud-connect-dev/.gitignore
@@ -1,3 +1,6 @@
 # Cloud Connect writes the enrolled instance identity and the cloud-managed
 # Spicepod here. Neither belongs in version control.
 .spice/
+# The demo password lives in the shell, never in a file.
+.env
+.env.local

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -156,19 +156,13 @@ runtime:
     captured_output: truncated
 ```
 
-Deploy the Spicepod. Check the instance:
-
-```shell
-spice connect status
-```
-
-The status includes this line:
+Deploy the Spicepod. The runtime names the sections that need a start, in the terminal running the instance:
 
 ```text
-restart: required for runtime
+INFO Spice Cloud Connect: applied the deployed spicepod (1 datasets, 0 models, 0 catalogs, 1 views); runtime takes effect when this instance next starts
 ```
 
-The instance continues to serve queries until you restart it.
+The project in Spice Cloud reports the same pending sections. The instance continues to serve queries until you restart it.
 
 ## 5. Restart and reconnect
 
@@ -180,11 +174,7 @@ spice run
 
 You do not need to run `spice connect` again. The existing identity reconnects the instance.
 
-Confirm that the restart is no longer required:
-
-```shell
-spice connect status
-```
+The instance now serves the deployed `runtime` settings, and the deployment reports nothing pending.
 
 > **Warning:** Spice Cloud invalidates the identity if the instance stays offline for more than 30 days. Enroll the instance again to reconnect it.
 

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -41,7 +41,9 @@ spice connect status
 
 ## 2. Deploy a live change
 
-In the Spice Cloud portal, add this view to the project Spicepod:
+A deployment replaces the Spicepod the instance runs. In the Spice Cloud portal, open the project Spicepod and paste in the contents of this recipe's local `spicepod.yaml`, so the deployed Spicepod still defines the `data` dataset.
+
+Add this view to the project Spicepod, below the datasets:
 
 ```yaml
 views:
@@ -78,13 +80,15 @@ docker compose exec postgres \
   -c 'SELECT count(*) FROM public.orders;'
 ```
 
-In the project **Secrets** page, add this secret:
+In the portal, open the project's **Settings → Secrets** and add:
 
 | Name          | Value                              |
 | ------------- | ---------------------------------- |
-| `pg_password` | Value of `$SPICE_DEMO_PG_PASSWORD` |
+| `PG_PASSWORD` | Value of `$SPICE_DEMO_PG_PASSWORD` |
 
-Add this dataset to the project Spicepod:
+Secret names are matched exactly. A Spicepod that references a name the project does not define is rejected when you deploy it, and the portal names the closest match it holds.
+
+Add this dataset to the project Spicepod in the portal — not to the local `spicepod.yaml`:
 
 ```yaml
 datasets:
@@ -95,7 +99,7 @@ datasets:
       pg_port: "55432"
       pg_db: spice_demo
       pg_user: spice_reader
-      pg_pass: ${secrets:pg_password}
+      pg_pass: ${secrets:PG_PASSWORD}
       pg_sslmode: disable
 ```
 
@@ -120,8 +124,6 @@ The query returns:
 | globex   | 4550        |
 | initech  | 31875       |
 +----------+-------------+
-
-Time: 0.003107 seconds. 3 rows.
 ```
 
 Confirm the delivery:
@@ -131,7 +133,7 @@ spice connect status
 ```
 
 ```text
-  secrets:     1 delivered: pg_password
+  secrets:     1 delivered: PG_PASSWORD
 ```
 
 Status reports secret names. Values stay in the runtime process.

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -261,7 +261,7 @@ Spice Cloud Connect: not connected (<path>/cloud-connect-dev)
 - **Nothing is committed.** `.spice/` is gitignored: the issued identity, the cloud-managed Spicepod, and the delivered-secrets cache all live there. `validate.sh` checks it.
 - **`spice connect` needs a terminal.** It is interactive; on a non-interactive stdin it exits and points at `spiced --token <enrollment-key>` for [headless enrollment](https://spiceai.org/docs/deployment/cloud-connect/headless).
 - **Cancelling is safe.** `Esc` or `Ctrl-C` at any prompt is a clean exit. An interrupted enrollment resumes on the next run rather than creating a duplicate instance or project.
-- **This recipe is foreground only.** To keep the instance running across reboots on Linux, see [Cloud Connect as a persistent service](https://spiceai.org/docs/deployment/cloud-connect/service). The managed service lifecycle does not yet support macOS or Windows; there, the foreground flow in this recipe is the development story.
+- **This recipe is foreground only.** To keep the instance running across reboots, install the managed service — systemd on Linux, launchd on macOS. See [Cloud Connect as a persistent service](https://spiceai.org/docs/deployment/cloud-connect/service). Windows has no managed service; there, the foreground flow in this recipe is the development story.
 
 ## Learn more
 

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -205,11 +205,11 @@ unset SPICE_DEMO_PG_PASSWORD
 
 ## Run as a service
 
-To keep the instance running after you close the terminal, see [Cloud Connect as a service](https://spiceai.org/docs/deployment/cloud-connect/service).
+To keep the instance running after you close the terminal, see [Cloud Connect as a service](https://spiceai.org/docs/deployment/cloud/cloud-connect/service).
 
 Windows does not support the managed service.
 
 ## Learn more
 
-- [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect)
+- [Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect)
 - [`spice connect` reference](https://spiceai.org/docs/cli/reference/connect)

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -1,0 +1,269 @@
+# Cloud Connect on a Development Machine
+
+Works with `v2.2+`
+
+Connect this directory to Spice Cloud with one command, watch a deployment apply to the running instance without a restart, stop it, and reconnect.
+
+The recipe is deliberately minimal: one public dataset, no infrastructure, no credentials on disk. What it demonstrates is the [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect) lifecycle on the machine you develop on.
+
+You will:
+
+1. Connect this directory and get a running instance attached to a new Spice Cloud project.
+2. Deploy a change that applies live, with no restart and no serving gap.
+3. Deploy a change that needs a restart, and see exactly which settings are pending.
+4. Stop with `Ctrl-C` and reconnect with `spice run` — the identity survives.
+5. Release the instance and delete its project.
+
+## Prerequisites
+
+- The Spice CLI, `v2.2.0` or later:
+
+  ```bash
+  curl https://install.spiceai.org | /bin/bash
+  ```
+
+- A Spice Cloud account with the **owner** or **admin** role in at least one organization. Those roles may enroll an instance and create a project; `member` may not.
+- Outbound HTTPS to `api.spice.ai` and to the Cloud Connect gateway.
+
+No `spice login` beforehand — `spice connect` runs login inline if needed.
+
+**Cost:** a Spice Cloud project on the free tier. Step 6 deletes it.
+
+## 1. Connect
+
+Clone the cookbook and enter this recipe. The directory name is the project-name default, so run from `cloud-connect-dev` exactly:
+
+```bash
+git clone https://github.com/spiceai/cookbook.git
+cd cookbook/cloud-connect-dev
+spice connect
+```
+
+With no saved login, `spice connect` offers two choices rather than failing:
+
+```console
+? Connect this directory to Spice Cloud ›
+❯ Log in to Spice Cloud (recommended)
+  Use an enrollment key
+```
+
+Choose **Log in to Spice Cloud**. Login runs in the same process and the connect flow continues — there is no second command.
+
+Next the organization. If your login is owner or admin in exactly one, it is named and used:
+
+```console
+Organization: <org> (owner)
+```
+
+If several are eligible, pick one. Then the project name, defaulted from this directory:
+
+```console
+? Project name › cloud-connect-dev
+```
+
+Press Enter to accept it. If the name is already taken in that organization, the CLI explains and re-prompts with an editable `cloud-connect-dev-2`; accept whatever it offers and use that name for the rest of the recipe.
+
+The runtime then starts in your terminal:
+
+```console
+Starting the Spice runtime. Press Ctrl-C to stop it.
+...
+INFO Spice Cloud Connect: connected to <org> / cloud-connect-dev
+INFO Monitor: https://spice.ai/<org>/cloud-connect-dev/monitor
+```
+
+Leave it running. Open the monitor link — the instance appears online, with the `data` dataset from `spicepod.yaml`.
+
+Confirm from a second terminal, in the same directory:
+
+```bash
+cd cookbook/cloud-connect-dev
+spice connect status
+```
+
+```console
+Spice Cloud Connect: connected — <org> / cloud-connect-dev
+  instance:    inst_<id>
+  identity:    <path>/cloud-connect-dev/.spice/identity.json
+  gateway:     connect.aws.spiceai.io:443
+  expiry:      unix=<seconds> (expired=false)
+  service:     not_installed
+  starts:      not started automatically
+  logs:        not configured by this service definition
+  deployment:  none yet — this instance runs its local spicepod until an app is deployed
+  secrets:     none delivered yet — deploy the app to deliver them
+  monitor:     https://spice.ai/<org>/cloud-connect-dev/monitor
+No service is installed for this directory. Run `spice connect service install` to keep this instance running across reboots.
+```
+
+Note the PID of the running runtime — nothing below changes it:
+
+```bash
+pgrep -f 'spiced' | head -1
+```
+
+## 2. Deploy a change that applies live
+
+In the portal, edit the project's Spicepod and add a view, then deploy. Anything under `datasets`, `views`, `models`, `functions`, or an added `catalog` is reconciled into the running process:
+
+```yaml
+views:
+  - name: recent
+    sql: SELECT * FROM data LIMIT 10
+```
+
+The foreground terminal reports the deployment. There is no restart and no gap in serving:
+
+```console
+INFO Spice Cloud Connect: applied the deployed spicepod (1 datasets, 0 models, 0 catalogs, 1 views)
+```
+
+Check the PID again — it is unchanged — and query the new view while the same process serves it:
+
+```bash
+spice sql
+```
+
+```sql
+SELECT count(*) FROM recent;
+```
+
+`spice connect status` now names the deployed Spicepod and reports no pending restart:
+
+```console
+  deployment:  <path>/cloud-connect-dev/.spice/spicepod-cloud-managed.yml
+  secrets:     none (the last deployment delivered no secrets)
+```
+
+## 3. Deploy a change that needs a restart
+
+Some sections are read only when the runtime starts. Add one in the portal — for example a `runtime` setting — and deploy again:
+
+```yaml
+runtime:
+  task_history:
+    captured_output: truncated
+```
+
+The instance keeps serving its current configuration. The deployment is persisted as desired state and the affected sections are named:
+
+```console
+INFO Spice Cloud Connect: applied the deployed spicepod (1 datasets, 0 models, 0 catalogs, 1 views); runtime takes effect when this instance next starts
+```
+
+The pending list is sticky and readable from three places, all backed by the same state:
+
+```bash
+spice connect status
+```
+
+```console
+  restart:     required for runtime
+```
+
+```bash
+spice connect status --output json | jq .deployment.restart_required
+```
+
+```console
+[
+  "runtime"
+]
+```
+
+```bash
+curl -s http://127.0.0.1:8090/v1/cloud-connect/status | jq
+```
+
+```console
+{
+  "instance_id": "inst_<id>",
+  "restart_required": [
+    "runtime"
+  ]
+}
+```
+
+The PID is still unchanged, and queries still work. In the foreground there is no supervisor to restart the instance — that is step 4.
+
+## 4. Stop and reconnect
+
+In the foreground terminal, press `Ctrl-C`. The runtime stops. The Cloud identity is **not** released: the instance shows as offline in the portal and `.spice/identity.json` is still on disk.
+
+```bash
+spice connect status
+```
+
+```console
+Spice Cloud Connect: connected — <org> / cloud-connect-dev
+```
+
+Start it again from the same directory. No Cloud Connect flag is needed — the identity reconnects it:
+
+```bash
+spice run
+```
+
+```console
+INFO Spice Cloud Connect: connected to <org> / cloud-connect-dev
+INFO Monitor: https://spice.ai/<org>/cloud-connect-dev/monitor
+```
+
+This start activates the desired configuration, so the pending list clears:
+
+```bash
+spice connect status
+```
+
+The `restart:` line is gone.
+
+`spice connect` from this directory does the same thing. It never enrolls a second instance — an existing identity always wins.
+
+## 5. Validate locally
+
+`validate.sh` checks the parts of this recipe that need no Spice Cloud account and no credentials. Run it any time:
+
+```bash
+./validate.sh
+```
+
+It asserts that the CLI is new enough, that the project-name default derives from this directory with no random fallback, that `spice connect status` reports a coherent snapshot in both output formats, that a non-interactive `spice connect` refuses instead of hanging, and that no credential or generated identity is staged for commit.
+
+## 6. Clean up
+
+Stop the runtime first — removal refuses while `spiced` is running — then release the instance:
+
+```bash
+spice connect remove
+```
+
+```console
+This will delete this instance's project in Spice Cloud and remove the instance from this host:
+  directory: <path>/cloud-connect-dev
+  identity:  <path>/cloud-connect-dev/.spice/identity.json (deleted)
+? Continue? › yes
+Deleted project cloud-connect-dev in Spice Cloud.
+Spice Cloud Connect identity cleared. To re-enroll this directory, mint a new enrollment key in the Spice Cloud portal and start the runtime with `spiced --token <enrollment-key>`.
+```
+
+The project is deleted with your logged-in user session, so stay logged in to the same organization. Confirm the directory is clear:
+
+```bash
+spice connect status
+```
+
+```console
+Spice Cloud Connect: not connected (<path>/cloud-connect-dev)
+```
+
+## Notes
+
+- **Nothing is committed.** `.spice/` is gitignored: the issued identity, the cloud-managed Spicepod, and the delivered-secrets cache all live there. `validate.sh` checks it.
+- **`spice connect` needs a terminal.** It is interactive; on a non-interactive stdin it exits and points at `spiced --token <enrollment-key>` for [headless enrollment](https://spiceai.org/docs/deployment/cloud-connect/headless).
+- **Cancelling is safe.** `Esc` or `Ctrl-C` at any prompt is a clean exit. An interrupted enrollment resumes on the next run rather than creating a duplicate instance or project.
+- **This recipe is foreground only.** To keep the instance running across reboots on Linux, see [Cloud Connect as a persistent service](https://spiceai.org/docs/deployment/cloud-connect/service). The managed service lifecycle does not yet support macOS or Windows; there, the foreground flow in this recipe is the development story.
+
+## Learn more
+
+- [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect)
+- [`spice connect` reference](https://spiceai.org/docs/cli/reference/connect)

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -4,15 +4,16 @@ Works with `v2.2+`
 
 Connect this directory to Spice Cloud with one command, watch a deployment apply to the running instance without a restart, stop it, and reconnect.
 
-The recipe is deliberately minimal: one public dataset, no infrastructure, no credentials on disk. What it demonstrates is the [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect) lifecycle on the machine you develop on.
+The recipe stays small: one public dataset, one local PostgreSQL in Docker, and no credential written to any file it tracks. What it demonstrates is the [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect) lifecycle on the machine you develop on, including how a deployment delivers the secrets its configuration needs.
 
 You will:
 
 1. Connect this directory and get a running instance attached to a new Spice Cloud project.
 2. Deploy a change that applies live, with no restart and no serving gap.
-3. Deploy a change that needs a restart, and see exactly which settings are pending.
-4. Stop with `Ctrl-C` and reconnect with `spice run` — the identity survives.
-5. Release the instance and delete its project.
+3. Deliver a secret with a deployment, and query a local PostgreSQL whose password only ever existed in your shell and in the portal.
+4. Deploy a change that needs a restart, and see exactly which settings are pending.
+5. Stop with `Ctrl-C` and reconnect with `spice run` — the identity survives.
+6. Release the instance and delete its project.
 
 ## Prerequisites
 
@@ -24,10 +25,11 @@ You will:
 
 - A Spice Cloud account with the **owner** or **admin** role in at least one organization. Those roles may enroll an instance and create a project; `member` may not.
 - Outbound HTTPS to `api.spice.ai` and to the Cloud Connect gateway.
+- Docker, for the local PostgreSQL in step 3. Steps 1, 2 and 4 onwards do not need it.
 
 No `spice login` beforehand — `spice connect` runs login inline if needed.
 
-**Cost:** a Spice Cloud project on the free tier. Step 6 deletes it.
+**Cost:** a Spice Cloud project on the free tier. Step 7 deletes it, and the database is a local container.
 
 ## 1. Connect
 
@@ -135,7 +137,125 @@ SELECT count(*) FROM recent;
   secrets:     none (the last deployment delivered no secrets)
 ```
 
-## 3. Deploy a change that needs a restart
+## 3. Deliver a secret with a deployment
+
+A deployment carries configuration **and** the secrets that configuration needs. This step connects a local PostgreSQL as a dataset whose password is never written in the Spicepod, never committed, and never typed on this machine after the first line below.
+
+Start the database. The password lives in your shell, and the container is the only thing on this machine that receives it:
+
+```bash
+export SPICE_DEMO_PG_PASSWORD="$(openssl rand -hex 16)"
+docker compose up -d
+```
+
+It seeds one table:
+
+```bash
+docker compose exec postgres psql -U spice_reader -d spice_demo -c 'SELECT count(*) FROM public.orders;'
+```
+
+```console
+ count
+-------
+     5
+(1 row)
+```
+
+Now put that same value in the portal. In the project's **Secrets**, add:
+
+| Name          | Value                                  |
+| ------------- | -------------------------------------- |
+| `pg_password` | the value of `$SPICE_DEMO_PG_PASSWORD` |
+
+Then add the dataset to the project's Spicepod and deploy:
+
+```yaml
+datasets:
+  - from: postgres:public.orders
+    name: orders
+    params:
+      pg_host: localhost
+      pg_port: "55432"
+      pg_db: spice_demo
+      pg_user: spice_reader
+      pg_pass: ${secrets:pg_password}
+      pg_sslmode: disable # a local container, so there is no TLS to verify
+```
+
+The deployment applies live — a dataset is a live section, and a secret this instance did not hold yet is installed the moment it arrives, so the dataset resolves its password as it loads:
+
+```console
+INFO Spice Cloud Connect: the deployment delivered 1 secret(s) this instance did not hold, now resolvable: pg_password
+INFO runtime::secrets_preflight: Secrets: all 1 secret reference(s) resolved.
+INFO runtime::init::dataset: Dataset orders registered (postgres:public.orders), results cache enabled. duration_ms=0
+```
+
+The PID is still the one from step 1. Query the table the portal just wired up:
+
+```bash
+spice sql
+```
+
+```sql
+SELECT customer, total_cents FROM orders ORDER BY id LIMIT 3;
+```
+
+```console
++----------+-------------+
+| customer | total_cents |
+|  varchar |    int32    |
++----------+-------------+
+| acme     | 12900       |
+| globex   | 4550        |
+| initech  | 31875       |
++----------+-------------+
+
+Time: 0.003107 seconds. 3 rows.
+```
+
+Status names what was delivered — the name only:
+
+```bash
+spice connect status
+```
+
+```console
+  deployment:  <path>/cloud-connect-dev/.spice/spicepod-cloud-managed.yml
+  secrets:     1 delivered: pg_password
+```
+
+### Why the Spicepod has no `secrets:` section
+
+`${secrets:pg_password}` resolves without declaring anything, because delivered secrets are a **built-in** store rather than one a Spicepod configures. That is what keeps the same Spicepod portable: it runs unchanged as a managed app and on this self-hosted instance, with no `secrets:` block that would be meaningless on the other.
+
+### A local value still wins
+
+The delivered store is registered at the **lowest** precedence, so any store you configure yourself — `env`, a `.env.local` file, a keyring — keeps its value for the same key. Delivery adds a source; it does not take your override away:
+
+```bash
+# The env store maps ${secrets:pg_password} to PG_PASSWORD, uppercased.
+export PG_PASSWORD="$SPICE_DEMO_PG_PASSWORD"
+```
+
+That is how you keep working against the same Spicepod with no portal round trip. Unset it before continuing, or the delivered value is never the one in use:
+
+```bash
+unset PG_PASSWORD
+```
+
+### If you deploy the dataset before setting the secret
+
+The runtime says exactly what is missing and which stores it searched, and the dataset is the only thing that fails:
+
+```console
+WARN runtime::secrets_preflight: Secrets: 1 of 1 secret reference(s) could not be resolved:
+  ✗ ${ secrets:pg_password }  dataset 'orders' (pg_pass) — not found in [env, cloud]
+ERROR runtime::init::dataset: Error initializing dataset orders. Failed to initialize data connector: Cannot connect to the dataset orders (postgres). Authentication failed.
+```
+
+Set the secret in the portal and deploy again — the instance keeps serving everything else throughout.
+
+## 4. Deploy a change that needs a restart
 
 Some sections are read only when the runtime starts. Add one in the portal — for example a `runtime` setting — and deploy again:
 
@@ -184,9 +304,24 @@ curl -s http://127.0.0.1:8090/v1/cloud-connect/status | jq
 }
 ```
 
-The PID is still unchanged, and queries still work. In the foreground there is no supervisor to restart the instance — that is step 4.
+The PID is still unchanged, and queries still work. In the foreground there is no supervisor to restart the instance — that is step 5.
 
-## 4. Stop and reconnect
+### A rotated secret is the same shape
+
+The first delivery of `pg_password` in step 3 applied live because nothing had resolved it yet. Rotating it is different: the components holding the old value keep it until they are built again, so a rotation is pending in exactly the way a `runtime` setting is. Change the password in the database, in the portal secret, and deploy:
+
+```bash
+docker compose exec postgres psql -U spice_reader -d spice_demo \
+  -c "ALTER ROLE spice_reader WITH PASSWORD 'the-new-value';"
+```
+
+```console
+  restart:     required for secrets
+```
+
+The instance goes on serving with the connection it already has. The restart in step 5 is what picks the new value up — and it reads it from the encrypted cache in `.spice/`, so it succeeds even with no route to Spice Cloud.
+
+## 5. Stop and reconnect
 
 In the foreground terminal, press `Ctrl-C`. The runtime stops. The Cloud identity is **not** released: the instance shows as offline in the portal and `.spice/identity.json` is still on disk.
 
@@ -219,7 +354,7 @@ The `restart:` line is gone.
 
 `spice connect` from this directory does the same thing. It never enrolls a second instance — an existing identity always wins.
 
-## 5. Validate locally
+## 6. Validate locally
 
 `validate.sh` checks the parts of this recipe that need no Spice Cloud account and no credentials. Run it any time:
 
@@ -229,7 +364,7 @@ The `restart:` line is gone.
 
 It asserts that the CLI is new enough, that the project-name default derives from this directory with no random fallback, that `spice connect status` reports a coherent snapshot in both output formats, that a non-interactive `spice connect` refuses instead of hanging, and that no credential or generated identity is staged for commit.
 
-## 6. Clean up
+## 7. Clean up
 
 Stop the runtime first — removal refuses while `spiced` is running — then release the instance:
 
@@ -256,9 +391,17 @@ spice connect status
 Spice Cloud Connect: not connected (<path>/cloud-connect-dev)
 ```
 
+Then stop the database and drop its volume:
+
+```bash
+docker compose down -v
+unset SPICE_DEMO_PG_PASSWORD
+```
+
 ## Notes
 
 - **Nothing is committed.** `.spice/` is gitignored: the issued identity, the cloud-managed Spicepod, and the delivered-secrets cache all live there. `validate.sh` checks it.
+- **A delivered value is never in plaintext on disk.** The cache under `.spice/` is sealed with a key derived from this instance's identity, and it is what makes a restart work without asking the control plane for the secret again. `spice connect status` reports delivered secret **names**; the values stay inside the runtime process.
 - **`spice connect` needs a terminal.** It is interactive; on a non-interactive stdin it exits and points at `spiced --token <enrollment-key>` for [headless enrollment](https://spiceai.org/docs/deployment/cloud-connect/headless).
 - **Cancelling is safe.** `Esc` or `Ctrl-C` at any prompt is a clean exit. An interrupted enrollment resumes on the next run rather than creating a duplicate instance or project.
 - **This recipe is foreground only.** To keep the instance running across reboots, install the managed service — systemd on Linux, launchd on macOS. See [Cloud Connect as a persistent service](https://spiceai.org/docs/deployment/cloud-connect/service). Windows has no managed service; there, the foreground flow in this recipe is the development story.

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -1,112 +1,47 @@
 # Cloud Connect on a Development Machine
 
-Works with `v2.2+`
+Works with Spice CLI v2.2 or later.
 
-Connect this directory to Spice Cloud with one command, watch a deployment apply to the running instance without a restart, stop it, and reconnect.
-
-The recipe stays small: one public dataset, one local PostgreSQL in Docker, and no credential written to any file it tracks. What it demonstrates is the [Cloud Connect](https://spiceai.org/docs/deployment/cloud-connect) lifecycle on the machine you develop on, including how a deployment delivers the secrets its configuration needs.
-
-You will:
-
-1. Connect this directory and get a running instance attached to a new Spice Cloud project.
-2. Deploy a change that applies live, with no restart and no serving gap.
-3. Deliver a secret with a deployment, and query a local PostgreSQL whose password only ever existed in your shell and in the portal.
-4. Deploy a change that needs a restart, and see exactly which settings are pending.
-5. Stop with `Ctrl-C` and reconnect with `spice run` — the identity survives.
-6. Release the instance and delete its project.
+Use this recipe to connect a local Spice instance to Spice Cloud. You will deploy live changes, deliver a secret, and reconnect the instance.
 
 ## Prerequisites
 
-- The Spice CLI, `v2.2.0` or later:
+- A Spice Cloud organization where you are an owner or admin
+- Docker
+- Spice CLI v2.2 or later
 
-  ```bash
-  curl https://install.spiceai.org | /bin/bash
-  ```
+Install the Spice CLI:
 
-- A Spice Cloud account with the **owner** or **admin** role in at least one organization. Those roles may enroll an instance and create a project; `member` may not.
-- Outbound HTTPS to `api.spice.ai` and to the Cloud Connect gateway.
-- Docker, for the local PostgreSQL in step 3. Steps 1, 2 and 4 onwards do not need it.
+```shell
+curl https://install.spiceai.org | /bin/bash
+```
 
-No `spice login` beforehand — `spice connect` runs login inline if needed.
+## 1. Connect the instance
 
-**Cost:** a Spice Cloud project on the free tier. Step 7 deletes it, and the database is a local container.
+Clone the cookbook and open this recipe:
 
-## 1. Connect
-
-Clone the cookbook and enter this recipe. The directory name is the project-name default, so run from `cloud-connect-dev` exactly:
-
-```bash
+```shell
 git clone https://github.com/spiceai/cookbook.git
 cd cookbook/cloud-connect-dev
 spice connect
 ```
 
-With no saved login, `spice connect` offers two choices rather than failing:
+Log in to Spice Cloud when the command prompts you. Select an organization. Accept `cloud-connect-dev` as the project name.
 
-```console
-? Connect this directory to Spice Cloud ›
-❯ Log in to Spice Cloud (recommended)
-  Use an enrollment key
-```
+If that name is in use, accept the suggested name.
 
-Choose **Log in to Spice Cloud**. Login runs in the same process and the connect flow continues — there is no second command.
+Leave the runtime open. Open the monitor link in the output.
 
-Next the organization. If your login is owner or admin in exactly one, it is named and used:
+In a second terminal, check the connection:
 
-```console
-Organization: <org> (owner)
-```
-
-If several are eligible, pick one. Then the project name, defaulted from this directory:
-
-```console
-? Project name › cloud-connect-dev
-```
-
-Press Enter to accept it. If the name is already taken in that organization, the CLI explains and re-prompts with an editable `cloud-connect-dev-2`; accept whatever it offers and use that name for the rest of the recipe.
-
-The runtime then starts in your terminal:
-
-```console
-Starting the Spice runtime. Press Ctrl-C to stop it.
-...
-INFO Spice Cloud Connect: connected to <org> / cloud-connect-dev
-INFO Monitor: https://spice.ai/<org>/cloud-connect-dev/monitor
-```
-
-Leave it running. Open the monitor link — the instance appears online, with the `data` dataset from `spicepod.yaml`.
-
-Confirm from a second terminal, in the same directory:
-
-```bash
+```shell
 cd cookbook/cloud-connect-dev
 spice connect status
 ```
 
-```console
-Spice Cloud Connect: connected — <org> / cloud-connect-dev
-  instance:    inst_<id>
-  identity:    <path>/cloud-connect-dev/.spice/identity.json
-  gateway:     connect.aws.spiceai.io:443
-  expiry:      unix=<seconds> (expired=false)
-  service:     not_installed
-  starts:      not started automatically
-  logs:        not configured by this service definition
-  deployment:  none yet — this instance runs its local spicepod until an app is deployed
-  secrets:     none delivered yet — deploy the app to deliver them
-  monitor:     https://spice.ai/<org>/cloud-connect-dev/monitor
-No service is installed for this directory. Run `spice connect service install` to keep this instance running across reboots.
-```
+## 2. Deploy a live change
 
-Note the PID of the running runtime — nothing below changes it:
-
-```bash
-pgrep -f 'spiced' | head -1
-```
-
-## 2. Deploy a change that applies live
-
-In the portal, edit the project's Spicepod and add a view, then deploy. Anything under `datasets`, `views`, `models`, `functions`, or an added `catalog` is reconciled into the running process:
+In the Spice Cloud portal, add this view to the project Spicepod:
 
 ```yaml
 views:
@@ -114,15 +49,11 @@ views:
     sql: SELECT * FROM data LIMIT 10
 ```
 
-The foreground terminal reports the deployment. There is no restart and no gap in serving:
+Deploy the Spicepod. You do not have to restart the instance.
 
-```console
-INFO Spice Cloud Connect: applied the deployed spicepod (1 datasets, 0 models, 0 catalogs, 1 views)
-```
+Query the view:
 
-Check the PID again — it is unchanged — and query the new view while the same process serves it:
-
-```bash
+```shell
 spice sql
 ```
 
@@ -130,44 +61,30 @@ spice sql
 SELECT count(*) FROM recent;
 ```
 
-`spice connect status` now names the deployed Spicepod and reports no pending restart:
+## 3. Deliver a secret
 
-```console
-  deployment:  <path>/cloud-connect-dev/.spice/spicepod-cloud-managed.yml
-  secrets:     none (the last deployment delivered no secrets)
-```
+Create a password and start PostgreSQL:
 
-## 3. Deliver a secret with a deployment
-
-A deployment carries configuration **and** the secrets that configuration needs. This step connects a local PostgreSQL as a dataset whose password is never written in the Spicepod, never committed, and never typed on this machine after the first line below.
-
-Start the database. The password lives in your shell, and the container is the only thing on this machine that receives it:
-
-```bash
+```shell
 export SPICE_DEMO_PG_PASSWORD="$(openssl rand -hex 16)"
 docker compose up -d
 ```
 
-It seeds one table:
+Confirm that PostgreSQL contains the sample data:
 
-```bash
-docker compose exec postgres psql -U spice_reader -d spice_demo -c 'SELECT count(*) FROM public.orders;'
+```shell
+docker compose exec postgres \
+  psql -U spice_reader -d spice_demo \
+  -c 'SELECT count(*) FROM public.orders;'
 ```
 
-```console
- count
--------
-     5
-(1 row)
-```
-
-Now put that same value in the portal. In the project's **Secrets**, add:
+In the project **Secrets** page, add this secret:
 
 | Name          | Value                                  |
 | ------------- | -------------------------------------- |
-| `pg_password` | the value of `$SPICE_DEMO_PG_PASSWORD` |
+| `pg_password` | Value of `$SPICE_DEMO_PG_PASSWORD`     |
 
-Then add the dataset to the project's Spicepod and deploy:
+Add this dataset to the project Spicepod:
 
 ```yaml
 datasets:
@@ -179,20 +96,12 @@ datasets:
       pg_db: spice_demo
       pg_user: spice_reader
       pg_pass: ${secrets:pg_password}
-      pg_sslmode: disable # a local container, so there is no TLS to verify
+      pg_sslmode: disable
 ```
 
-The deployment applies live — a dataset is a live section, and a secret this instance did not hold yet is installed the moment it arrives, so the dataset resolves its password as it loads:
+Deploy the Spicepod. Then query the PostgreSQL data:
 
-```console
-INFO Spice Cloud Connect: the deployment delivered 1 secret(s) this instance did not hold, now resolvable: pg_password
-INFO runtime::secrets_preflight: Secrets: all 1 secret reference(s) resolved.
-INFO runtime::init::dataset: Dataset orders registered (postgres:public.orders), results cache enabled. duration_ms=0
-```
-
-The PID is still the one from step 1. Query the table the portal just wired up:
-
-```bash
+```shell
 spice sql
 ```
 
@@ -200,64 +109,21 @@ spice sql
 SELECT customer, total_cents FROM orders ORDER BY id LIMIT 3;
 ```
 
-```console
+The query returns:
+
+```text
 +----------+-------------+
 | customer | total_cents |
-|  varchar |    int32    |
 +----------+-------------+
 | acme     | 12900       |
 | globex   | 4550        |
 | initech  | 31875       |
 +----------+-------------+
-
-Time: 0.003107 seconds. 3 rows.
 ```
 
-Status names what was delivered — the name only:
+## 4. Deploy a change that requires a restart
 
-```bash
-spice connect status
-```
-
-```console
-  deployment:  <path>/cloud-connect-dev/.spice/spicepod-cloud-managed.yml
-  secrets:     1 delivered: pg_password
-```
-
-### Why the Spicepod has no `secrets:` section
-
-`${secrets:pg_password}` resolves without declaring anything, because delivered secrets are a **built-in** store rather than one a Spicepod configures. That is what keeps the same Spicepod portable: it runs unchanged as a managed app and on this self-hosted instance, with no `secrets:` block that would be meaningless on the other.
-
-### A local value still wins
-
-The delivered store is registered at the **lowest** precedence, so any store you configure yourself — `env`, a `.env.local` file, a keyring — keeps its value for the same key. Delivery adds a source; it does not take your override away:
-
-```bash
-# The env store maps ${secrets:pg_password} to PG_PASSWORD, uppercased.
-export PG_PASSWORD="$SPICE_DEMO_PG_PASSWORD"
-```
-
-That is how you keep working against the same Spicepod with no portal round trip. Unset it before continuing, or the delivered value is never the one in use:
-
-```bash
-unset PG_PASSWORD
-```
-
-### If you deploy the dataset before setting the secret
-
-The runtime says exactly what is missing and which stores it searched, and the dataset is the only thing that fails:
-
-```console
-WARN runtime::secrets_preflight: Secrets: 1 of 1 secret reference(s) could not be resolved:
-  ✗ ${ secrets:pg_password }  dataset 'orders' (pg_pass) — not found in [env, cloud]
-ERROR runtime::init::dataset: Error initializing dataset orders. Failed to initialize data connector: Cannot connect to the dataset orders (postgres). Authentication failed.
-```
-
-Set the secret in the portal and deploy again — the instance keeps serving everything else throughout.
-
-## 4. Deploy a change that needs a restart
-
-Some sections are read only when the runtime starts. Add one in the portal — for example a `runtime` setting — and deploy again:
+Add this setting to the project Spicepod:
 
 ```yaml
 runtime:
@@ -265,146 +131,68 @@ runtime:
     captured_output: truncated
 ```
 
-The instance keeps serving its current configuration. The deployment is persisted as desired state and the affected sections are named:
+Deploy the Spicepod. Check the instance:
 
-```console
-INFO Spice Cloud Connect: applied the deployed spicepod (1 datasets, 0 models, 0 catalogs, 1 views); runtime takes effect when this instance next starts
-```
-
-The pending list is sticky and readable from three places, all backed by the same state:
-
-```bash
+```shell
 spice connect status
 ```
 
-```console
-  restart:     required for runtime
+The status includes this line:
+
+```text
+restart: required for runtime
 ```
 
-```bash
-spice connect status --output json | jq .deployment.restart_required
-```
+The instance continues to serve queries until you restart it.
 
-```console
-[
-  "runtime"
-]
-```
+## 5. Restart and reconnect
 
-```bash
-curl -s http://127.0.0.1:8090/v1/cloud-connect/status | jq
-```
+In the first terminal, press `Ctrl-C`. Start the instance again from the same directory:
 
-```console
-{
-  "instance_id": "inst_<id>",
-  "restart_required": [
-    "runtime"
-  ]
-}
-```
-
-The PID is still unchanged, and queries still work. In the foreground there is no supervisor to restart the instance — that is step 5.
-
-### A rotated secret is the same shape
-
-The first delivery of `pg_password` in step 3 applied live because nothing had resolved it yet. Rotating it is different: the components holding the old value keep it until they are built again, so a rotation is pending in exactly the way a `runtime` setting is. Change the password in the database, in the portal secret, and deploy:
-
-```bash
-docker compose exec postgres psql -U spice_reader -d spice_demo \
-  -c "ALTER ROLE spice_reader WITH PASSWORD 'the-new-value';"
-```
-
-```console
-  restart:     required for secrets
-```
-
-The instance goes on serving with the connection it already has. The restart in step 5 is what picks the new value up — and it reads it from the encrypted cache in `.spice/`, so it succeeds even with no route to Spice Cloud.
-
-## 5. Stop and reconnect
-
-In the foreground terminal, press `Ctrl-C`. The runtime stops. The Cloud identity is **not** released: the instance shows as offline in the portal and `.spice/identity.json` is still on disk.
-
-```bash
-spice connect status
-```
-
-```console
-Spice Cloud Connect: connected — <org> / cloud-connect-dev
-```
-
-Start it again from the same directory. No Cloud Connect flag is needed — the identity reconnects it:
-
-```bash
+```shell
 spice run
 ```
 
-```console
-INFO Spice Cloud Connect: connected to <org> / cloud-connect-dev
-INFO Monitor: https://spice.ai/<org>/cloud-connect-dev/monitor
-```
+You do not need to run `spice connect` again. The existing identity reconnects the instance.
 
-This start activates the desired configuration, so the pending list clears:
+Confirm that the restart is no longer required:
 
-```bash
+```shell
 spice connect status
 ```
 
-The `restart:` line is gone.
+> **Warning:** Spice Cloud invalidates the identity if the instance stays offline for more than 30 days. Enroll the instance again to reconnect it.
 
-`spice connect` from this directory does the same thing. It never enrolls a second instance — an existing identity always wins.
+## 6. Validate the recipe
 
-## 6. Validate locally
+Run the local checks:
 
-`validate.sh` checks the parts of this recipe that need no Spice Cloud account and no credentials. Run it any time:
-
-```bash
+```shell
 ./validate.sh
 ```
 
-It asserts that the CLI is new enough, that the project-name default derives from this directory with no random fallback, that `spice connect status` reports a coherent snapshot in both output formats, that a non-interactive `spice connect` refuses instead of hanging, and that no credential or generated identity is staged for commit.
+These checks do not connect to Spice Cloud or use credentials.
 
 ## 7. Clean up
 
-Stop the runtime first — removal refuses while `spiced` is running — then release the instance:
+Stop the runtime. Remove the Cloud Connect instance and project:
 
-```bash
+```shell
 spice connect remove
 ```
 
-```console
-This will delete this instance's project in Spice Cloud and remove the instance from this host:
-  directory: <path>/cloud-connect-dev
-  identity:  <path>/cloud-connect-dev/.spice/identity.json (deleted)
-? Continue? › yes
-Deleted project cloud-connect-dev in Spice Cloud.
-Spice Cloud Connect identity cleared. To re-enroll this directory, mint a new enrollment key in the Spice Cloud portal and start the runtime with `spiced --token <enrollment-key>`.
-```
+Stop PostgreSQL and delete its volume:
 
-The project is deleted with your logged-in user session, so stay logged in to the same organization. Confirm the directory is clear:
-
-```bash
-spice connect status
-```
-
-```console
-Spice Cloud Connect: not connected (<path>/cloud-connect-dev)
-```
-
-Then stop the database and drop its volume:
-
-```bash
+```shell
 docker compose down -v
 unset SPICE_DEMO_PG_PASSWORD
 ```
 
-## Notes
+## Run as a service
 
-- **Nothing is committed.** `.spice/` is gitignored: the issued identity, the cloud-managed Spicepod, and the delivered-secrets cache all live there. `validate.sh` checks it.
-- **A delivered value is never in plaintext on disk.** The cache under `.spice/` is sealed with a key derived from this instance's identity, and it is what makes a restart work without asking the control plane for the secret again. `spice connect status` reports delivered secret **names**; the values stay inside the runtime process.
-- **`spice connect` needs a terminal.** It is interactive; on a non-interactive stdin it exits and points at `spiced --token <enrollment-key>` for [headless enrollment](https://spiceai.org/docs/deployment/cloud-connect/headless).
-- **Cancelling is safe.** `Esc` or `Ctrl-C` at any prompt is a clean exit. An interrupted enrollment resumes on the next run rather than creating a duplicate instance or project.
-- **This recipe is foreground only.** To keep the instance running across reboots, install the managed service — systemd on Linux, launchd on macOS. See [Cloud Connect as a persistent service](https://spiceai.org/docs/deployment/cloud-connect/service). Windows has no managed service; there, the foreground flow in this recipe is the development story.
+To keep the instance running after you close the terminal, see [Cloud Connect as a service](https://spiceai.org/docs/deployment/cloud-connect/service).
+
+Windows does not support the managed service.
 
 ## Learn more
 

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -80,9 +80,9 @@ docker compose exec postgres \
 
 In the project **Secrets** page, add this secret:
 
-| Name          | Value                                  |
-| ------------- | -------------------------------------- |
-| `pg_password` | Value of `$SPICE_DEMO_PG_PASSWORD`     |
+| Name          | Value                              |
+| ------------- | ---------------------------------- |
+| `pg_password` | Value of `$SPICE_DEMO_PG_PASSWORD` |
 
 Add this dataset to the project Spicepod:
 
@@ -114,12 +114,35 @@ The query returns:
 ```text
 +----------+-------------+
 | customer | total_cents |
+|  varchar |    int32    |
 +----------+-------------+
 | acme     | 12900       |
 | globex   | 4550        |
 | initech  | 31875       |
 +----------+-------------+
+
+Time: 0.003107 seconds. 3 rows.
 ```
+
+Confirm the delivery:
+
+```shell
+spice connect status
+```
+
+```text
+  secrets:     1 delivered: pg_password
+```
+
+Status reports secret names. Values stay in the runtime process.
+
+Three properties of a delivered secret:
+
+- The Spicepod declares no `secrets:` section. Delivered secrets are a built-in store, so the same Spicepod runs unchanged as a managed app and on a self-hosted instance.
+- A local value wins. The built-in store has the lowest precedence, so an `env` or `.env.local` value for `PG_PASSWORD` overrides the delivered one. Unset it to use the delivered value.
+- Only the first delivery applies live. Rotating a secret that a component already resolved requires a restart, like a `runtime` change.
+
+If you deploy the dataset before adding the secret, the runtime names the unresolved reference and that dataset fails to load. Add the secret and deploy again.
 
 ## 4. Deploy a change that requires a restart
 

--- a/cloud-connect-dev/docker-compose.yml
+++ b/cloud-connect-dev/docker-compose.yml
@@ -1,0 +1,26 @@
+# A local PostgreSQL for the secrets step of the README.
+#
+# The password is never written here. It is read from the environment, and the
+# same value is what you set as the `pg_password` secret in the Spice Cloud
+# portal — so the one credential this recipe uses exists in your shell and in
+# the portal, and in no file this repository tracks.
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: cloud-connect-dev-postgres
+    environment:
+      POSTGRES_USER: spice_reader
+      POSTGRES_DB: spice_demo
+      # `:?` fails the command with this message rather than starting a
+      # container with an empty password.
+      POSTGRES_PASSWORD: ${SPICE_DEMO_PG_PASSWORD:?export SPICE_DEMO_PG_PASSWORD first — see step 3 of the README}
+    ports:
+      # 55432, not 5432: a development machine often already has a Postgres.
+      - "55432:5432"
+    volumes:
+      - ./init:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U spice_reader -d spice_demo"]
+      interval: 5s
+      timeout: 5s
+      retries: 12

--- a/cloud-connect-dev/init/01-orders.sql
+++ b/cloud-connect-dev/init/01-orders.sql
@@ -1,0 +1,14 @@
+-- Seeded once, on the container's first start.
+CREATE TABLE public.orders (
+  id          integer PRIMARY KEY,
+  customer    text        NOT NULL,
+  total_cents integer     NOT NULL,
+  placed_at   timestamptz NOT NULL
+);
+
+INSERT INTO public.orders (id, customer, total_cents, placed_at) VALUES
+  (1, 'acme',    12900, '2026-01-04T09:15:00Z'),
+  (2, 'globex',   4550, '2026-01-04T11:02:00Z'),
+  (3, 'initech', 31875, '2026-01-05T14:40:00Z'),
+  (4, 'acme',      990, '2026-01-06T08:05:00Z'),
+  (5, 'umbrella', 7625, '2026-01-06T16:22:00Z');

--- a/cloud-connect-dev/spicepod.yaml
+++ b/cloud-connect-dev/spicepod.yaml
@@ -1,0 +1,9 @@
+version: v1
+kind: Spicepod
+name: cloud-connect-dev
+
+datasets:
+  - from: s3://spiceai-public-datasets/hive_partitioned_data/
+    name: data
+    params:
+      file_format: parquet

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -35,10 +35,10 @@ need spice
 echo "cloud-connect-dev validation"
 echo
 
-# The checks are ordered so that the ones needing no CLI run first and always
-# report. An older CLI stops the flow-specific assertions below, but it says
-# nothing about whether this recipe's files agree with each other — and those
-# are exactly the checks CI can enforce before the release ships.
+# Ordering is deliberate: the checks needing no CLI run first and always report.
+# A CLI too old for this flow stops the assertions below it, and says nothing
+# about whether the recipe's own files agree with each other — so those are
+# checked before the version gate, and a broken file fails rather than skips.
 
 # --- The project-name default comes from this directory, not from a random
 # --- fallback. The suggestion is the directory's final component, slugified.

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -121,10 +121,17 @@ echo
 # refuses to start without one, and that the three places naming the database
 # agree with each other.
 echo "Secrets sync"
-if grep -q '\${secrets:pg_password}' README.md; then
-  ok "the deployed Spicepod resolves the password from \${secrets:pg_password}"
+# The name must match what the project defines, and Spice Cloud rejects a
+# deployment that references one it does not hold.
+if grep -q '\${secrets:PG_PASSWORD}' README.md; then
+  ok "the deployed Spicepod resolves the password from \${secrets:PG_PASSWORD}"
 else
-  no "the README's Spicepod does not use \${secrets:pg_password}"
+  no "the README's Spicepod does not use \${secrets:PG_PASSWORD}"
+fi
+if grep -q 'secrets:pg_password' README.md; then
+  no "a lowercase secret reference remains" "Spice Cloud matches secret names exactly"
+else
+  ok "no lowercase secret reference remains"
 fi
 if grep -q 'secrets:' spicepod.yaml; then
   no "the local spicepod declares a secrets: section" "delivered secrets are a built-in store; declaring one makes the Spicepod unportable"

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -35,6 +35,143 @@ need spice
 echo "cloud-connect-dev validation"
 echo
 
+# The checks are ordered so that the ones needing no CLI run first and always
+# report. An older CLI stops the flow-specific assertions below, but it says
+# nothing about whether this recipe's files agree with each other — and those
+# are exactly the checks CI can enforce before the release ships.
+
+# --- The project-name default comes from this directory, not from a random
+# --- fallback. The suggestion is the directory's final component, slugified.
+echo "Project naming"
+dir_name="$(basename "$PWD")"
+if [ "$dir_name" = "cloud-connect-dev" ]; then
+  ok "recipe directory is 'cloud-connect-dev'"
+else
+  no "recipe directory is '$dir_name'" "run this from the cloud-connect-dev directory"
+fi
+# Same contract the CLI validates a project name against: 4-38 characters of
+# lowercase letters, digits, and dashes, not starting or ending with a dash.
+len=${#dir_name}
+if [ "$len" -ge 4 ] && [ "$len" -le 38 ] &&
+  printf '%s' "$dir_name" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  ok "'$dir_name' is a valid project name, so no <adjective>-spice fallback is used"
+else
+  no "'$dir_name' is not a valid project name" "the CLI would fall back to a generated suggestion"
+fi
+echo
+
+# --- Nothing secret and nothing generated is staged for commit. -------------
+echo "Secrets"
+if grep -q '^\.spice/$' .gitignore 2>/dev/null; then
+  ok ".spice/ is gitignored"
+else
+  no ".spice/ is not gitignored" "the issued identity would be committable"
+fi
+if [ -d .spice ] && git check-ignore -q .spice 2>/dev/null; then
+  ok "the local .spice directory is ignored by git"
+elif [ ! -d .spice ]; then
+  ok "no .spice directory present"
+else
+  no "a .spice directory exists and git does not ignore it"
+fi
+tracked="$(git ls-files . 2>/dev/null)"
+case "$tracked" in
+*.spice/*) no "files under .spice/ are tracked by git" ;;
+*) ok "no .spice/ file is tracked by git" ;;
+esac
+
+# The recipe's own files must not carry a key, a token, or an identity. Scan
+# what git tracks; outside a git checkout, scan the recipe directory instead,
+# so the check is never vacuously true.
+# This script is excluded: it is the one file in the recipe whose content is
+# credential *patterns*, which would match themselves.
+scan_files="$(printf '%s\n' "$tracked" | grep -v '^validate\.sh$')"
+scan_source="tracked"
+if [ -z "$tracked" ]; then
+  scan_files="$(find . -type f -not -path './.spice/*' -not -name validate.sh 2>/dev/null)"
+  scan_source="recipe"
+fi
+# An enrollment key is long and opaque. Requiring both length and a letter is
+# what separates a real key from the documented `spice-enroll-…` placeholder
+# and from the all-digit value used above to prove positional refusal.
+key_shaped='spice-enroll-[A-Za-z0-9]{16,}'
+has_letter='spice-enroll-[0-9]*[A-Za-z]'
+if [ -n "$scan_files" ] &&
+  printf '%s\n' "$scan_files" |
+  xargs grep -h -o -E "$key_shaped" 2>/dev/null |
+  grep -q -E "$has_letter"; then
+  no "a $scan_source file contains an enrollment-key-shaped value"
+else
+  ok "no $scan_source file contains an enrollment-key-shaped value"
+fi
+if [ -n "$scan_files" ] &&
+  printf '%s\n' "$scan_files" |
+  xargs grep -l -E '"private_key_pem"|"identity_cert_pem"|BEGIN [A-Z ]*PRIVATE KEY|BEGIN CERTIFICATE' 2>/dev/null |
+  grep -q .; then
+  no "a $scan_source file contains an identity or private key"
+else
+  ok "no $scan_source file contains an identity or private key"
+fi
+echo
+
+# --- The secrets step is internally consistent and carries no credential. ---
+#
+# None of this needs Spice Cloud: it checks that the recipe asks for the
+# password from a delivered secret rather than a literal, that the container
+# refuses to start without one, and that the three places naming the database
+# agree with each other.
+echo "Secrets sync"
+if grep -q '\${secrets:pg_password}' README.md; then
+  ok "the deployed Spicepod resolves the password from \${secrets:pg_password}"
+else
+  no "the README's Spicepod does not use \${secrets:pg_password}"
+fi
+if grep -q 'secrets:' spicepod.yaml; then
+  no "the local spicepod declares a secrets: section" "delivered secrets are a built-in store; declaring one makes the Spicepod unportable"
+else
+  ok "no secrets: section is declared — the delivered store is built in"
+fi
+if grep -qE 'POSTGRES_PASSWORD: \$\{SPICE_DEMO_PG_PASSWORD:\?' docker-compose.yml; then
+  ok "compose reads the password from the environment and fails loudly without it"
+else
+  no "compose does not read POSTGRES_PASSWORD from the environment with a :? guard"
+fi
+if grep -q 'CREATE TABLE public.orders' init/01-orders.sql; then
+  ok "the seed creates the table the README queries"
+else
+  no "init/01-orders.sql does not create public.orders"
+fi
+
+# The published port, the Spicepod's pg_port, and the psql examples must agree,
+# or the reader follows three different databases.
+# Quote-agnostic: a formatter may normalise '55432' to "55432", and a check that
+# reads only one spelling reports a mismatch that does not exist.
+compose_port="$(grep -oE '[0-9]{4,5}:5432' docker-compose.yml | head -1 | cut -d: -f1)"
+readme_port="$(grep -oE 'pg_port: .?[0-9]{4,5}' README.md | head -1 | grep -oE '[0-9]{4,5}')"
+if [ -n "$compose_port" ] && [ "$compose_port" = "$readme_port" ]; then
+  ok "compose publishes $compose_port and the Spicepod connects to it"
+else
+  no "port mismatch: compose publishes '${compose_port:-?}', the README uses '${readme_port:-?}'"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  if SPICE_DEMO_PG_PASSWORD=validate-only docker compose config >/dev/null 2>&1; then
+    ok "docker-compose.yml parses"
+  else
+    no "docker-compose.yml does not parse" "$(SPICE_DEMO_PG_PASSWORD=validate-only docker compose config 2>&1 | head -3)"
+  fi
+  # The guard is the point: an unset password must stop the command, not start
+  # a database that accepts an empty one.
+  if (unset SPICE_DEMO_PG_PASSWORD; docker compose config >/dev/null 2>&1); then
+    no "compose accepts an unset SPICE_DEMO_PG_PASSWORD"
+  else
+    ok "compose refuses to run with SPICE_DEMO_PG_PASSWORD unset"
+  fi
+else
+  printf '  skip docker not available; compose file not parsed\n'
+fi
+echo
+
 # --- The CLI is new enough to have the flow this recipe documents. ----------
 #
 # An older CLI still has a `spice connect` command, but it is the superseded
@@ -56,7 +193,12 @@ if [ -z "${cli_major:-}" ] || [ -z "${cli_minor:-}" ]; then
 fi
 if [ "$cli_major" -lt 2 ] || { [ "$cli_major" -eq 2 ] && [ "$cli_minor" -lt 2 ]; }; then
   printf '  skip CLI is %s; this recipe needs v2.2 or later\n' "$version"
-  printf '\nNot validated: install Spice CLI v2.2+ and re-run.\nTEST SKIPPED\n'
+  printf '\n%d passed, %d failed before the CLI-dependent checks\n' "$pass" "$fail"
+  if [ "$fail" -gt 0 ]; then
+    printf 'TEST FAILED\n'
+    exit 1
+  fi
+  printf 'Not validated beyond the file checks: install Spice CLI v2.2+ and re-run.\nTEST SKIPPED\n'
   exit 2
 fi
 ok "CLI is $version (v2.2+)"
@@ -70,26 +212,6 @@ case "$help" in
 *'spiced --token'*) ok "help points unattended enrollment at 'spiced --token'" ;;
 *) no "help does not mention 'spiced --token' for unattended enrollment" ;;
 esac
-echo
-
-# --- The project-name default comes from this directory, not from a random
-# --- fallback. The suggestion is the directory's final component, slugified.
-echo "Project naming"
-dir_name="$(basename "$PWD")"
-if [ "$dir_name" = "cloud-connect-dev" ]; then
-  ok "recipe directory is 'cloud-connect-dev'"
-else
-  no "recipe directory is '$dir_name'" "run this from the cloud-connect-dev directory"
-fi
-# Same contract the CLI validates a project name against: 4-38 characters of
-# lowercase letters, digits, and dashes, not starting or ending with a dash.
-len=${#dir_name}
-if [ "$len" -ge 4 ] && [ "$len" -le 38 ] &&
-  printf '%s' "$dir_name" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
-  ok "'$dir_name' is a valid project name, so no <adjective>-spice fallback is used"
-else
-  no "'$dir_name' is not a valid project name" "the CLI would fall back to a generated suggestion"
-fi
 echo
 
 # --- Status reports a coherent snapshot in both output formats. -------------
@@ -157,60 +279,6 @@ case "$out" in
 *'not accepted as a positional argument'*) ok "an enrollment key is refused as a positional argument" ;;
 *) no "an enrollment key was not refused positionally" "$out" ;;
 esac
-echo
-
-# --- Nothing secret and nothing generated is staged for commit. -------------
-echo "Secrets"
-if grep -q '^\.spice/$' .gitignore 2>/dev/null; then
-  ok ".spice/ is gitignored"
-else
-  no ".spice/ is not gitignored" "the issued identity would be committable"
-fi
-if [ -d .spice ] && git check-ignore -q .spice 2>/dev/null; then
-  ok "the local .spice directory is ignored by git"
-elif [ ! -d .spice ]; then
-  ok "no .spice directory present"
-else
-  no "a .spice directory exists and git does not ignore it"
-fi
-tracked="$(git ls-files . 2>/dev/null)"
-case "$tracked" in
-*.spice/*) no "files under .spice/ are tracked by git" ;;
-*) ok "no .spice/ file is tracked by git" ;;
-esac
-
-# The recipe's own files must not carry a key, a token, or an identity. Scan
-# what git tracks; outside a git checkout, scan the recipe directory instead,
-# so the check is never vacuously true.
-# This script is excluded: it is the one file in the recipe whose content is
-# credential *patterns*, which would match themselves.
-scan_files="$(printf '%s\n' "$tracked" | grep -v '^validate\.sh$')"
-scan_source="tracked"
-if [ -z "$tracked" ]; then
-  scan_files="$(find . -type f -not -path './.spice/*' -not -name validate.sh 2>/dev/null)"
-  scan_source="recipe"
-fi
-# An enrollment key is long and opaque. Requiring both length and a letter is
-# what separates a real key from the documented `spice-enroll-…` placeholder
-# and from the all-digit value used above to prove positional refusal.
-key_shaped='spice-enroll-[A-Za-z0-9]{16,}'
-has_letter='spice-enroll-[0-9]*[A-Za-z]'
-if [ -n "$scan_files" ] &&
-  printf '%s\n' "$scan_files" |
-  xargs grep -h -o -E "$key_shaped" 2>/dev/null |
-  grep -q -E "$has_letter"; then
-  no "a $scan_source file contains an enrollment-key-shaped value"
-else
-  ok "no $scan_source file contains an enrollment-key-shaped value"
-fi
-if [ -n "$scan_files" ] &&
-  printf '%s\n' "$scan_files" |
-  xargs grep -l -E '"private_key_pem"|"identity_cert_pem"|BEGIN [A-Z ]*PRIVATE KEY|BEGIN CERTIFICATE' 2>/dev/null |
-  grep -q .; then
-  no "a $scan_source file contains an identity or private key"
-else
-  ok "no $scan_source file contains an identity or private key"
-fi
 echo
 
 printf '%d passed, %d failed\n' "$pass" "$fail"

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Deterministic local checks for the cloud-connect-dev recipe.
+#
+# Everything here runs without a Spice Cloud account, without a login, and
+# without network access to the control plane. It never creates, stores, or
+# reads a credential. The cloud-side steps of the README (enrollment, project
+# creation, deployment) are not covered — they need an account.
+set -uo pipefail
+
+cd "$(dirname "$0")" || exit 1
+
+pass=0
+fail=0
+
+ok() {
+  printf '  ok   %s\n' "$1"
+  pass=$((pass + 1))
+}
+
+no() {
+  printf '  FAIL %s\n' "$1"
+  [ $# -gt 1 ] && printf '       %s\n' "$2"
+  fail=$((fail + 1))
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || {
+    printf 'TEST FAILED: %s is required\n' "$1"
+    exit 1
+  }
+}
+
+need spice
+
+echo "cloud-connect-dev validation"
+echo
+
+# --- The CLI is new enough to have the flow this recipe documents. ----------
+echo "CLI"
+version="$(spice version 2>/dev/null | sed -n 's/^CLI version: *//p' | head -1)"
+if [ -z "$version" ]; then
+  no "spice version reports a CLI version"
+else
+  major_minor="$(printf '%s' "$version" | sed -n 's/^v\{0,1\}\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*/\1 \2/p')"
+  set -- $major_minor
+  if [ $# -eq 2 ] && { [ "$1" -gt 2 ] || { [ "$1" -eq 2 ] && [ "$2" -ge 2 ]; }; }; then
+    ok "CLI is $version (v2.2+)"
+  else
+    no "CLI is $version; this recipe needs v2.2 or later"
+  fi
+fi
+
+help="$(spice connect --help 2>&1)"
+case "$help" in
+*'spice connect service install'*) ok "'spice connect service' is the documented service group" ;;
+*) no "'spice connect --help' does not describe the service group" ;;
+esac
+case "$help" in
+*'spiced --token'*) ok "help points unattended enrollment at 'spiced --token'" ;;
+*) no "help does not mention 'spiced --token' for unattended enrollment" ;;
+esac
+echo
+
+# --- The project-name default comes from this directory, not from a random
+# --- fallback. The suggestion is the directory's final component, slugified.
+echo "Project naming"
+dir_name="$(basename "$PWD")"
+if [ "$dir_name" = "cloud-connect-dev" ]; then
+  ok "recipe directory is 'cloud-connect-dev'"
+else
+  no "recipe directory is '$dir_name'" "run this from the cloud-connect-dev directory"
+fi
+# Same contract the CLI validates a project name against: 4-38 characters of
+# lowercase letters, digits, and dashes, not starting or ending with a dash.
+len=${#dir_name}
+if [ "$len" -ge 4 ] && [ "$len" -le 38 ] &&
+  printf '%s' "$dir_name" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  ok "'$dir_name' is a valid project name, so no <adjective>-spice fallback is used"
+else
+  no "'$dir_name' is not a valid project name" "the CLI would fall back to a generated suggestion"
+fi
+echo
+
+# --- Status reports a coherent snapshot in both output formats. -------------
+echo "Status"
+table="$(spice connect status 2>&1)"
+if [ $? -eq 0 ]; then
+  ok "'spice connect status' exits 0"
+else
+  no "'spice connect status' exited non-zero" "$table"
+fi
+case "$table" in
+*'Spice Cloud Connect:'*) ok "table output reports a connection state" ;;
+*) no "table output has no connection state" "$table" ;;
+esac
+
+json="$(spice connect status --output json 2>/dev/null)"
+if command -v jq >/dev/null 2>&1; then
+  if printf '%s' "$json" | jq -e . >/dev/null 2>&1; then
+    ok "'--output json' writes JSON and nothing else to stdout"
+  else
+    no "'--output json' did not write parseable JSON" "$json"
+  fi
+  for field in .connection.state .service.state .deployment.state .schema_version; do
+    if printf '%s' "$json" | jq -e "$field != null" >/dev/null 2>&1; then
+      ok "status JSON has $field"
+    else
+      no "status JSON is missing $field"
+    fi
+  done
+  # The service object is identical in the full and filtered reports, so
+  # automation never has to reconcile two schemas.
+  svc_full="$(printf '%s' "$json" | jq -Sc .service 2>/dev/null)"
+  svc_only="$(spice connect service status --output json 2>/dev/null | jq -Sc .service 2>/dev/null)"
+  if [ -n "$svc_full" ] && [ "$svc_full" = "$svc_only" ]; then
+    ok "'connect status' and 'connect service status' render the same service object"
+  else
+    no "the two status commands disagree about the service object"
+  fi
+else
+  printf '  skip jq not installed; JSON assertions skipped\n'
+fi
+echo
+
+# --- The interactive flow refuses rather than hanging without a terminal. ---
+echo "Non-interactive safety"
+out="$(spice connect </dev/null 2>&1)"
+code=$?
+if [ "$code" -ne 0 ]; then
+  ok "non-interactive 'spice connect' exits non-zero instead of prompting"
+else
+  no "non-interactive 'spice connect' exited 0" "$out"
+fi
+case "$out" in
+*'requires a terminal'*) ok "it explains that setup is interactive" ;;
+*) no "it does not explain that setup needs a terminal" "$out" ;;
+esac
+case "$out" in
+*'spiced --token'*) ok "it names the unattended alternative" ;;
+*) no "it does not name the unattended alternative" "$out" ;;
+esac
+
+# An enrollment key must never ride a positional argument.
+out="$(spice connect spice-enroll-000000000000 2>&1)"
+case "$out" in
+*'not accepted as a positional argument'*) ok "an enrollment key is refused as a positional argument" ;;
+*) no "an enrollment key was not refused positionally" "$out" ;;
+esac
+echo
+
+# --- Nothing secret and nothing generated is staged for commit. -------------
+echo "Secrets"
+if grep -q '^\.spice/$' .gitignore 2>/dev/null; then
+  ok ".spice/ is gitignored"
+else
+  no ".spice/ is not gitignored" "the issued identity would be committable"
+fi
+if [ -d .spice ] && git check-ignore -q .spice 2>/dev/null; then
+  ok "the local .spice directory is ignored by git"
+elif [ ! -d .spice ]; then
+  ok "no .spice directory present"
+else
+  no "a .spice directory exists and git does not ignore it"
+fi
+tracked="$(git ls-files . 2>/dev/null)"
+case "$tracked" in
+*.spice/*) no "files under .spice/ are tracked by git" ;;
+*) ok "no .spice/ file is tracked by git" ;;
+esac
+# The recipe's own files must not carry a key, a token, or an identity.
+if [ -n "$tracked" ] &&
+  printf '%s\n' "$tracked" | xargs grep -l -E 'spice-enroll-[A-Za-z0-9]|"private_key"|BEGIN [A-Z ]*PRIVATE KEY' 2>/dev/null | grep -q .; then
+  no "a tracked recipe file contains credential-shaped material"
+else
+  ok "no tracked recipe file contains credential-shaped material"
+fi
+echo
+
+printf '%d passed, %d failed\n' "$pass" "$fail"
+if [ "$fail" -eq 0 ]; then
+  echo "TEST PASSED"
+  exit 0
+fi
+echo "TEST FAILED"
+exit 1

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -36,19 +36,30 @@ echo "cloud-connect-dev validation"
 echo
 
 # --- The CLI is new enough to have the flow this recipe documents. ----------
+#
+# An older CLI still has a `spice connect` command, but it is the superseded
+# one: every assertion below would fail for the same single reason. Report that
+# reason once and stop, with exit code 2 so a caller can tell "not validated
+# here" from "validated and broken".
 echo "CLI"
 version="$(spice version 2>/dev/null | sed -n 's/^CLI version: *//p' | head -1)"
 if [ -z "$version" ]; then
-  no "spice version reports a CLI version"
-else
-  major_minor="$(printf '%s' "$version" | sed -n 's/^v\{0,1\}\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*/\1 \2/p')"
-  set -- $major_minor
-  if [ $# -eq 2 ] && { [ "$1" -gt 2 ] || { [ "$1" -eq 2 ] && [ "$2" -ge 2 ]; }; }; then
-    ok "CLI is $version (v2.2+)"
-  else
-    no "CLI is $version; this recipe needs v2.2 or later"
-  fi
+  printf '  FAIL spice version reports no CLI version\n\nTEST FAILED\n'
+  exit 1
 fi
+read -r cli_major cli_minor <<EOF
+$(printf '%s' "$version" | sed -n 's/^v\{0,1\}\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*/\1 \2/p')
+EOF
+if [ -z "${cli_major:-}" ] || [ -z "${cli_minor:-}" ]; then
+  printf '  FAIL could not read a version number from "%s"\n\nTEST FAILED\n' "$version"
+  exit 1
+fi
+if [ "$cli_major" -lt 2 ] || { [ "$cli_major" -eq 2 ] && [ "$cli_minor" -lt 2 ]; }; then
+  printf '  skip CLI is %s; this recipe needs v2.2 or later\n' "$version"
+  printf '\nNot validated: install Spice CLI v2.2+ and re-run.\nTEST SKIPPED\n'
+  exit 2
+fi
+ok "CLI is $version (v2.2+)"
 
 help="$(spice connect --help 2>&1)"
 case "$help" in
@@ -167,12 +178,38 @@ case "$tracked" in
 *.spice/*) no "files under .spice/ are tracked by git" ;;
 *) ok "no .spice/ file is tracked by git" ;;
 esac
-# The recipe's own files must not carry a key, a token, or an identity.
-if [ -n "$tracked" ] &&
-  printf '%s\n' "$tracked" | xargs grep -l -E 'spice-enroll-[A-Za-z0-9]|"private_key"|BEGIN [A-Z ]*PRIVATE KEY' 2>/dev/null | grep -q .; then
-  no "a tracked recipe file contains credential-shaped material"
+
+# The recipe's own files must not carry a key, a token, or an identity. Scan
+# what git tracks; outside a git checkout, scan the recipe directory instead,
+# so the check is never vacuously true.
+# This script is excluded: it is the one file in the recipe whose content is
+# credential *patterns*, which would match themselves.
+scan_files="$(printf '%s\n' "$tracked" | grep -v '^validate\.sh$')"
+scan_source="tracked"
+if [ -z "$tracked" ]; then
+  scan_files="$(find . -type f -not -path './.spice/*' -not -name validate.sh 2>/dev/null)"
+  scan_source="recipe"
+fi
+# An enrollment key is long and opaque. Requiring both length and a letter is
+# what separates a real key from the documented `spice-enroll-…` placeholder
+# and from the all-digit value used above to prove positional refusal.
+key_shaped='spice-enroll-[A-Za-z0-9]{16,}'
+has_letter='spice-enroll-[0-9]*[A-Za-z]'
+if [ -n "$scan_files" ] &&
+  printf '%s\n' "$scan_files" |
+  xargs grep -h -o -E "$key_shaped" 2>/dev/null |
+  grep -q -E "$has_letter"; then
+  no "a $scan_source file contains an enrollment-key-shaped value"
 else
-  ok "no tracked recipe file contains credential-shaped material"
+  ok "no $scan_source file contains an enrollment-key-shaped value"
+fi
+if [ -n "$scan_files" ] &&
+  printf '%s\n' "$scan_files" |
+  xargs grep -l -E '"private_key_pem"|"identity_cert_pem"|BEGIN [A-Z ]*PRIVATE KEY|BEGIN CERTIFICATE' 2>/dev/null |
+  grep -q .; then
+  no "a $scan_source file contains an identity or private key"
+else
+  ok "no $scan_source file contains an identity or private key"
 fi
 echo
 


### PR DESCRIPTION
Closes #577

A minimal recipe named for its directory, so the project-name default `spice connect` derives is `cloud-connect-dev` with no generated fallback.

## The tutorial

1. `spice connect` — log in inline, resolve the organization, accept the directory-derived project name, and land on a running instance with its monitor link.
2. Deploy a change that applies live — the PID is unchanged and the new view is queryable on the same process.
3. **Deliver a secret with a deployment** — a local PostgreSQL in Docker is added as a dataset whose `pg_pass` is `${secrets:pg_password}`. The value is generated into the shell, given to the container and to the project's secrets, and written to no file the repository tracks. The first delivery resolves live, so the dataset loads on the running process and the table is queryable immediately.
4. Deploy a change that needs a restart — the instance keeps serving, and the pending sections are read from the terminal, `spice connect status` (table and JSON), and `GET /v1/cloud-connect/status`. A rotated secret is shown as the same shape, because components holding the old value keep it until they are rebuilt.
5. `Ctrl-C`, then `spice run` — the identity survives and reconnects, the start clears the pending list, and the rotated secret is read from the encrypted cache rather than from the control plane.
6. `spice connect remove`, then `docker compose down -v` — deletes the project and clears local state.

## What the secrets step teaches

Beyond the happy path, because each of these is a decision a reader will otherwise hit as a surprise:

- **No `secrets:` section is declared**, and the recipe says why: delivered secrets are a built-in store, so the same Spicepod runs unchanged as a managed app and on a self-hosted instance. `validate.sh` asserts the section stays absent.
- **A local value still wins.** The built-in store is appended last in precedence order, so an `env` or `.env.local` value for the same key keeps working — the recipe shows the override and tells the reader to unset it before continuing, or the delivered value is never the one in use.
- **First delivery is live, rotation is not.** A secret the instance did not hold is installed the moment it arrives; a rotation of an already-resolved value is pending until a restart, and reads `restart: required for secrets`.
- **The failure mode is documented**, since deploying the dataset before setting the secret is the easy mistake: the preflight names the reference, the dataset, the parameter and the stores it searched.

## Validation

`validate.sh` covers everything that needs no Spice Cloud account and stores no credential: CLI version, the directory-derived project name against the CLI's own name contract, the status snapshot in both output formats, the two status commands rendering one identical service object, the non-interactive refusal, the positional-enrollment-key refusal, and that no credential or generated identity is committable.

An older CLI makes every assertion fail for one reason, so the script exits 2 with a single explanation and CI reports that as a notice — an unvalidated run never reads as green. The check is live on this PR: the released CLI is v2.1.5, so it currently reports `TEST SKIPPED`, and it starts asserting for real when v2.2.0 ships.

`.spice/` is gitignored — the issued identity, the cloud-managed Spicepod, and the delivered-secrets cache all live there. The secret scan matches enrollment keys by length and content and identity material by its PEM markers, so it catches a real leak without tripping on the documented `spice-enroll-…` placeholder; both branches were exercised against planted fixtures.

## What was and was not run

Against a local `spice` build of the stack (`v2.2.0-unstable`, built from #13203's head `a0e19f6c`), on macOS:

- `validate.sh` — 29 checks, 0 failures.
- The step 1 authentication prompt was captured from a real TTY run and is reproduced verbatim in the README.
- Cancelling that prompt leaves no state, as the README says.
- **The database half of step 3 was executed.** The container was started from this `docker-compose.yml`, the seed produced the five rows the README shows, a runtime loaded the exact Spicepod block the README deploys, and `spice sql` returned the transcript reproduced there — including its type row and timing line. The unresolved-secret failure block was captured the same way, by starting the runtime with the value absent.
- Compose refuses to start without `SPICE_DEMO_PG_PASSWORD`, so the container can never come up with an empty password. Asserted in `validate.sh`.

Two things were **not** executed, both for the same reason — there is no Spice Cloud login on the machine this was written on, and the flow creates and deletes a real project:

- enrollment, project creation and the portal deployments; and
- the delivery path itself, so the password reached the runtime through the `env` store rather than from the control plane. The resolution behaviour either way is the same walk, and the delivery-specific literals are taken from the runtime sources at `a0e19f6c` rather than invented.

## Sequencing

spiceai/spiceai#13203, the runtime PR carrying the `spice connect` flow this recipe walks through, has merged. Companion docs: spiceai/docs#2108.

**A credentialed run has since exercised steps 1 to 3** — enrolling, deploying from the project Spicepod, and delivering the secret — and the recipe carries three corrections it produced:

- Spice Cloud matches secret names exactly and the project defines `PG_PASSWORD`, so a Spicepod referencing `pg_password` is rejected at deploy time. The recipe uses `PG_PASSWORD` throughout, states the exact-match rule, and `validate.sh` fails if a lowercase reference reappears.
- A deployment replaces the Spicepod the instance runs, so step 2 now copies the local `spicepod.yaml` into the project Spicepod first. Without that, the deployed Spicepod does not define `data` and the view added on top of it has nothing to select from.
- Each step names which Spicepod it edits — the project's in the portal, not the local file.

**Still unexercised on a credentialed host:** the restart-required deployment, the reconnect, and `spice connect remove` (steps 4 to 7). Their transcripts come from the runtime sources rather than from a run.



