### PR TITLE
Spark 3.5 recipe: bump Spark to 3.5.9 to fix Docker build

### DIFF
--- a/spark/spark-3.5/spark/Dockerfile
+++ b/spark/spark-3.5/spark/Dockerfile
@@ -38,7 +38,7 @@ ENV PYTHONPATH=$SPARK_HOME/python:$SPARK_HOME/python/lib/py4j-0.10.9.7-src.zip:$
 
 WORKDIR ${SPARK_HOME}
 
-ENV SPARK_VERSION=3.5.6
+ENV SPARK_VERSION=3.5.9
 
 RUN mkdir -p /home/spark/data \
     /home/spark/notebooks \
@@ -55,7 +55,7 @@ RUN cd ${SPARK_HOME} \
     && tar xvzf spark-${SPARK_VERSION}-bin-hadoop3.tgz --directory /opt/spark --strip-components 1 \
     && rm -rf spark-${SPARK_VERSION}-bin-hadoop3.tgz
 
-ENV SPARK_VERSION=3.5.6
+ENV SPARK_VERSION=3.5.9
 RUN cd ${SPARK_HOME} && \
     curl -fL https://repo1.maven.org/maven2/org/apache/spark/spark-connect_2.12/${SPARK_VERSION}/spark-connect_2.12-${SPARK_VERSION}.jar -o jars/spark-connect_2.12-${SPARK_VERSION}.jar
 


### PR DESCRIPTION
The Spark 3.5 recipe fails to build:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
```

Spark 3.5.6 was removed from `dlcdn.apache.org` (the CDN only hosts the latest releases), so `curl` downloads a small error page and `tar` fails.

Bumped `SPARK_VERSION` to 3.5.9. Verified the tarball and the spark-connect jars exist for 3.5.9, and that `docker compose build` completes successfully.