### PR TITLE
Fix acceleration/cron recipe: version floor v1.0 → v1.4.0 and stale accelerated size

### DIFF
--- a/acceleration/cron/README.md
+++ b/acceleration/cron/README.md
@@ -1,6 +1,6 @@
 # Cron-based Dataset Refresh
 
-Works with `v1.0+`
+Works with `v1.4.0+`
 
 Spice supports specifying cron schedules for accelerated datasets, to refresh datasets on defined schedules.
 
@@ -75,10 +75,10 @@ After the initial load, observe that the `taxi_trips` dataset refreshes on every
 2025-06-09T06:27:33.630576Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-06-09T06:27:35.928527Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2025-06-09T06:27:35.929924Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:27:50.915273Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 14s 985ms.
+2025-06-09T06:27:50.915273Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 14s 985ms.
 2025-06-09T06:27:50.986350Z  INFO runtime: All components are loaded. Spice runtime is ready!
 2025-06-09T06:28:00.001597Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:28:13.954105Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 13s 952ms.
+2025-06-09T06:28:13.954105Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 952ms.
 2025-06-09T06:28:30.001882Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:28:43.802372Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 13s 800ms.
+2025-06-09T06:28:43.802372Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 800ms.
 ```


### PR DESCRIPTION
## Summary

- **Version floor.** The recipe says `Works with v1.0+`, but its whole subject — the `refresh_cron` acceleration parameter added in Step 2 — did not exist until **v1.4.0**. A reader on v1.0–v1.3 cannot complete the recipe. Same correction already merged for the `views` recipe in #538.
- **Stale accelerated size.** Step 2's transcript reports `399.41 MiB` for `taxi_trips`; Step 1 of the same recipe reports `399.38 MiB`, which is what the runtime prints today. A README that contradicts itself about the same dataset is drift regardless of which run is newer.

## Verified against

`spiceai/spiceai` — `refresh_cron` first appears at `v1.4.0`:

```
$ for t in v1.0.0 v1.1.0 v1.2.0 v1.3.0 v1.4.0; do
    printf "%-8s %s\n" $t "$(git grep -c refresh_cron $t -- crates | wc -l)"; done
v1.0.0   0
v1.1.0   0
v1.2.0   0
v1.3.0   0
v1.4.0   6
```

Current definition: `crates/spicepod/src/acceleration/mod.rs:502`, consumed at `crates/runtime/src/init/scheduler.rs:219-254`.

## Evidence

Ran the recipe end-to-end on CLI/runtime **v2.1.5** (`spice add spiceai/quickstart`, added `refresh_cron: "*/30 * * * * *"` to `spicepods/spiceai/quickstart/spicepod.yaml`, `spice run`):

```
2026-08-19T12:20:12.712184Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled. duration_ms=0
2026-08-19T12:20:12.713847Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
2026-08-19T12:20:15.315898Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 2s 602ms.
2026-08-19T12:20:30.320838Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
2026-08-19T12:20:37.331335Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 7s 10ms.
2026-08-19T12:21:00.335406Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
```

The cron schedule fires on the 30-second boundary as documented, the `spicepods/spiceai/quickstart/spicepod.yaml` path is correct, and the six-field expression parses (`crates/scheduler/src/channel/cron.rs:39-44` builds the parser with `Seconds::Optional`). Row count and size confirmed as 2,964,624 / 399.38 MiB.

Load durations in the transcript are left as-is — they vary per run and per network. The `Initializing dataset taxi_trips` line in the same block is corrected separately by #587; this PR deliberately does not touch that line.