### PR TITLE
Fix mysql/rds-aurora-cdc recipe: correct the fabricated startup transcript

### DIFF
--- a/mysql/rds-aurora-cdc/README.md
+++ b/mysql/rds-aurora-cdc/README.md
@@ -169,14 +169,18 @@ MYSQL_PASS=spice" > .env
 spice run
 ```
 
-You should see the dataset bootstrap from a consistent snapshot and then transition to live binlog streaming:
+You should see GTID auto-positioning confirmed, the dataset bootstrap from a consistent snapshot, and the stream transition to live binlog changes:
 
 ```
-2025-01-13T12:00:00Z  INFO runtime::init::dataset: Initializing dataset orders
-2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset orders registered (mysql:spicedemo.orders), acceleration (cayenne:file, changes).
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::mysql: Bootstrapping MySQL table orders, records=3
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::mysql: Bootstrap complete for orders. Streaming binlog changes.
-2025-01-13T12:00:00Z  INFO runtime: All components are loaded. Spice runtime is ready!
+2026-08-19T18:22:41.317523Z  INFO runtime::init::dataset: Dataset orders initializing...
+2026-08-19T18:22:41.392667Z  INFO runtime::init::dataset: Dataset orders registered (mysql:spicedemo.orders), acceleration (cayenne:file, changes), results cache enabled. duration_ms=75
+2026-08-19T18:22:41.396202Z  INFO data_components::mysql_replication::shared: MySQL replication: GTID auto-positioning active. dataset=orders
+2026-08-19T18:22:41.397269Z  INFO data_components::mysql_replication::shared: dataset joined shared mysql binlog group dataset=orders connection=spice-aurora-cdc-cookbook.cluster-abcdefghijkl.us-east-1.rds.amazonaws.com:3306 snapshot=true rejoining=false members=1
+2026-08-19T18:22:41.802719Z  INFO data_components::mysql_replication::bootstrap: mysql replication: starting initial snapshot dataset=orders
+2026-08-19T18:22:42.104727Z  INFO data_components::mysql_replication::bootstrap: mysql replication: initial snapshot complete dataset=orders rows=3
+2026-08-19T18:22:42.491325Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-08-19T18:22:42.492029Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-08-19T18:22:44.042282Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 ---


### PR DESCRIPTION
## Summary

The new Aurora MySQL CDC recipe's Step 9 log block was written by hand rather than captured from a run — four of its five lines are strings the runtime never emits, so a reader watching for them never sees the recipe "work":

| README claims | Runtime actually emits |
| --- | --- |
| `runtime::init::dataset: Initializing dataset orders` | `runtime::init::dataset: Dataset orders initializing...` |
| `runtime::dataconnector::mysql: Bootstrapping MySQL table orders, records=3` | `data_components::mysql_replication::bootstrap: mysql replication: starting initial snapshot dataset=orders` |
| `runtime::dataconnector::mysql: Bootstrap complete for orders. Streaming binlog changes.` | `data_components::mysql_replication::bootstrap: mysql replication: initial snapshot complete dataset=orders rows=3` |
| `Dataset orders registered (mysql:spicedemo.orders), acceleration (cayenne:file, changes).` | same, plus the `, results cache enabled` suffix and the `duration_ms` field emitted by default |

Neither `Bootstrapping MySQL` nor `Streaming binlog changes` exists anywhere in `spiceai/spiceai`, and there is no `runtime::dataconnector::mysql` tracing target for replication — binlog bootstrap logs from `data_components::mysql_replication`.

The block also omitted `MySQL replication: GTID auto-positioning active.`, which is the one line that confirms the recipe's whole premise: GTID mode is enabled (Steps 5–6) precisely so the checkpoint survives an Aurora failover. The placeholder `2025-01-13T12:00:00Z` timestamps are replaced with the runtime's actual microsecond format.

The replacement mirrors the sibling [mysql/cdc](../mysql/cdc/README.md) recipe's verified transcript, adjusted for this recipe's `cayenne:file` accelerator, `spicedemo.orders` source, and Aurora writer endpoint.

## Verified against

`spiceai/spiceai` at `trunk` (v2.2.0 development, matching this recipe's `Works with v2.2.0+` floor — no `v2.2.0` tag exists yet):

- `crates/runtime/src/init/dataset.rs:215` — `Dataset {ds} initializing...`
- `crates/runtime/src/tracing_util.rs:30-52` — `dataset_registered_trace`, including the `, results cache enabled` suffix; `crates/runtime/src/init/dataset.rs:1015-1023` adds `duration_ms`
- `crates/data_components/src/mysql_replication/shared.rs:855` — `MySQL replication: GTID auto-positioning active.` (field: `dataset`)
- `crates/data_components/src/mysql_replication/shared.rs:911-917` — `dataset joined shared mysql binlog group` (fields: `dataset`, `connection` = `host:port`, `snapshot`, `rejoining`, `members`)
- `crates/data_components/src/mysql_replication/bootstrap.rs:87,187` — snapshot start/complete
- `git grep "Bootstrapping MySQL"` and `git grep "Streaming binlog changes"` return nothing

## Evidence

Static review against source. This recipe provisions a real Aurora cluster, so it was not run; the strings above are quoted from the emitting `tracing::info!` calls, and every line in the replacement block appears in the already-validated `mysql/cdc` transcript.

The rest of the recipe checks out: `mysql_sslmode: preferred` is accepted by the replication path (`crates/data-connectors/connector-mysql/src/replication.rs:759-773`), `engine: cayenne` has a binlog checkpoint sidecar arm (`crates/runtime/src/dataaccelerator/spice_sys/mysql_binlog/mod.rs`), `${env:AURORA_WRITER_ENDPOINT}` resolves from the `.env` Step 8 writes, and both `spiceai.org/docs/next/...` links return 200.