### PR TITLE
Fix postgres CDC recipe: use 'auto' for pg_replication_initial_snapshot

### DIFF
--- a/postgres/cdc/spicepod.yaml
+++ b/postgres/cdc/spicepod.yaml
@@ -13,7 +13,7 @@ datasets:
       pg_user: postgres
       pg_pass: ${secrets:PG_PASS}
       pg_replication_slot: spice_orders
-      pg_replication_initial_snapshot: 'true'
+      pg_replication_initial_snapshot: 'auto'
     acceleration:
       enabled: true
       engine: duckdb


### PR DESCRIPTION
The boolean value `'true'` for `pg_replication_initial_snapshot` is deprecated in Spice v2.2.0.

This change sets the value to `'auto'` to clear the runtime warning. The behavior does not change.

Verified by running the `postgres/cdc` recipe.