### PR TITLE
Set s3_auth: public on dual-dataset-registration recipe

### DIFF
--- a/acceleration/dual-dataset-registration/README.md
+++ b/acceleration/dual-dataset-registration/README.md
@@ -54,12 +54,14 @@ datasets:
     name: taxi_trips
     params:
       file_format: parquet
+      s3_auth: public
 
   # Accelerated copy — loads in the background
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips_accelerated
     params:
       file_format: parquet
+      s3_auth: public
     ready_state: on_registration # Required for runtime to be ready while loading
     acceleration:
       enabled: true
@@ -70,6 +72,7 @@ datasets:
 
 Key points:
 
+- `s3_auth: public` forces unauthenticated access to the public bucket. Without it, Spice falls back to the default AWS credential chain, which fails if the local environment has invalid or expired AWS credentials configured.
 - `taxi_trips` is a federated dataset with no acceleration. It is ready the moment the runtime starts.
 - `taxi_trips_accelerated` points to the same source but has `acceleration.enabled: true`. The runtime begins loading data into a local DuckDB file as soon as it starts.
 - `ready_state: on_registration` is required on the accelerated dataset so the runtime becomes ready immediately. Without it the runtime waits for the acceleration to finish loading before marking itself ready, which blocks the federated dataset from serving queries.

--- a/acceleration/dual-dataset-registration/spicepod.yaml
+++ b/acceleration/dual-dataset-registration/spicepod.yaml
@@ -8,12 +8,14 @@ datasets:
     name: taxi_trips
     params:
       file_format: parquet
+      s3_auth: public
 
   # Accelerated copy — loads in the background
   - from: s3://spiceai-demo-datasets/taxi_trips/2024/
     name: taxi_trips_accelerated
     params:
       file_format: parquet
+      s3_auth: public
     ready_state: on_registration
     acceleration:
       enabled: true


### PR DESCRIPTION
## Summary
- Adds `s3_auth: public` to both dataset entries in the `dual-dataset-registration` recipe, forcing unauthenticated access to the public S3 bucket.
- Without this, the runtime falls back to the default AWS credential chain. On a machine where local AWS credentials exist but are invalid or expired, dataset registration fails with an `InvalidToken` S3 error, even though the source bucket does not require authentication.
- Updates the README's spicepod snippet and key points to match.

## Test plan
- [x] Reproduced the failure: ran `spiced` against the recipe's original `spicepod.yaml` with an expired AWS session token present in `~/.aws/credentials`; dataset registration failed with `InvalidToken`.
- [x] Applied `s3_auth: public` and reran with the same credentials present; both datasets registered and loaded successfully.
- [x] Verified the federated query (`SELECT COUNT(*) FROM taxi_trips`) and the accelerated query after load both return the expected row count from the README.