### PR TITLE
fix(xai): update default Grok model

### DIFF
--- a/models/xai/spicepod.yaml
+++ b/models/xai/spicepod.yaml
@@ -3,7 +3,7 @@ kind: Spicepod
 name: xai
 
 models:
-  - from: xai:grok-4-1-fast-non-reasoning
+  - from: xai:grok-4.3
     name: xai
     params:
       xai_api_key: ${secrets:SPICE_XAI_API_KEY}


### PR DESCRIPTION
## Summary
- Replace the retired default xAI model with grok-4.3.

## Validation
- Started the pinned v2.2.0 Spice runtime against this model in a temporary Spicepod.
- Confirmed a chat completions request succeeded with the configured xAI account.