### PR TITLE
Fix cayenne recipe: refresh the startup and query transcripts

### DIFF
--- a/cayenne/README.md
+++ b/cayenne/README.md
@@ -41,10 +41,12 @@ Confirm in the terminal output the `taxi_trips` dataset has been loaded:
 
 ```bash
 Spice.ai runtime starting...
-2024-09-16T21:25:43.306009Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-09-16T21:25:43.309474Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-16T21:25:43.507974Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-09-16T21:25:44.101055Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
+2026-08-24T20:57:43.603253Z  INFO spiced: Starting runtime v2.1.5+models.metal
+2026-08-24T20:57:43.687793Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-24T20:57:43.968078Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-08-24T20:57:43.972502Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-08-24T20:57:49.910117Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled. duration_ms=18
+2026-08-24T20:57:50.043569Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 **Step 4.** Run queries against the dataset using the Spice SQL REPL.
@@ -64,20 +66,21 @@ select "VendorID", tpep_pickup_datetime, tpep_dropoff_datetime, passenger_count 
 ```
 +----------+----------------------+-----------------------+-----------------+
 | VendorID | tpep_pickup_datetime | tpep_dropoff_datetime | passenger_count |
+|   int32  |     timestamp[us]    |     timestamp[us]     |      int64      |
 +----------+----------------------+-----------------------+-----------------+
-| 2        | 2024-01-13T03:18:09  | 2024-01-13T03:24:37   | 1               |
-| 2        | 2024-01-13T03:52:58  | 2024-01-13T04:01:18   | 1               |
-| 2        | 2024-01-13T03:26:02  | 2024-01-13T03:34:43   | 1               |
-| 2        | 2024-01-13T03:53:44  | 2024-01-13T04:10:56   | 1               |
-| 2        | 2024-01-13T02:58:28  | 2024-01-13T03:14:33   | 1               |
-| 2        | 2024-01-13T03:54:24  | 2024-01-13T04:03:58   | 1               |
-| 2        | 2024-01-13T03:06:55  | 2024-01-13T03:50:08   | 3               |
-| 2        | 2024-01-13T03:22:26  | 2024-01-13T03:30:50   | 2               |
-| 2        | 2024-01-13T03:21:19  | 2024-01-13T03:46:54   | 1               |
-| 1        | 2024-01-13T03:13:35  | 2024-01-13T03:40:25   | 1               |
+| 1        | 2024-01-02T18:04:31  | 2024-01-02T18:11:49   | 0               |
+| 1        | 2024-01-02T18:13:28  | 2024-01-02T18:34:45   | 0               |
+| 1        | 2024-01-02T18:52:21  | 2024-01-02T18:57:43   | 0               |
+| 1        | 2024-01-02T18:37:05  | 2024-01-02T18:51:38   | 0               |
+| 1        | 2024-01-02T18:46:54  | 2024-01-02T18:53:18   | 0               |
+| 1        | 2024-01-02T18:18:22  | 2024-01-02T18:24:30   | 0               |
+| 1        | 2024-01-02T18:06:50  | 2024-01-02T18:25:04   | 0               |
+| 1        | 2024-01-02T18:45:31  | 2024-01-02T18:58:08   | 0               |
+| 1        | 2024-01-02T18:33:29  | 2024-01-02T18:42:09   | 0               |
+| 1        | 2024-01-02T18:05:25  | 2024-01-02T18:17:25   | 0               |
 +----------+----------------------+-----------------------+-----------------+
 
-Time: 4.684086261 seconds. 10 rows.
+Time: 1.256426375 seconds. 10 rows.
 ```
 
 **Step 5.** Update the `spicepod.yaml` to enable Cayenne acceleration.
@@ -101,12 +104,15 @@ datasets:
 **Step 6.** Restart the Spice app and observe the dataset loading and accelerating.
 
 ```bash
-2024-09-12T23:08:53.964728Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-09-12T23:08:53.965420Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-09-12T23:08:55.308963Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled.
-2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 167ms.
+Spice.ai runtime starting...
+2026-08-24T20:58:40.483388Z  INFO spiced: Starting runtime v2.1.5+models.metal
+2026-08-24T20:58:40.631669Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-08-24T20:58:40.897943Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-08-24T20:58:40.905264Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-08-24T20:58:43.033807Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled. duration_ms=477
+2026-08-24T20:58:43.035086Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
+2026-08-24T20:58:53.353320Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 302ms.
+2026-08-24T20:58:53.400890Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
 **Step 7.** Run a query against the `taxi_trips` dataset again, observing the fast query time.
@@ -118,20 +124,21 @@ select "VendorID", tpep_pickup_datetime, tpep_dropoff_datetime, passenger_count 
 ```
 +----------+----------------------+-----------------------+-----------------+
 | VendorID | tpep_pickup_datetime | tpep_dropoff_datetime | passenger_count |
+|   int32  |     timestamp[us]    |     timestamp[us]     |      int64      |
 +----------+----------------------+-----------------------+-----------------+
-| 2        | 2024-01-13T03:18:09  | 2024-01-13T03:24:37   | 1               |
-| 2        | 2024-01-13T03:52:58  | 2024-01-13T04:01:18   | 1               |
-| 2        | 2024-01-13T03:26:02  | 2024-01-13T03:34:43   | 1               |
-| 2        | 2024-01-13T03:53:44  | 2024-01-13T04:10:56   | 1               |
-| 2        | 2024-01-13T02:58:28  | 2024-01-13T03:14:33   | 1               |
-| 2        | 2024-01-13T03:54:24  | 2024-01-13T04:03:58   | 1               |
-| 2        | 2024-01-13T03:06:55  | 2024-01-13T03:50:08   | 3               |
-| 2        | 2024-01-13T03:22:26  | 2024-01-13T03:30:50   | 2               |
-| 2        | 2024-01-13T03:21:19  | 2024-01-13T03:46:54   | 1               |
-| 1        | 2024-01-13T03:13:35  | 2024-01-13T03:40:25   | 1               |
+| 1        | 2024-01-04T18:01:18  | 2024-01-04T18:11:46   | 1               |
+| 1        | 2024-01-04T18:13:06  | 2024-01-04T18:27:17   | 1               |
+| 1        | 2024-01-04T18:29:48  | 2024-01-04T18:52:12   | 1               |
+| 2        | 2024-01-04T18:19:18  | 2024-01-04T18:49:18   | 1               |
+| 2        | 2024-01-04T18:52:38  | 2024-01-04T19:12:11   | 1               |
+| 2        | 2024-01-04T18:29:18  | 2024-01-04T18:34:46   | 1               |
+| 2        | 2024-01-04T18:36:24  | 2024-01-04T18:55:09   | 1               |
+| 2        | 2024-01-04T18:26:17  | 2024-01-04T18:35:32   | 1               |
+| 2        | 2024-01-04T18:51:48  | 2024-01-04T19:05:35   | 1               |
+| 2        | 2024-01-04T18:06:09  | 2024-01-04T18:30:35   | 1               |
 +----------+----------------------+-----------------------+-----------------+
 
-Time: 0.023339453 seconds. 10 rows.
+Time: 0.064644125 seconds. 10 rows.
 ```
 
 ## Learn more


### PR DESCRIPTION
## Summary

Ran the Cayenne recipe end to end on current stable (v2.1.5) and every transcript in it was stale:

| Recipe says | v2.1.5 actually prints |
| --- | --- |
| `Loaded 2,964,624 rows (421.71 MiB) ... in 16s 167ms` | `Loaded 2,964,624 rows (399.38 MiB) ... in 10s 302ms` |
| cache line *after* the Flight/HTTP listener lines | cache line *before* them, and `Starting runtime v2.1.5+models.metal` above both |
| `Dataset taxi_trips registered (...), results cache enabled.` | same line plus `duration_ms=18` |
| query tables with a header row only | header row plus the data-type row (`int32`, `timestamp[us]`, `int64`) that v2 `spice sql` prints |

The 421.71 MiB figure is the same pre-v2 accelerated size that #588 corrected in the sibling [`acceleration/partitioning`](https://github.com/spiceai/cookbook/tree/trunk/acceleration/partitioning) recipe; this recipe accelerates the identical dataset with the identical engine, so it drifted the same way.

Row values in Steps 4 and 7 also differ from what the recipe shows — the `LIMIT 10` has no `ORDER BY`, so the rows the runtime returns are whatever the scan yields first (they differed between my own two runs). The tables here are the verbatim output of one live run rather than a promise of specific rows.

Config, steps, version floor (`v1.9+`), and links all check out unchanged.

## Verified against

spiceai/spiceai at v2.1.5 (current stable), CLI and runtime `v2.1.5+models.metal`.

## Evidence

Step 6, accelerated (`engine: cayenne`, `mode: file`):

```
2026-08-24T20:58:43.033807Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled. duration_ms=477
2026-08-24T20:58:43.035086Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
2026-08-24T20:58:53.353320Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 302ms.
2026-08-24T20:58:53.400890Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

The query the recipe uses took `1.256426375 seconds` against S3 and `0.064644125 seconds` once accelerated, so the point of the recipe still lands.
