### PR TITLE
Rework cloud-connect-dev recipe onto the spice cloud enrollment flow

### DIFF
--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -31,7 +31,15 @@ Sign in to Spice Cloud:
 spice login
 ```
 
-In the Spice Cloud portal, create a Cloud Connect project named `cloud-connect-dev` — a project your own runtime serves, which has no region to choose. If that name is taken in your organization, pick another and use it everywhere below.
+Create the project. With no `--kind`, this creates a Cloud Connect project — one your own runtime serves, which has no region to choose:
+
+```shell
+spice cloud project create cloud-connect-dev
+```
+
+If that name is taken in your organization, pick another and use it everywhere below.
+
+`--region`, and the hosted-runtime flags such as `--replicas` and `--memory`, are refused here rather than ignored. They configure a Spice-managed project, which you ask for with `--kind set` or `--kind cluster`.
 
 Link this directory to the project:
 

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -205,11 +205,11 @@ unset SPICE_DEMO_PG_PASSWORD
 
 ## Run as a service
 
-To keep the instance running after you close the terminal, see [Cloud Connect as a service](https://spiceai.org/docs/deployment/cloud/cloud-connect/service).
+To keep the instance running after you close the terminal, see [Cloud Connect as a service](https://spiceai.org/docs/next/deployment/cloud/cloud-connect/service).
 
 Windows does not support the managed service.
 
 ## Learn more
 
-- [Cloud Connect](https://spiceai.org/docs/deployment/cloud/cloud-connect)
-- [`spice connect` reference](https://spiceai.org/docs/cli/reference/connect)
+- [Cloud Connect](https://spiceai.org/docs/next/deployment/cloud/cloud-connect)
+- [`spice connect` reference](https://spiceai.org/docs/next/cli/reference/connect)

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -28,7 +28,7 @@ cd cookbook/cloud-connect-dev
 Sign in to Spice Cloud:
 
 ```shell
-spice cloud login
+spice login
 ```
 
 In the Spice Cloud portal, create a Cloud Connect project named `cloud-connect-dev` — a project your own runtime serves, which has no region to choose. If that name is taken in your organization, pick another and use it everywhere below.
@@ -72,7 +72,7 @@ cd cookbook/cloud-connect-dev
 spice cloud status
 ```
 
-The report covers the project, its latest deployment, and the instances serving it, then closes with this directory's own state under `Local enrolled-instance state:`.
+The report covers the project, its latest deployment, and the instances serving it, then closes with this directory's own state under `Local enrolled-instance state:`. It reads from Spice Cloud, so it needs the session `spice login` created.
 
 ## 2. Deploy a live change
 

--- a/cloud-connect-dev/README.md
+++ b/cloud-connect-dev/README.md
@@ -121,13 +121,30 @@ docker compose exec postgres \
   -c 'SELECT count(*) FROM public.orders;'
 ```
 
-In the portal, open the project's **Settings → Secrets** and add:
+Store the password as a project secret. Linking set this directory's project, so `--project` is not needed:
 
-| Name          | Value                              |
-| ------------- | ---------------------------------- |
-| `PG_PASSWORD` | Value of `$SPICE_DEMO_PG_PASSWORD` |
+```shell
+spice cloud secrets set PG_PASSWORD "$SPICE_DEMO_PG_PASSWORD"
+```
 
-Secret names are matched exactly. A Spicepod that references a name the project does not define is rejected when you deploy it, and the portal names the closest match it holds.
+```text
+✓ Secret 'PG_PASSWORD' set successfully
+```
+
+The value is a command argument. Passing the variable keeps the password out of your shell history, but the expanded value is visible in the process list to anyone else on the machine while the command runs. On a shared machine, set it in the portal under **Settings → Secrets** instead.
+
+Confirm the name without printing the value:
+
+```shell
+spice cloud secrets list
+```
+
+```text
+NAME          UPDATED
+PG_PASSWORD   2026-01-06T16:22:00Z
+```
+
+Secret names are matched exactly. A Spicepod that references a name the project does not define is rejected when you deploy it, and Spice Cloud names the closest match it holds.
 
 Add this dataset to the project Spicepod in the portal — not to the local `spicepod.yaml`:
 

--- a/cloud-connect-dev/docker-compose.yml
+++ b/cloud-connect-dev/docker-compose.yml
@@ -1,9 +1,9 @@
 # A local PostgreSQL for the secrets step of the README.
 #
 # The password is never written here. It is read from the environment, and the
-# same value is what you set as the `PG_PASSWORD` secret in the Spice Cloud
-# portal — so the one credential this recipe uses exists in your shell and in
-# the portal, and in no file this repository tracks.
+# same value is what you set as the `PG_PASSWORD` secret on the Spice Cloud
+# project — so the one credential this recipe uses exists in your shell and in
+# the project, and in no file this repository tracks.
 services:
   postgres:
     image: postgres:16-alpine

--- a/cloud-connect-dev/docker-compose.yml
+++ b/cloud-connect-dev/docker-compose.yml
@@ -1,7 +1,7 @@
 # A local PostgreSQL for the secrets step of the README.
 #
 # The password is never written here. It is read from the environment, and the
-# same value is what you set as the `pg_password` secret in the Spice Cloud
+# same value is what you set as the `PG_PASSWORD` secret in the Spice Cloud
 # portal — so the one credential this recipe uses exists in your shell and in
 # the portal, and in no file this repository tracks.
 services:

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -233,6 +233,36 @@ for sub in install uninstall start stop restart; do
 done
 echo
 
+# --- The secrets step names commands that exist, and leaks nothing. ---------
+#
+# `secrets` reaches the control plane and needs a resolvable project, so only
+# `--help` is asserted here. Nothing sets, reads or deletes a real secret: a
+# validator that mutates a cloud project when a developer happens to be logged
+# in is worse than the coverage it would buy.
+echo "Secrets commands"
+secrets_help="$(spice cloud secrets --help 2>&1)"
+for sub in list set get delete; do
+  case "$secrets_help" in
+  *"  $sub "*) ok "'spice cloud secrets' has $sub" ;;
+  *) no "'spice cloud secrets' is missing $sub" ;;
+  esac
+done
+# The password must reach the CLI through the variable. Spelled literally it
+# would sit in the reader's shell history, and in this file.
+if grep -qF 'spice cloud secrets set PG_PASSWORD "$SPICE_DEMO_PG_PASSWORD"' README.md; then
+  ok "the README passes the password by variable, not by literal"
+else
+  no "the README does not set PG_PASSWORD from \$SPICE_DEMO_PG_PASSWORD"
+fi
+# `secrets get` prints the value to stdout, so the recipe confirms with `list`,
+# which reports names and timestamps only.
+if grep -q 'spice cloud secrets get' README.md; then
+  no "the README calls 'spice cloud secrets get'" "it prints the secret value; confirm with 'spice cloud secrets list'"
+else
+  ok "the README confirms the secret without printing its value"
+fi
+echo
+
 # --- The project the README creates is a Cloud Connect one. -----------------
 #
 # `spice cloud project create` resolves placement before it connects, so these

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -233,6 +233,36 @@ for sub in install uninstall start stop restart; do
 done
 echo
 
+# --- The project the README creates is a Cloud Connect one. -----------------
+#
+# `spice cloud project create` resolves placement before it connects, so these
+# refusals are argument validation: they answer with no account and create
+# nothing. The exit code is asserted too, so a future ordering change that
+# created the project first would fail here rather than quietly succeed.
+echo "Project kind"
+out="$(spice cloud project create validate-only-never-created --region us-east-1-prod-aws-data 2>&1)"
+code=$?
+if [ "$code" -ne 0 ]; then
+  ok "'--region' without '--kind' is refused"
+else
+  no "'--region' without '--kind' exited 0" "$out"
+fi
+case "$out" in
+*'without --kind this creates a Cloud Connect project'*) ok "omitting --kind asks for a Cloud Connect project" ;;
+*) no "the refusal does not say that omitting --kind means Cloud Connect" "$out" ;;
+esac
+out="$(spice cloud project create validate-only-never-created --kind set 2>&1)"
+case "$out" in
+*'needs a region'*) ok "'--kind set' is the Spice-managed path and needs a region" ;;
+*) no "'--kind set' did not ask for a region" "$out" ;;
+esac
+if grep -q 'spice cloud project create cloud-connect-dev' README.md; then
+  ok "the README creates the project with no kind or placement flags"
+else
+  no "the README does not create the project with a bare 'spice cloud project create'"
+fi
+echo
+
 # --- The README and the CLI agree on which commands exist. ------------------
 #
 # A recipe naming a spelling the CLI has dropped sends the reader into an

--- a/cloud-connect-dev/validate.sh
+++ b/cloud-connect-dev/validate.sh
@@ -184,6 +184,54 @@ else
 fi
 echo
 
+# --- The README names commands the CLI still has, and leaks no credential. --
+#
+# Pure text checks, deliberately above the version gate: they need no CLI, so
+# they run on every checkout, including the CI image whose stable CLI skips
+# everything below. The password guard in particular has to run everywhere.
+echo "README commands"
+if grep -q 'spice cloud project create cloud-connect-dev' README.md; then
+  ok "the README creates the project with no kind or placement flags"
+else
+  no "the README does not create the project with a bare 'spice cloud project create'"
+fi
+if grep -q 'spice cloud link' README.md; then
+  ok "the README links the instance with 'spice cloud link'"
+else
+  no "the README does not use 'spice cloud link'"
+fi
+if grep -q 'spice cloud unlink' README.md; then
+  ok "the README detaches with 'spice cloud unlink'"
+else
+  no "the README does not use 'spice cloud unlink'"
+fi
+if grep -q 'spiced --token' README.md; then
+  ok "the README names 'spiced --token' for unattended enrollment"
+else
+  no "the README does not name 'spiced --token' for unattended enrollment"
+fi
+# A recipe naming a spelling the CLI has dropped sends the reader into an error.
+if grep -q 'spice connect' README.md; then
+  no "the README still calls 'spice connect'" "that command only retains the deprecated <org>/<pod> Spicepod form"
+else
+  ok "the README calls no removed 'spice connect' lifecycle spelling"
+fi
+# The password must reach the CLI through the variable. Spelled literally it
+# would sit in the reader's shell history, and in this file.
+if grep -qF 'spice cloud secrets set PG_PASSWORD "$SPICE_DEMO_PG_PASSWORD"' README.md; then
+  ok "the README passes the password by variable, not by literal"
+else
+  no "the README does not set PG_PASSWORD from \$SPICE_DEMO_PG_PASSWORD"
+fi
+# `secrets get` prints the value to stdout, so the recipe confirms with `list`,
+# which reports names and timestamps only.
+if grep -q 'spice cloud secrets get' README.md; then
+  no "the README calls 'spice cloud secrets get'" "it prints the secret value; confirm with 'spice cloud secrets list'"
+else
+  ok "the README confirms the secret without printing its value"
+fi
+echo
+
 # --- The CLI is new enough to have the flow this recipe documents. ----------
 #
 # Below the gate every assertion would fail for the same single reason on an
@@ -247,20 +295,6 @@ for sub in list set get delete; do
   *) no "'spice cloud secrets' is missing $sub" ;;
   esac
 done
-# The password must reach the CLI through the variable. Spelled literally it
-# would sit in the reader's shell history, and in this file.
-if grep -qF 'spice cloud secrets set PG_PASSWORD "$SPICE_DEMO_PG_PASSWORD"' README.md; then
-  ok "the README passes the password by variable, not by literal"
-else
-  no "the README does not set PG_PASSWORD from \$SPICE_DEMO_PG_PASSWORD"
-fi
-# `secrets get` prints the value to stdout, so the recipe confirms with `list`,
-# which reports names and timestamps only.
-if grep -q 'spice cloud secrets get' README.md; then
-  no "the README calls 'spice cloud secrets get'" "it prints the secret value; confirm with 'spice cloud secrets list'"
-else
-  ok "the README confirms the secret without printing its value"
-fi
 echo
 
 # --- The project the README creates is a Cloud Connect one. -----------------
@@ -286,33 +320,6 @@ case "$out" in
 *'needs a region'*) ok "'--kind set' is the Spice-managed path and needs a region" ;;
 *) no "'--kind set' did not ask for a region" "$out" ;;
 esac
-if grep -q 'spice cloud project create cloud-connect-dev' README.md; then
-  ok "the README creates the project with no kind or placement flags"
-else
-  no "the README does not create the project with a bare 'spice cloud project create'"
-fi
-echo
-
-# --- The README and the CLI agree on which commands exist. ------------------
-#
-# A recipe naming a spelling the CLI has dropped sends the reader into an
-# error, so the drift is worth failing on rather than reading past.
-echo "README and CLI agree"
-if grep -q 'spice cloud link' README.md; then
-  ok "the README links the instance with 'spice cloud link'"
-else
-  no "the README does not use 'spice cloud link'"
-fi
-if grep -q 'spice cloud unlink' README.md; then
-  ok "the README detaches with 'spice cloud unlink'"
-else
-  no "the README does not use 'spice cloud unlink'"
-fi
-if grep -q 'spice connect' README.md; then
-  no "the README still calls 'spice connect'" "that command only retains the deprecated <org>/<pod> Spicepod form"
-else
-  ok "the README calls no removed 'spice connect' lifecycle spelling"
-fi
 echo
 
 # --- Enrollment refuses rather than hanging without a terminal. -------------
@@ -337,11 +344,6 @@ case "$out" in
 *'spiced --token'*) ok "it names the unattended alternative" ;;
 *) no "it does not name the unattended alternative" "$out" ;;
 esac
-if grep -q 'spiced --token' README.md; then
-  ok "the README names the same unattended alternative"
-else
-  no "the README does not name 'spiced --token' for unattended enrollment"
-fi
 echo
 
 printf '%d passed, %d failed\n' "$pass" "$fail"


### PR DESCRIPTION
## Summary

`spice connect` is no longer how a runtime is connected to Spice Cloud. It retains only the deprecated `<org>/<pod>` Spicepod-add form and rejects every lifecycle spelling:

```
$ spice connect status
ERROR Invalid argument: `spice connect` only accepts the deprecated `<org>/<pod>` Spicepod form; use `spice cloud` for instance lifecycle.
```

The `cloud-connect-dev` recipe taught `spice connect`, `spice connect status`, and `spice connect remove` — so every cloud-facing command in it exits non-zero today. Repairing its doc links (the original scope of this PR) would have left a recipe that walks the reader down a path the CLI no longer has, so the recipe body is reworked onto the current surface. **The link repairs are kept.**

## What changed

`README.md` now uses `spice login` → `spice cloud project create` → `spice cloud link <org>/<project>` → `spice run`, with `spice cloud secrets`, `spice cloud status`, `spice cloud unlink`, and `spice cloud service` for the rest. The portal is used only where it is genuinely the tool: editing the project Spicepod. Behaviours documented because the CLI actually does them:

- `spice cloud link` enrols the directory and attaches it in one step, requires a terminal, and does **not** start the runtime — its own output tells you to run `spice run`.
- A project holding no Spicepod is seeded from the local one, so the recipe's manual "paste `spicepod.yaml` into the portal" step is gone.
- `spice cloud unlink` releases the instance but **never deletes the project**. Clean-up names `spice cloud project delete` separately, and says to stop the runtime first, because unlink takes the runtime lock and refuses while it is held.
- `spice cloud status` reports project health and appends the local view under a `Local enrolled-instance state:` header, which the expected-output block gains. It reads from the control plane, so unlike the old command it does not work signed out — the README says so.

**Breaking for anyone parsing `--output json`:** the status JSON moves `connection`, `service`, and `deployment` under a `link` object; `schema_version` stays at the top level. That is a runtime change, not one this PR makes, but it is not discoverable from this diff and it silently breaks existing parsers.

The project is created with `spice cloud project create cloud-connect-dev`. `--kind` is the discriminator: naming one asks for a Spice-managed project and requires `--region`, while omitting it asks for a Cloud Connect project, which has no region to choose. `--region` and the hosted-runtime flags are **refused rather than ignored** when no kind is given, so the README says so.

`validate.sh` asserts that distinction, and can do it headlessly: `execute_project_create` resolves placement before it connects, so both refusals are argument validation that answer with no account and create nothing. The exit code is asserted alongside the message, so a future ordering change that created the project before validating it would fail the check rather than pass silently.

## Secrets, and a hazard worth naming

The secrets step is `spice cloud secrets set PG_PASSWORD "$SPICE_DEMO_PG_PASSWORD"`, confirmed with `spice cloud secrets list`. Linking resolves the project, so neither needs `--project`.

**The value is a required positional argument, and there is no stdin, file, or environment form** — `SecretsSetArgs.value` is a bare `String` with no clap attribute, and the only stdin read in the module is the project-delete confirmation prompt. So the recipe passes the shell variable: history records the line as typed, which keeps the password out of it, but the expanded value is still in the process argument list while the command runs. The README states that plainly and points at the portal for a shared machine, rather than implying the CLI form is unconditionally safer.

`spice cloud secrets get` prints the value to stdout, so the confirmation step uses `list`, which reports names and timestamps only. `validate.sh` fails if the README ever reaches for `get`, or if it spells the password literally instead of passing the variable.

## validate.sh

Its stated contract is to run with no account, no login, and no control-plane access. The old `spice connect status` assertions met that because the command only read local state. `spice cloud status` calls the control plane — offline it exits 1 with `No app specified` — so those checks cannot be ported. Replacing them:

- `--help` assertions that the four lifecycle commands and all five `service` subcommands exist
- a README/CLI drift guard that fails if the recipe reintroduces a removed `spice connect` spelling
- the non-interactive refusal path, which still fails closed and still names `spiced --token`

Nothing in the suite sets, reads, or deletes a real secret, for the same reason a bare `project create` is not asserted: those commands reach the control plane, and a validator that mutates someone's cloud project when a developer happens to be logged in is a worse defect than the coverage it would buy.

**Dropped:** the assertion that an enrollment key is refused as a positional argument. `spice cloud link` fails its terminal check before argument handling, so that property is no longer reachable from this recipe's surface. The scan that fails the build if a key-shaped value appears in a recipe file is unchanged.

## Verified against

- **The shipped binary**, not the release notes: `spice cloud --help` and the `link` / `unlink` / `status` / `service` / `project create` subcommand helps.
- **Source**, for the strings and ordering the README quotes: `bin/spice/src/commands/cloud/mod.rs` (`execute_link` output, `execute_unlink` runtime lock, `execute_status` local-state header and JSON shape) and `bin/spice/src/commands/connect/status.rs` (`  secrets:     {n} delivered: {names}`).
- **Links**: every URL in the README re-checked with `curl -sL -o /dev/null -w '%{http_code}'` — 4/4 return 200. `/docs/next/` is the correct prefix today because the released paths still 404: Cloud Connect is new in v2.2 and no `version-2.2.x` snapshot has been cut yet. When v2.2 is published these pages are snapshotted and also resolve at `/docs/deployment/cloud/cloud-connect`, which is then the better link for a recipe whose readers run the stable CLI — `/docs/next/` tracks trunk and drifts from it. Worth revisiting at that point.
- The `spice connect` CLI reference link is **removed rather than repointed** — the `spice cloud` reference page is not published yet (`/docs/cli/reference/cloud` and `/docs/next/cli/reference/cloud` both 404). It can be added in a follow-up once that page exists.

## Evidence

`./cloud-connect-dev/validate.sh`, run locally against a v2.2 CLI:

```
before:  18 passed, 12 failed   TEST FAILED
after:   43 passed,  0 failed   TEST PASSED
```

All 12 prior failures were the `spice connect` assertions.

Note on CI: `validate-cloud-connect-dev` installs the **stable** CLI, which still predates v2.2, so the workflow takes the version gate and reports the "not validated" notice — a green check there is not evidence for the CLI-dependent assertions, which were exercised locally against v2.2 and start running in CI when v2.2 ships.

The checks that only read `README.md` need no CLI, so they now sit **above** the gate and do run in CI: **23 checks, up from 16**, including the guard that fails if the recipe ever spells the database password literally instead of passing `$SPICE_DEMO_PG_PASSWORD`. That is the check that most needs to run on every pull request, and it previously never did.

## Sweep

The rest of the cookbook was checked for `spice connect`. Five other files match only in ordinary prose — "the replication user Spice connects with", "Spice connects to Unity Catalog", "the Spice connector accepts the dot form" — and no file anywhere uses the still-supported deprecated `spice connect <org>/<pod>` pod-add form. No other recipe needs a change.
