### PR TITLE
Fix caching/accelerator recipe: complete the cache schema table

### DIFF
--- a/caching/accelerator/README.md
+++ b/caching/accelerator/README.md
@@ -161,15 +161,18 @@ The `+` and `-` keys on the time server adjust response delay:
 
 ## Cache Schema
 
-The caching accelerator automatically adds metadata fields to cached data:
+The cached table carries the request and response metadata alongside the content — `describe time` lists all eight columns:
 
-| Field           | Type      | Description                       |
-| --------------- | --------- | --------------------------------- |
-| `request_path`  | String    | The URL path used for the request |
-| `request_query` | String    | Query parameters from the request |
-| `request_body`  | String    | Request body (for POST requests)  |
-| `content`       | String    | The response content              |
-| `_fetched_at`   | Timestamp | When the data was fetched (named `fetched_at` on Spice `v1.x`) |
+| Field              | Type            | Description                                                    |
+| ------------------ | --------------- | -------------------------------------------------------------- |
+| `request_path`     | `Utf8`          | The URL path used for the request                              |
+| `request_query`    | `Utf8`          | Query parameters from the request                              |
+| `request_body`     | `Utf8`          | Request body (for POST requests)                               |
+| `request_headers`  | `Utf8`          | Headers sent with the request                                  |
+| `content`          | `Utf8`          | The response content                                           |
+| `response_status`  | `UInt16`        | HTTP status code returned by the upstream server               |
+| `response_headers` | `Map`           | Response headers, as a map of string keys to string values     |
+| `_fetched_at`      | `Timestamp(ns)` | When the data was fetched (named `fetched_at` on Spice `v1.x`) |
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary

The recipe's **Cache Schema** section lists five columns (`request_path`, `request_query`, `request_body`, `content`, `_fetched_at`) with prose types (`String`, `Timestamp`). The cached table actually has **eight** columns, and a reader who runs `describe time` after following the recipe sees three the section never mentions — including `response_status`, which is what you would query to see the effect of the recipe's own error-mode experiment (press `s` on the time server).

This PR replaces the table with the real schema and the types `describe` reports.

## Verified against

spiceai/spiceai at v2.1.5 (current stable) — [`crates/data_components/src/http/provider.rs`](https://github.com/spiceai/spiceai/blob/v2.1.5/crates/data_components/src/http/provider.rs) `base_table_schema()`, which declares all eight fields.

Everything else in the recipe checked out: the three accelerator params (`caching_ttl`, `caching_stale_while_revalidate_ttl`, `caching_stale_if_error`) all exist, the `v1.10+` floor is right (the `Caching` refresh-mode variant first appears in v1.10.0), `_fetched_at` is correct for v2.x, and both documentation links resolve.

## Evidence

Ran the recipe's spicepod against a stand-in time server on `localhost:7400` (same shape as `time_server/`: 1s delay, `Date` header, no cache headers), since the published image needs Docker:

```
sql> describe time;
+--------------+------------------+----------------------------------------------------------------------------------+-------------+
| table_schema |    column_name   |                                     data_type                                    | is_nullable |
+--------------+------------------+----------------------------------------------------------------------------------+-------------+
| public       | request_path     | Utf8                                                                             | NO          |
| public       | request_query    | Utf8                                                                             | YES         |
| public       | request_body     | Utf8                                                                             | YES         |
| public       | request_headers  | Utf8                                                                             | YES         |
| public       | content          | Utf8                                                                             | NO          |
| public       | response_status  | UInt16                                                                           | NO          |
| public       | response_headers | Map("entries": non-null Struct("keys": non-null Utf8, "values": Utf8), unsorted) | YES         |
| public       | _fetched_at      | Timestamp(ns)                                                                    | YES         |
+--------------+------------------+----------------------------------------------------------------------------------+-------------+
```

The caching behaviour the recipe describes held up in the same run: cold query 1.13s, repeat 0.03s, and after `caching_ttl` expired the stale row still came back immediately while the refresh ran in the background.

Two runtime observations from the run, neither of them recipe bugs, noted here for whoever owns them:

- The runtime logs `Dataset time: 'on_zero_results' is ignored when 'refresh_mode: caching' is set. Remove 'on_zero_results' from the dataset configuration to silence this warning.` — but this spicepod never sets `on_zero_results`, so the warning is unsilenceable as written.
- The URL in that warning, `https://spiceai.org/docs/components/data-accelerators/data-refresh#refresh-modes`, 404s.
