### PR TITLE
Fix serializable-transactions recipe: use 'auto' for pg_replication_initial_snapshot

### DIFF
--- a/serializable-transactions/spicepod.yaml
+++ b/serializable-transactions/spicepod.yaml
@@ -25,7 +25,7 @@ datasets:
       pg_pass: ${secrets:PG_PASS}
       pg_sslmode: disable
       pg_replication_slot: spice_checking
-      pg_replication_initial_snapshot: "true"
+      pg_replication_initial_snapshot: "auto"
     replication:
       enabled: true
     acceleration:
@@ -49,7 +49,7 @@ datasets:
       pg_pass: ${secrets:PG_PASS}
       pg_sslmode: disable
       pg_replication_slot: spice_savings
-      pg_replication_initial_snapshot: "true"
+      pg_replication_initial_snapshot: "auto"
     replication:
       enabled: true
     acceleration:


### PR DESCRIPTION
## Summary

`serializable-transactions/spicepod.yaml` sets `pg_replication_initial_snapshot: "true"` on both datasets. v2.2.0 deprecates the boolean spellings, so every run logs:

```
parameter `pg_replication_initial_snapshot` uses the deprecated boolean value "true"; use 'auto' instead (or 'always'/'disabled')
```

`"true"` maps to `auto`, so this is a rename with no behaviour change — the same fix #608 makes to `postgres/cdc`, which is the only other recipe that sets the parameter.

## Verified against

spiceai/spiceai at `trunk` (v2.2.0) — `crates/data-connectors/connector-postgres/src/replication.rs`, `parse_initial_snapshot`: the canonical vocabulary is `auto | always | disabled`, and `true|1|yes|y` is accepted as a deprecated alias for `auto` with the warning above.

## Evidence

Static review; this recipe needs a Postgres with logical replication and the Cayenne write-back path, which I could not stand up here. The change is a value rename verified directly against the parser, and the recipe's README does not quote the parameter, so nothing else needs updating.
