### PR TITLE
Fix stale accelerated size across 7 recipes

### DIFF
--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -79,7 +79,7 @@ Result:
 2024-12-12T22:10:02.221149Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2024-12-12T22:10:02.222425Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
 2024-12-12T22:10:06.212606Z  INFO runtime::accelerated_table::refresh_task: Loaded 74 rows (1.06 MiB) for dataset spiceai.files in 4s 570ms.
-2024-12-12T22:10:10.896203Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 8s 673ms.
+2024-12-12T22:10:10.896203Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 673ms.
 
 ```
 

--- a/client-sdk/gospice-sdk-sample/README.md
+++ b/client-sdk/gospice-sdk-sample/README.md
@@ -38,7 +38,7 @@ Sample runtime logs:
 2024-11-28T00:24:28.607738Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-28T00:24:29.247902Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2024-11-28T00:24:29.249355Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-11-28T00:24:37.106088Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 7s 856ms.
+2024-11-28T00:24:37.106088Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 7s 856ms.
 ```
 
 Run the Go sample in another terminal:

--- a/client-sdk/spice-java-sdk-sample/README.md
+++ b/client-sdk/spice-java-sdk-sample/README.md
@@ -37,7 +37,7 @@ Spice.ai runtime starting...
 2024-07-16T19:16:34.197770Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-07-16T19:16:34.885084Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2024-07-16T19:16:34.886257Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-07-16T19:16:40.494038Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 5s 607ms.
+2024-07-16T19:16:40.494038Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 5s 607ms.
 ```
 
 In another terminal, compile and run:

--- a/client-sdk/spice-rs-sdk-sample/README.md
+++ b/client-sdk/spice-rs-sdk-sample/README.md
@@ -30,7 +30,7 @@ spice run
 2024-11-27T20:46:11.544488Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-27T20:46:12.286180Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2024-11-27T20:46:12.287391Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-11-27T20:46:22.751704Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 10s 464ms.
+2024-11-27T20:46:22.751704Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 464ms.
 ```
 
 ## Build sample application

--- a/duckdb/accelerator/README.md
+++ b/duckdb/accelerator/README.md
@@ -108,7 +108,7 @@ datasets:
 2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-12T23:08:55.308963Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file), results cache enabled.
 2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 167ms.
+2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 167ms.
 ```
 
 **Step 7.** Run a query against the `taxi_trips` dataset again, observing the fast query time.

--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -45,7 +45,7 @@ Spice.ai runtime starting...
 2024-08-05T14:35:55.354940Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-08-05T14:35:56.584438Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 2024-08-05T14:35:56.585614Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-08-05T14:36:06.654548Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 10s 68ms.
+2024-08-05T14:36:06.654548Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 68ms.
 ```
 
 Run `spice sql` to check the number of rows and the 5 earliest records sorted by `tpep_pickup_datetime`

--- a/sqlite/accelerator/README.md
+++ b/sqlite/accelerator/README.md
@@ -115,7 +115,7 @@ The following output is shown in the Spice runtime terminal confirming new confi
 2024-09-10T06:59:21.908667Z  INFO runtime: Unloaded dataset taxi_trips
 2024-09-10T06:59:22.524295Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (sqlite:file), results cache enabled.
 2024-09-10T06:59:22.525789Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-09-10T06:59:39.244473Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 718ms.
+2024-09-10T06:59:39.244473Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 718ms.
 ```
 
 Run query to display the longest taxi trips again:


### PR DESCRIPTION
## Summary

Seven recipes print a refresh line for the shared `s3://spiceai-demo-datasets/taxi_trips/2024/` dataset with a pre-v2 accelerated size — `421.71 MiB` or `419.31 MiB`. On current stable the same 2,964,624 rows load as **399.38 MiB**, which is already the figure in [`acceleration/partitioning`](https://github.com/spiceai/cookbook/tree/trunk/acceleration/partitioning) and [`acceleration/cron`](https://github.com/spiceai/cookbook/tree/trunk/acceleration/cron).

Only the size is changed. The timestamps and load durations in those transcripts are left alone — they are illustrative and machine-dependent, whereas the size is a property of the dataset a reader can compare against directly.

Files: `refresh-data-window`, `azure_openai`, `sqlite/accelerator`, `duckdb/accelerator`, and the Go, Java, and Rust SDK samples.

`s3/README.md` carries the same drift in two places but is already being edited by #607, so it is left out of this PR to avoid a conflict; `cayenne/README.md` is covered by #611.

## Verified against

spiceai/spiceai at v2.1.5 (current stable), runtime `v2.1.5+models.metal`.

## Evidence

One spicepod, the same S3 dataset accelerated three ways — the size is engine-independent, so a single figure is right for all seven recipes:

```
2026-08-24T21:07:36.397178Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset t_arrow in 12s 114ms.
2026-08-24T21:07:40.247571Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset t_duckdb in 15s 752ms.
2026-08-24T21:07:40.478864Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset t_sqlite in 16s 130ms.
```

A separate Cayenne run of the same dataset reported `399.38 MiB` as well.
