### PR TITLE
Fix accelerated-table log module path and stale load sizes for v2.2.0

### DIFF
--- a/acceleration/cron/README.md
+++ b/acceleration/cron/README.md
@@ -31,8 +31,8 @@ Spice.ai runtime starting...
 2026-08-05T12:06:14.412746Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-08-05T12:06:14.415936Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-05T12:06:19.784484Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2026-08-05T12:06:19.785986Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-05T12:06:23.126886Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 3s 340ms.
+2026-08-05T12:06:19.785986Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-05T12:06:23.126886Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 3s 340ms.
 ```
 
 ## Step 2. Configure a cron refresh schedule
@@ -74,11 +74,11 @@ After the initial load, observe that the `taxi_trips` dataset refreshes on every
 2025-06-09T06:27:33.627071Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
 2025-06-09T06:27:33.630576Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-06-09T06:27:35.928527Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2025-06-09T06:27:35.929924Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:27:50.915273Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 14s 985ms.
+2025-06-09T06:27:35.929924Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-06-09T06:27:50.915273Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 14s 985ms.
 2025-06-09T06:27:50.986350Z  INFO runtime: All components are loaded. Spice runtime is ready!
-2025-06-09T06:28:00.001597Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:28:13.954105Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 952ms.
-2025-06-09T06:28:30.001882Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-06-09T06:28:43.802372Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 800ms.
+2025-06-09T06:28:00.001597Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-06-09T06:28:13.954105Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 952ms.
+2025-06-09T06:28:30.001882Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-06-09T06:28:43.802372Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 13s 800ms.
 ```

--- a/acceleration/data-refresh/README.md
+++ b/acceleration/data-refresh/README.md
@@ -31,8 +31,8 @@ Spice.ai runtime starting...
 2026-08-05T12:06:14.412746Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-08-05T12:06:14.415936Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-05T12:06:19.784484Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2026-08-05T12:06:19.785986Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-05T12:06:23.126886Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 3s 340ms.
+2026-08-05T12:06:19.785986Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-05T12:06:23.126886Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 3s 340ms.
 ```
 
 **In a new terminal window**, run `spice sql` to start the Spice SQL REPL.
@@ -86,8 +86,8 @@ datasets:
 Save the file and note that the dataset has been updated:
 
 ```console
-2026-08-05T12:07:15.397249Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-05T12:07:17.674699Z  INFO runtime::accelerated_table::refresh_task: Loaded 405,103 rows (55.13 MiB) for dataset taxi_trips in 2s 277ms.
+2026-08-05T12:07:15.397249Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-05T12:07:17.674699Z  INFO runtime_table::accelerated::refresh_task: Loaded 405,103 rows (55.13 MiB) for dataset taxi_trips in 2s 277ms.
 2026-08-05T12:07:18.827981Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 ```
 
@@ -126,7 +126,7 @@ curl -i -X PATCH \
 ```
 
 ```bash
-2026-08-05T12:07:57.314898Z  INFO runtime::accelerated_table: [refresh] Updated refresh SQL for taxi_trips to SELECT * FROM taxi_trips WHERE passenger_count = 3
+2026-08-05T12:07:57.314898Z  INFO runtime_table::accelerated: [refresh] Updated refresh SQL for taxi_trips to SELECT * FROM taxi_trips WHERE passenger_count = 3
 ```
 
 The updated `refresh_sql` will be applied on the _next_ refresh. With no `refresh_check_interval` configured, that refresh has to be triggered.
@@ -138,8 +138,8 @@ curl -i -H "Content-Type: application/json" -X POST localhost:8090/v1/datasets/t
 ```
 
 ```bash
-2026-08-05T12:07:57.325903Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-05T12:07:59.150212Z  INFO runtime::accelerated_table::refresh_task: Loaded 91,262 rows (13.19 MiB) for dataset taxi_trips in 1s 824ms.
+2026-08-05T12:07:57.325903Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-05T12:07:59.150212Z  INFO runtime_table::accelerated::refresh_task: Loaded 91,262 rows (13.19 MiB) for dataset taxi_trips in 1s 824ms.
 ```
 
 Swap to the Spice SQL REPL and enter:

--- a/acceleration/dual-dataset-registration/README.md
+++ b/acceleration/dual-dataset-registration/README.md
@@ -90,7 +90,7 @@ Shortly after startup you will see both datasets register. The federated table i
 ```bash
 2025-03-24T10:00:01.123456Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), results cache enabled.
 2025-03-24T10:00:01.234567Z  INFO runtime::init::dataset: Dataset taxi_trips_accelerated registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file, 1800s refresh), results cache enabled.
-2025-03-24T10:00:01.234890Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips_accelerated
+2025-03-24T10:00:01.234890Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips_accelerated
 ```
 
 ## Step 4. Query the federated table immediately
@@ -187,7 +187,7 @@ When the acceleration finishes, `taxi_trips_accelerated` reports `Ready`:
 The Spice runtime logs also confirm when the load completes:
 
 ```bash
-2025-03-24T10:03:45.678901Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips_accelerated in 3m 44s.
+2025-03-24T10:03:45.678901Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips_accelerated in 3m 44s.
 ```
 
 ## Step 6. Switch to the accelerated table

--- a/acceleration/indexes/README.md
+++ b/acceleration/indexes/README.md
@@ -33,10 +33,10 @@ spice run
 2024-09-30T18:04:26.270747Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-30T18:04:26.286500Z  INFO runtime::init::dataset: Dataset traces registered (file:large_eth_traces.parquet), acceleration (duckdb:file), results cache enabled.
 2024-09-30T18:04:26.287326Z  INFO runtime::init::dataset: Dataset traces_no_index registered (file:large_eth_traces.parquet), acceleration (duckdb:file), results cache enabled.
-2024-09-30T18:04:26.287668Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset traces
-2024-09-30T18:04:26.288332Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset traces_no_index
-2024-09-30T18:05:00.532792Z  INFO runtime::accelerated_table::refresh_task: Loaded 7,595,994 rows (7.04 GiB) for dataset traces in 34s 245ms.
-2024-09-30T18:05:00.683737Z  INFO runtime::accelerated_table::refresh_task: Loaded 7,595,994 rows (7.04 GiB) for dataset traces_no_index in 34s 395ms.
+2024-09-30T18:04:26.287668Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset traces
+2024-09-30T18:04:26.288332Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset traces_no_index
+2024-09-30T18:05:00.532792Z  INFO runtime_table::accelerated::refresh_task: Loaded 7,595,994 rows (7.04 GiB) for dataset traces in 34s 245ms.
+2024-09-30T18:05:00.683737Z  INFO runtime_table::accelerated::refresh_task: Loaded 7,595,994 rows (7.04 GiB) for dataset traces_no_index in 34s 395ms.
 ```
 
 **Step 3.** Run a query on the dataset without an index

--- a/acceleration/partitioning/README.md
+++ b/acceleration/partitioning/README.md
@@ -50,8 +50,8 @@ Spice.ai runtime starting...
 2026-08-15T12:09:50.646429Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-08-15T12:09:50.646776Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-15T12:09:51.818849Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled. duration_ms=101
-2026-08-15T12:09:51.820118Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-15T12:10:02.183762Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 363ms.
+2026-08-15T12:09:51.820118Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-15T12:10:02.183762Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 363ms.
 2026-08-15T12:10:02.265750Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
@@ -131,8 +131,8 @@ The `bucket(50, PULocationID)` function hashes the `PULocationID` column and dis
 2026-08-15T12:11:09.656053Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-15T12:11:09.664397Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
 2026-08-15T12:11:15.122630Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled. duration_ms=76
-2026-08-15T12:11:15.123765Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-15T12:11:23.519321Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 395ms.
+2026-08-15T12:11:15.123765Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-15T12:11:23.519321Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 395ms.
 2026-08-15T12:11:23.604755Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/arrow/README.md
+++ b/arrow/README.md
@@ -109,8 +109,8 @@ datasets:
 
 ```bash
 2026-08-13T12:19:22.038848Z  INFO runtime::init::dataset: Accelerated Dataset taxi_trips updating...
-2026-08-13T12:19:23.118534Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-13T12:19:25.902457Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 2s 783ms.
+2026-08-13T12:19:23.118534Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-13T12:19:25.902457Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 2s 783ms.
 2026-08-13T12:19:26.977420Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled. duration_ms=0
 ```
 

--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -74,12 +74,12 @@ Result:
 2024-12-12T22:10:01.248962Z  INFO runtime::init::model: Loading model [chat-model] from azure:gpt-4o-mini...
 2024-12-12T22:10:01.448894Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-12-12T22:10:01.640572Z  INFO runtime::init::dataset: Dataset spiceai.files registered (github:github.com/spiceai/spiceai/files/trunk), acceleration (arrow), results cache enabled.
-2024-12-12T22:10:01.641876Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.files
+2024-12-12T22:10:01.641876Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.files
 2024-12-12T22:10:01.920208Z  INFO runtime::init::model: Model [chat-model] deployed, ready for inferencing
 2024-12-12T22:10:02.221149Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2024-12-12T22:10:02.222425Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-12-12T22:10:06.212606Z  INFO runtime::accelerated_table::refresh_task: Loaded 74 rows (1.06 MiB) for dataset spiceai.files in 4s 570ms.
-2024-12-12T22:10:10.896203Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 673ms.
+2024-12-12T22:10:02.222425Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-12-12T22:10:06.212606Z  INFO runtime_table::accelerated::refresh_task: Loaded 74 rows (1.06 MiB) for dataset spiceai.files in 4s 570ms.
+2024-12-12T22:10:10.896203Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 673ms.
 
 ```
 

--- a/cayenne/README.md
+++ b/cayenne/README.md
@@ -110,8 +110,8 @@ Spice.ai runtime starting...
 2026-08-24T20:58:40.897943Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-08-24T20:58:40.905264Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-24T20:58:43.033807Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (cayenne:file), results cache enabled. duration_ms=477
-2026-08-24T20:58:43.035086Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2026-08-24T20:58:53.353320Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 302ms.
+2026-08-24T20:58:43.035086Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-08-24T20:58:53.353320Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 302ms.
 2026-08-24T20:58:53.400890Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/cdc-debezium/.env
+++ b/cdc-debezium/.env
@@ -1,3 +1,3 @@
-SPICED_LOG="runtime::accelerated_table::refresh_task::changes=TRACE,info"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,info"
 KAFKA_USERNAME=admin
 KAFKA_PASSWORD=admin123

--- a/cdc-debezium/.env
+++ b/cdc-debezium/.env
@@ -1,3 +1,3 @@
-SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,info"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,runtime::accelerated_table::refresh_task::changes=TRACE,info"
 KAFKA_USERNAME=admin
 KAFKA_PASSWORD=admin123

--- a/cdc-debezium/README.md
+++ b/cdc-debezium/README.md
@@ -64,7 +64,7 @@ datasets:
 Spice runtime is already configured to run with the debug level of information, with environment variable configured in `cdc-debezium/.env`
 
 ```bash
-SPICED_LOG="runtime::accelerated_table::refresh_task::changes=TRACE,info"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,info"
 ```
 
 Ensure the current directory is `cdc-debezium`, and start the spice runtime with the following command
@@ -77,8 +77,8 @@ Observe that it consumes all of the changes. It should look like:
 
 ```bash
 2026-05-06T18:28:22.326698Z  INFO runtime::init::dataset: Dataset cdc registered (debezium:cdc.public.customer_addresses), acceleration (sqlite:file, changes), results cache enabled.
-2026-05-06T18:28:23.828971Z TRACE runtime::accelerated_table::refresh_task::changes: Processing append/change stream batch: dataset=cdc, rows=50, sub-batches=1
-2026-05-06T18:28:23.828986Z TRACE runtime::accelerated_table::refresh_task::changes: Processing upsert batch for cdc with 50 rows
+2026-05-06T18:28:23.828971Z TRACE runtime_table::accelerated::refresh_task::changes: Processing append/change stream batch: dataset=cdc, rows=50, sub-batches=1
+2026-05-06T18:28:23.828986Z TRACE runtime_table::accelerated::refresh_task::changes: Processing upsert batch for cdc with 50 rows
 ...
 ```
 
@@ -105,7 +105,7 @@ VALUES
 Notice that the Spice log shows the change.
 
 ```bash
-2026-05-06T18:30:24.317690Z TRACE runtime::accelerated_table::refresh_task::changes: Processing upsert batch for cdc with 1 rows
+2026-05-06T18:30:24.317690Z TRACE runtime_table::accelerated::refresh_task::changes: Processing upsert batch for cdc with 1 rows
 ```
 
 Querying the data again from the `spice sql` REPL will show the new record.

--- a/cdc-debezium/README.md
+++ b/cdc-debezium/README.md
@@ -64,7 +64,7 @@ datasets:
 Spice runtime is already configured to run with the debug level of information, with environment variable configured in `cdc-debezium/.env`
 
 ```bash
-SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,info"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=TRACE,runtime::accelerated_table::refresh_task::changes=TRACE,info"
 ```
 
 Ensure the current directory is `cdc-debezium`, and start the spice runtime with the following command

--- a/cdc-debezium/sasl-scram/README.md
+++ b/cdc-debezium/sasl-scram/README.md
@@ -88,8 +88,8 @@ Observe that it consumes all of the changes. It should look like:
 
 ```bash
 2024-07-01T12:39:22.207145Z  INFO runtime::init::dataset: Dataset cdc registered (debezium:cdc.inventory.customer_addresses), acceleration (sqlite:file, changes), results cache enabled.
-2024-07-01T12:39:22.677117Z  INFO runtime::accelerated_table::refresh_task::changes: Upserting data row for cdc with id=3
-2024-07-01T12:39:22.692018Z  INFO runtime::accelerated_table::refresh_task::changes: Upserting data row for cdc with id=4
+2024-07-01T12:39:22.677117Z  INFO runtime_table::accelerated::refresh_task::changes: Upserting data row for cdc with id=3
+2024-07-01T12:39:22.692018Z  INFO runtime_table::accelerated::refresh_task::changes: Upserting data row for cdc with id=4
 ...
 ```
 
@@ -116,7 +116,7 @@ VALUES
 Notice that the Spice log shows the change.
 
 ```bash
-2024-08-26T22:29:48.540739Z DEBUG runtime::accelerated_table::refresh_task::changes: Upserting data row for cdc with id=100
+2024-08-26T22:29:48.540739Z DEBUG runtime_table::accelerated::refresh_task::changes: Upserting data row for cdc with id=100
 ```
 
 Querying the data again from the `spice sql` REPL will show the new record.

--- a/client-sdk/gospice-sdk-sample/README.md
+++ b/client-sdk/gospice-sdk-sample/README.md
@@ -37,8 +37,8 @@ Sample runtime logs:
 2024-11-28T00:24:28.419672Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-11-28T00:24:28.607738Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-28T00:24:29.247902Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2024-11-28T00:24:29.249355Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-11-28T00:24:37.106088Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 7s 856ms.
+2024-11-28T00:24:29.249355Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-11-28T00:24:37.106088Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 7s 856ms.
 ```
 
 Run the Go sample in another terminal:

--- a/client-sdk/spice-dotnet-sdk-sample/README.md
+++ b/client-sdk/spice-dotnet-sdk-sample/README.md
@@ -37,8 +37,8 @@ Sample runtime logs:
 2025-08-28T21:08:11.151175Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
 2025-08-28T21:08:11.162604Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-28T21:08:12.336410Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2025-08-28T21:08:12.338066Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-08-28T21:08:20.383434Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 8s 45ms.
+2025-08-28T21:08:12.338066Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-08-28T21:08:20.383434Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 8s 45ms.
 2025-08-28T21:08:20.455383Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/client-sdk/spice-dotnet-sdk-sample/README.md
+++ b/client-sdk/spice-dotnet-sdk-sample/README.md
@@ -38,7 +38,7 @@ Sample runtime logs:
 2025-08-28T21:08:11.162604Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-28T21:08:12.336410Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2025-08-28T21:08:12.338066Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2025-08-28T21:08:20.383434Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 8s 45ms.
+2025-08-28T21:08:20.383434Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 45ms.
 2025-08-28T21:08:20.455383Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/client-sdk/spice-java-sdk-sample/README.md
+++ b/client-sdk/spice-java-sdk-sample/README.md
@@ -36,8 +36,8 @@ Spice.ai runtime starting...
 2024-07-16T19:16:34.197759Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-16T19:16:34.197770Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-07-16T19:16:34.885084Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2024-07-16T19:16:34.886257Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-07-16T19:16:40.494038Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 5s 607ms.
+2024-07-16T19:16:34.886257Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-07-16T19:16:40.494038Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 5s 607ms.
 ```
 
 In another terminal, compile and run:

--- a/client-sdk/spice-rs-sdk-sample/README.md
+++ b/client-sdk/spice-rs-sdk-sample/README.md
@@ -29,8 +29,8 @@ spice run
 2024-11-27T20:46:11.346653Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-11-27T20:46:11.544488Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-11-27T20:46:12.286180Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2024-11-27T20:46:12.287391Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-11-27T20:46:22.751704Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 464ms.
+2024-11-27T20:46:12.287391Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-11-27T20:46:22.751704Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 464ms.
 ```
 
 ## Build sample application

--- a/client-sdk/spicepy-sdk-sample/README.md
+++ b/client-sdk/spicepy-sdk-sample/README.md
@@ -43,7 +43,7 @@ Sample runtime logs:
 2025-01-27T19:54:02.157072Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:54:02.866819Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2025-01-27T19:54:02.868324Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2025-01-27T19:54:13.743056Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 874ms.
+2025-01-27T19:54:13.743056Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 874ms.
 ```
 
 Run the Python sample in another terminal:

--- a/client-sdk/spicepy-sdk-sample/README.md
+++ b/client-sdk/spicepy-sdk-sample/README.md
@@ -42,8 +42,8 @@ Sample runtime logs:
 2025-01-27T19:54:01.958254Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-27T19:54:02.157072Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-27T19:54:02.866819Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2025-01-27T19:54:02.868324Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-01-27T19:54:13.743056Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 874ms.
+2025-01-27T19:54:02.868324Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-01-27T19:54:13.743056Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 874ms.
 ```
 
 Run the Python sample in another terminal:

--- a/deepseek/README.md
+++ b/deepseek/README.md
@@ -59,7 +59,7 @@ Result:
 2025-01-21T22:48:40.570139Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-01-21T22:48:40.769265Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-21T22:48:41.380306Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2025-01-21T22:48:41.381620Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
+2025-01-21T22:48:41.381620Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
 2025-01-21T22:48:44.001483Z  INFO runtime::init::model: Model [deepseek] deployed, ready for inferencing
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -76,7 +76,7 @@ spiced-container      | 2024-12-19T01:36:24.888807Z  INFO runtime::init::dataset
 spiced-container      | 2024-12-19T01:36:24.888926Z  INFO runtime::init::model: Loading model [openai] from openai:gpt-4o...
 spiced-container      | 2024-12-19T01:36:24.889476Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 spiced-container      | 2024-12-19T01:36:24.904304Z  INFO runtime::init::dataset: Dataset films registered (mysql:film), acceleration (arrow), results cache enabled.
-spiced-container      | 2024-12-19T01:36:24.905805Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset films
+spiced-container      | 2024-12-19T01:36:24.905805Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset films
 spiced-container      | 2024-12-19T01:36:28.185593Z  INFO runtime::init::model: Model [openai] deployed, ready for inferencing
 ```
 

--- a/duckdb/accelerator/README.md
+++ b/duckdb/accelerator/README.md
@@ -107,8 +107,8 @@ datasets:
 2024-09-12T23:08:53.965420Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-09-12T23:08:53.965471Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-09-12T23:08:55.308963Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (duckdb:file), results cache enabled.
-2024-09-12T23:08:55.310382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-09-12T23:09:11.477553Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 167ms.
+2024-09-12T23:08:55.310382Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-09-12T23:09:11.477553Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 167ms.
 ```
 
 **Step 7.** Run a query against the `taxi_trips` dataset again, observing the fast query time.

--- a/dynamodb/README.md
+++ b/dynamodb/README.md
@@ -77,8 +77,8 @@ If your credentials and region are correct, the dataset will load and logs outpu
 ```bash
 INFO runtime::init::dataset: Dataset sample_data initializing...
 INFO runtime::init::dataset: Dataset sample_data registered (dynamodb:sample_data), acceleration (arrow), results cache enabled.
-INFO runtime::accelerated_table::refresh_task: Loading data for dataset sample_data
-INFO runtime::accelerated_table::refresh_task: Loaded 2 rows (3.25 kiB) for dataset sample_data in 34ms.
+INFO runtime_table::accelerated::refresh_task: Loading data for dataset sample_data
+INFO runtime_table::accelerated::refresh_task: Loaded 2 rows (3.25 kiB) for dataset sample_data in 34ms.
 ```
 
 ---

--- a/ftp/README.md
+++ b/ftp/README.md
@@ -41,8 +41,8 @@ Output:
 2025-06-09T17:59:21.491284Z  INFO runtime::init::dataset: Dataset customers initializing...
 2025-06-09T17:59:21.492025Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-06-09T17:59:21.633945Z  INFO runtime::init::dataset: Dataset customers registered (ftp://localhost/customers.csv), acceleration (arrow, 10s refresh), results cache enabled.
-2025-06-09T17:59:21.635123Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customers
-2025-06-09T17:59:21.707071Z  INFO runtime::accelerated_table::refresh_task: Loaded 100 rows (23.05 kiB) for dataset customers in 71ms.
+2025-06-09T17:59:21.635123Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset customers
+2025-06-09T17:59:21.707071Z  INFO runtime_table::accelerated::refresh_task: Loaded 100 rows (23.05 kiB) for dataset customers in 71ms.
 2025-06-09T17:59:21.735570Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/full-text-search/README.md
+++ b/full-text-search/README.md
@@ -53,7 +53,7 @@ Wait for the dataset to load and index:
 
 ```shell
 2026-01-21T01:00:00.000000Z  INFO runtime::init::dataset: Dataset cookbook_files registered (github:github.com/spiceai/cookbook/files/trunk), acceleration (arrow), results cache enabled.
-2026-01-21T01:00:05.000000Z  INFO runtime::accelerated_table::refresh_task: Loaded 104 rows (1.13 MiB) for dataset cookbook_files in 4s.
+2026-01-21T01:00:05.000000Z  INFO runtime_table::accelerated::refresh_task: Loaded 104 rows (1.13 MiB) for dataset cookbook_files in 4s.
 2026-01-21T01:00:05.100000Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/github/README.md
+++ b/github/README.md
@@ -52,26 +52,26 @@ spice run
 2025-07-16T15:17:14.162515Z  INFO runtime::init::dataset: Dataset spiceai.files initializing...
 2025-07-16T15:17:14.166935Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-07-16T15:17:15.311687Z  INFO runtime::init::dataset: Dataset spiceai.commits registered (github:github.com/spiceai/spiceai/commits), acceleration (arrow), results cache enabled.
-2025-07-16T15:17:15.313347Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.commits
+2025-07-16T15:17:15.313347Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.commits
 2025-07-16T15:17:15.507378Z  INFO runtime::init::dataset: Dataset spiceai.stargazers registered (github:github.com/spiceai/spiceai/stargazers), acceleration (arrow), results cache enabled.
-2025-07-16T15:17:15.508684Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.stargazers
+2025-07-16T15:17:15.508684Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.stargazers
 2025-07-16T15:17:16.406635Z  INFO runtime::init::dataset: Dataset spiceai.files registered (github:github.com/spiceai/spiceai/files/trunk), acceleration (arrow), results cache enabled.
-2025-07-16T15:17:16.407961Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.files
+2025-07-16T15:17:16.407961Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.files
 2025-07-16T15:17:16.772995Z  INFO runtime::init::dataset: Dataset spiceai.issues registered (github:github.com/spiceai/spiceai/issues), acceleration (arrow), results cache enabled.
-2025-07-16T15:17:16.774218Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.issues
+2025-07-16T15:17:16.774218Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.issues
 2025-07-16T15:17:17.447103Z  INFO runtime::init::dataset: Dataset apache.members registered (github:github.com/apache/members), acceleration (arrow), results cache enabled.
-2025-07-16T15:17:17.448839Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset apache.members
+2025-07-16T15:17:17.448839Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset apache.members
 ```
 
 Wait until all datasets are loaded:
 
 ```console
-2025-07-16T15:17:18.240151Z  INFO runtime::accelerated_table::refresh_task: Loaded 52 rows (184.75 kiB) for dataset spiceai.issues in 1s 465ms.
-2025-07-16T15:17:19.861151Z  INFO runtime::accelerated_table::refresh_task: Loaded 300 rows (617.12 kiB) for dataset spiceai.stargazers in 4s 352ms.
-2025-07-16T15:17:19.965102Z  INFO runtime::accelerated_table::refresh_task: Loaded 300 rows (618.50 kiB) for dataset apache.members in 2s 516ms.
-2025-07-16T15:17:23.204760Z  INFO runtime::accelerated_table::refresh_task: Loaded 140 rows (1.20 MiB) for dataset spiceai.files in 6s 796ms.
-2025-07-16T15:17:26.329481Z  INFO runtime::accelerated_table::refresh_task: Loaded 49 rows (149.97 kiB) for dataset spiceai.pulls in 3s 203ms.
-2025-07-16T15:17:26.419725Z  INFO runtime::accelerated_table::refresh_task: Loaded 300 rows (908.66 kiB) for dataset spiceai.commits in 11s 106ms.
+2025-07-16T15:17:18.240151Z  INFO runtime_table::accelerated::refresh_task: Loaded 52 rows (184.75 kiB) for dataset spiceai.issues in 1s 465ms.
+2025-07-16T15:17:19.861151Z  INFO runtime_table::accelerated::refresh_task: Loaded 300 rows (617.12 kiB) for dataset spiceai.stargazers in 4s 352ms.
+2025-07-16T15:17:19.965102Z  INFO runtime_table::accelerated::refresh_task: Loaded 300 rows (618.50 kiB) for dataset apache.members in 2s 516ms.
+2025-07-16T15:17:23.204760Z  INFO runtime_table::accelerated::refresh_task: Loaded 140 rows (1.20 MiB) for dataset spiceai.files in 6s 796ms.
+2025-07-16T15:17:26.329481Z  INFO runtime_table::accelerated::refresh_task: Loaded 49 rows (149.97 kiB) for dataset spiceai.pulls in 3s 203ms.
+2025-07-16T15:17:26.419725Z  INFO runtime_table::accelerated::refresh_task: Loaded 300 rows (908.66 kiB) for dataset spiceai.commits in 11s 106ms.
 ```
 
 **Step 3.** Run `spice sql` in a new terminal to start an interactive SQL query session against the Spice runtime.

--- a/graphql/README.md
+++ b/graphql/README.md
@@ -80,8 +80,8 @@ Example output:
 2025-07-07T18:32:50.761704Z  INFO runtime::init::dataset: Dataset stargazers initializing...
 2025-07-07T18:32:50.761790Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-07-07T18:32:52.129189Z  INFO runtime::init::dataset: Dataset stargazers registered (graphql:https://api.github.com/graphql), acceleration (arrow), results cache enabled.
-2025-07-07T18:32:52.130877Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset stargazers
-2025-07-07T18:33:14.858107Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,478 rows (2.59 MiB) for dataset stargazers in 22s 727ms.
+2025-07-07T18:32:52.130877Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset stargazers
+2025-07-07T18:33:14.858107Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,478 rows (2.59 MiB) for dataset stargazers in 22s 727ms.
 2025-07-07T18:33:14.930166Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/json_strings/README.md
+++ b/json_strings/README.md
@@ -80,8 +80,8 @@ Result:
 2026-08-01T12:22:17.794970Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2026-08-01T12:22:17.796959Z  INFO runtime::init::dataset: Dataset products registered (file://tshirts.csv), acceleration (arrow), results cache enabled. duration_ms=0
 2026-08-01T12:22:17.797065Z  INFO runtime::datafusion: Initializing view products_with_color
-2026-08-01T12:22:17.798404Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset products
-2026-08-01T12:22:17.799379Z  INFO runtime::accelerated_table::refresh_task: Loaded 8 rows (3.46 kiB) for dataset products in 0s.
+2026-08-01T12:22:17.798404Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset products
+2026-08-01T12:22:17.799379Z  INFO runtime_table::accelerated::refresh_task: Loaded 8 rows (3.46 kiB) for dataset products in 0s.
 2026-08-01T12:22:18.721572Z  INFO runtime::datafusion: View products_with_color registered.
 2026-08-01T12:22:18.820636Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```

--- a/kafka/.env
+++ b/kafka/.env
@@ -1,1 +1,1 @@
-SPICED_LOG="runtime_table::accelerated::refresh_task::changes=DEBUG,runtime=INFO"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=DEBUG,runtime::accelerated_table::refresh_task::changes=DEBUG,runtime=INFO"

--- a/kafka/.env
+++ b/kafka/.env
@@ -1,1 +1,1 @@
-SPICED_LOG="runtime::accelerated_table::refresh_task::changes=DEBUG,runtime=INFO"
+SPICED_LOG="runtime_table::accelerated::refresh_task::changes=DEBUG,runtime=INFO"

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -79,8 +79,8 @@ Observe that Spice loads data from the configured Kafka topic into the `orders` 
 2025-08-24T05:06:41.527790Z  INFO runtime::init::dataset: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb:file), results cache enabled.
 2025-08-24T05:06:41.531264Z  INFO runtime::init::dataset: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb:file), results cache enabled.
 2025-08-24T05:06:41.531332Z  INFO runtime::init::dataset: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb:file), results cache enabled.
-2025-08-24T05:06:54.138084Z DEBUG runtime::accelerated_table::refresh_task::changes: Inserting data row for orders
-2025-08-24T05:06:54.167452Z DEBUG runtime::accelerated_table::refresh_task::changes: Inserting data row for orders
+2025-08-24T05:06:54.138084Z DEBUG runtime_table::accelerated::refresh_task::changes: Inserting data row for orders
+2025-08-24T05:06:54.167452Z DEBUG runtime_table::accelerated::refresh_task::changes: Inserting data row for orders
 ...
 ```
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -79,10 +79,15 @@ Observe that Spice loads data from the configured Kafka topic into the `orders` 
 2025-08-24T05:06:41.527790Z  INFO runtime::init::dataset: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb:file), results cache enabled.
 2025-08-24T05:06:41.531264Z  INFO runtime::init::dataset: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb:file), results cache enabled.
 2025-08-24T05:06:41.531332Z  INFO runtime::init::dataset: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb:file), results cache enabled.
-2025-08-24T05:06:54.138084Z DEBUG runtime_table::accelerated::refresh_task::changes: Inserting data row for orders
-2025-08-24T05:06:54.167452Z DEBUG runtime_table::accelerated::refresh_task::changes: Inserting data row for orders
+2025-08-24T05:06:54.138084Z DEBUG runtime::accelerated_table::refresh_task::changes: Inserting data row for orders
+2025-08-24T05:06:54.167452Z DEBUG runtime::accelerated_table::refresh_task::changes: Inserting data row for orders
 ...
 ```
+
+The transcript above is from `v1.6.0`. From `v2.2.0` the accelerated-table code moved to its own
+`runtime-table` crate, so those two records read
+`runtime_table::accelerated::refresh_task::changes` instead. The `SPICED_LOG` filter in `kafka/.env`
+names both targets, so the recipe shows them on either version.
 
 Run `spice sql` in a separate terminal to query the data
 

--- a/localpod/README.md
+++ b/localpod/README.md
@@ -55,11 +55,11 @@ $ spice run
 2026-08-02T12:24:38.452860Z  INFO runtime::init::dataset: Loading datasets: 1 tasks dispatched, 0 skipped at accelerator init (of 2 total; localpod datasets may be chained).
 2026-08-02T12:24:38.452891Z  INFO runtime::init::dataset: Dataset local_time_series initializing...
 2026-08-02T12:24:38.453637Z  INFO runtime::init::dataset: Dataset time_series registered (file:data.csv), acceleration (arrow, 15s refresh), results cache enabled. duration_ms=0
-2026-08-02T12:24:38.454943Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset time_series
-2026-08-02T12:24:38.455886Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows for dataset time_series in 0s.
+2026-08-02T12:24:38.454943Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset time_series
+2026-08-02T12:24:38.455886Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows for dataset time_series in 0s.
 2026-08-02T12:24:38.458522Z  INFO runtime::init::dataset: Dataset local_time_series registered (localpod:time_series), acceleration (duckdb:file, 10s refresh), results cache enabled. duration_ms=3
-2026-08-02T12:24:38.459791Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset local_time_series
-2026-08-02T12:24:38.463429Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows for dataset local_time_series in 3ms.
+2026-08-02T12:24:38.459791Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset local_time_series
+2026-08-02T12:24:38.463429Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows for dataset local_time_series in 3ms.
 2026-08-02T12:24:38.561540Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
@@ -101,8 +101,8 @@ Replace the seed data with 1,000 generated rows and observe the `localpod` updat
 In the terminal where `spice run` is running, you should see a message indicating the new data is loaded:
 
 ```shell
-2026-08-02T12:25:23.471503Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset time_series in 4ms.
-2026-08-02T12:25:28.564207Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (24.00 B) for dataset local_time_series in 15ms.
+2026-08-02T12:25:23.471503Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (24.00 B) for dataset time_series in 4ms.
+2026-08-02T12:25:28.564207Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (24.00 B) for dataset local_time_series in 15ms.
 ```
 
 And the same SQL queries as above will give updated results:

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -73,9 +73,9 @@ Result:
 2025-01-20T16:19:45.544669Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-20T16:19:45.544761Z  INFO runtime::init::model: Loading model [chat-model] from openai:gpt-4o...
 2025-01-20T16:19:46.164600Z  INFO runtime::init::dataset: Dataset spiceai.docs registered (github:github.com/spiceai/spiceai/files/trunk), acceleration (arrow), results cache enabled.
-2025-01-20T16:19:46.165929Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset spiceai.docs
+2025-01-20T16:19:46.165929Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.docs
 2025-01-20T16:19:46.534044Z  INFO runtime::init::model: Model [chat-model] deployed, ready for inferencing
-2025-01-20T16:19:49.394003Z  INFO runtime::accelerated_table::refresh_task: Loaded 93 rows (1.28 MiB) for dataset spiceai.docs in 3s 228ms.
+2025-01-20T16:19:49.394003Z  INFO runtime_table::accelerated::refresh_task: Loaded 93 rows (1.28 MiB) for dataset spiceai.docs in 3s 228ms.
 ```
 
 ## SQL Search

--- a/mssql/README.md
+++ b/mssql/README.md
@@ -39,14 +39,14 @@ instances are accessible from within Spice to demonstrate that you can query acr
    2024-09-23T19:43:29.281023Z  WARN tiberius::client::tls_stream::rustls_tls_stream: Trusting the server certificate without validation.
    2024-09-23T19:43:29.281987Z  WARN tiberius::client::tls_stream::rustls_tls_stream: Trusting the server certificate without validation.
    2024-09-23T19:43:29.296410Z  INFO runtime::init::dataset: Dataset sales.customer registered (mssql:Sales.Customer), acceleration (arrow), results cache enabled.
-   2024-09-23T19:43:29.296456Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset sales.customer
+   2024-09-23T19:43:29.296456Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset sales.customer
    2024-09-23T19:43:29.298284Z  INFO runtime::init::dataset: Dataset sales.customer2022 registered (mssql:Sales.Customer), acceleration (arrow), results cache enabled.
    2024-09-23T19:43:29.298383Z  INFO runtime::init::dataset: Dataset sales.salesorderheader registered (mssql:Sales.SalesOrderHeader), acceleration (arrow), results cache enabled.
-   2024-09-23T19:43:29.299097Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset sales.salesorderheader
-   2024-09-23T19:43:29.299104Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset sales.customer2022
-   2024-09-23T19:43:29.374935Z  INFO runtime::accelerated_table::refresh_task: Loaded 19,820 rows (2.20 MiB) for dataset sales.customer in 78ms.
-   2024-09-23T19:43:29.387697Z  INFO runtime::accelerated_table::refresh_task: Loaded 19,820 rows (2.20 MiB) for dataset sales.customer2022 in 88ms.
-   2024-09-23T19:43:29.394271Z  INFO runtime::accelerated_table::refresh_task: Loaded 31,465 rows (7.19 MiB) for dataset sales.salesorderheader in 95ms.
+   2024-09-23T19:43:29.299097Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset sales.salesorderheader
+   2024-09-23T19:43:29.299104Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset sales.customer2022
+   2024-09-23T19:43:29.374935Z  INFO runtime_table::accelerated::refresh_task: Loaded 19,820 rows (2.20 MiB) for dataset sales.customer in 78ms.
+   2024-09-23T19:43:29.387697Z  INFO runtime_table::accelerated::refresh_task: Loaded 19,820 rows (2.20 MiB) for dataset sales.customer2022 in 88ms.
+   2024-09-23T19:43:29.394271Z  INFO runtime_table::accelerated::refresh_task: Loaded 31,465 rows (7.19 MiB) for dataset sales.salesorderheader in 95ms.
    ```
 
 4. In another shell, fire up the Spice SQL REPL using `spice sql`

--- a/mysql/cdc/README.md
+++ b/mysql/cdc/README.md
@@ -59,7 +59,7 @@ You should see the dataset bootstrap from a consistent snapshot and then transit
 2026-07-23T01:40:37.396202Z  INFO data_components::mysql_replication::shared: MySQL replication: GTID auto-positioning active. dataset=orders source_table=spice_demo.orders
 2026-07-23T01:40:37.397269Z  INFO data_components::mysql_replication::shared: dataset joined shared mysql binlog group dataset=orders connection=localhost:3308 snapshot=true rejoining=false members=1
 2026-07-23T01:40:37.397719Z  INFO data_components::mysql_replication::bootstrap: mysql replication: starting initial snapshot dataset=orders
-2026-07-23T01:40:37.397936Z  INFO runtime::accelerated_table::refresh_task::changes: Processing TRUNCATE for orders
+2026-07-23T01:40:37.397936Z  INFO runtime_table::accelerated::refresh_task::changes: Processing TRUNCATE for orders
 2026-07-23T01:40:37.404727Z  INFO data_components::mysql_replication::bootstrap: mysql replication: initial snapshot complete dataset=orders rows=3
 2026-07-23T01:40:37.491325Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2026-07-23T01:40:37.492029Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090

--- a/mysql/rds-aurora/README.md
+++ b/mysql/rds-aurora/README.md
@@ -135,8 +135,8 @@ You should see the dataset load and the accelerator perform its first full refre
 ```
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Initializing dataset customers
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset customers registered (mysql:testdb.customers), acceleration (arrow, full).
-2025-01-13T12:00:00Z  INFO runtime::accelerated_table::refresh_task: Refreshing dataset customers
-2025-01-13T12:00:00Z  INFO runtime::accelerated_table::refresh_task: Loaded 3 rows for dataset customers
+2025-01-13T12:00:00Z  INFO runtime_table::accelerated::refresh_task: Refreshing dataset customers
+2025-01-13T12:00:00Z  INFO runtime_table::accelerated::refresh_task: Loaded 3 rows for dataset customers
 2025-01-13T12:00:00Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -35,10 +35,10 @@ spice run
 2025-08-25T23:34:31.165957Z  INFO runtime::init::model: Loading model [gpt-4o-responses] from openai:gpt-4o...
 2025-08-25T23:34:31.177013Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-08-25T23:34:31.992304Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2025-08-25T23:34:31.993720Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
+2025-08-25T23:34:31.993720Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
 2025-08-25T23:34:34.491656Z  INFO runtime::init::model: Model [gpt-4o-responses] deployed, ready for inferencing
-2025-08-25T23:34:42.538074Z  INFO runtime::accelerated_table::refresh_task: Dataset taxi_trips received 2,358,416 records
-2025-08-25T23:34:46.359978Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 14s 366ms.
+2025-08-25T23:34:42.538074Z  INFO runtime_table::accelerated::refresh_task: Dataset taxi_trips received 2,358,416 records
+2025-08-25T23:34:46.359978Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 14s 366ms.
 2025-08-25T23:34:46.453673Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/openai-responses-api/README.md
+++ b/openai-responses-api/README.md
@@ -38,7 +38,7 @@ spice run
 2025-08-25T23:34:31.993720Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
 2025-08-25T23:34:34.491656Z  INFO runtime::init::model: Model [gpt-4o-responses] deployed, ready for inferencing
 2025-08-25T23:34:42.538074Z  INFO runtime_table::accelerated::refresh_task: Dataset taxi_trips received 2,358,416 records
-2025-08-25T23:34:46.359978Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 14s 366ms.
+2025-08-25T23:34:46.359978Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 14s 366ms.
 2025-08-25T23:34:46.453673Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/openai_sdk/README.md
+++ b/openai_sdk/README.md
@@ -36,7 +36,7 @@ Output:
 2025-01-13T21:27:42.242310Z  INFO runtime::init::model: Model [openai] deployed, ready for inferencing
 2025-01-13T21:27:42.576976Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2025-01-13T21:27:42.578442Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2025-01-13T21:27:53.260052Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 681ms.
+2025-01-13T21:27:53.260052Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 681ms.
 ```
 
 Spice will use your OpenAI API key to communicate with OpenAI on your client code's behalf.

--- a/openai_sdk/README.md
+++ b/openai_sdk/README.md
@@ -35,8 +35,8 @@ Output:
 2025-01-13T21:27:41.902271Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2025-01-13T21:27:42.242310Z  INFO runtime::init::model: Model [openai] deployed, ready for inferencing
 2025-01-13T21:27:42.576976Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2025-01-13T21:27:42.578442Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-01-13T21:27:53.260052Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 681ms.
+2025-01-13T21:27:42.578442Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-01-13T21:27:53.260052Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.41 MiB) for dataset taxi_trips in 10s 681ms.
 ```
 
 Spice will use your OpenAI API key to communicate with OpenAI on your client code's behalf.

--- a/oracle/README.md
+++ b/oracle/README.md
@@ -62,13 +62,13 @@ This will start the Spice runtime, which will connect to Oracle and load the TPC
 2025-07-07T20:41:43.432399Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2025-07-07T20:41:43.915273Z  INFO runtime::init::dataset: Dataset lineitem registered (oracle:"LINEITEM"), acceleration (arrow), results cache enabled.
 2025-07-07T20:41:43.916361Z  INFO runtime::init::dataset: Dataset orders registered (oracle:"ORDERS"), acceleration (arrow), results cache enabled.
-2025-07-07T20:41:43.916382Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
-2025-07-07T20:41:43.917524Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
+2025-07-07T20:41:43.916382Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset lineitem
+2025-07-07T20:41:43.917524Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset orders
 2025-07-07T20:41:43.935174Z  INFO runtime::init::dataset: Dataset customer registered (oracle:"CUSTOMER"), acceleration (arrow), results cache enabled.
-2025-07-07T20:41:43.936280Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
-2025-07-07T20:41:43.949015Z  INFO runtime::accelerated_table::refresh_task: Loaded 7 rows (5.56 kiB) for dataset orders in 31ms.
-2025-07-07T20:41:43.949027Z  INFO runtime::accelerated_table::refresh_task: Loaded 27 rows (10.37 kiB) for dataset lineitem in 32ms.
-2025-07-07T20:41:43.950450Z  INFO runtime::accelerated_table::refresh_task: Loaded 7 rows (6.43 kiB) for dataset customer in 14ms.
+2025-07-07T20:41:43.936280Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset customer
+2025-07-07T20:41:43.949015Z  INFO runtime_table::accelerated::refresh_task: Loaded 7 rows (5.56 kiB) for dataset orders in 31ms.
+2025-07-07T20:41:43.949027Z  INFO runtime_table::accelerated::refresh_task: Loaded 27 rows (10.37 kiB) for dataset lineitem in 32ms.
+2025-07-07T20:41:43.950450Z  INFO runtime_table::accelerated::refresh_task: Loaded 7 rows (6.43 kiB) for dataset customer in 14ms.
 2025-07-07T20:41:44.036153Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/postgres/accelerator/README.md
+++ b/postgres/accelerator/README.md
@@ -114,8 +114,8 @@ Save the changes to `spicepod.yaml`. The Spice runtime terminal will show that t
 
 ```console
 2025-01-07T00:58:34.081889Z  INFO runtime::init::dataset: Dataset taxi_trips registered (spice.ai/spiceai/quickstart/datasets/taxi_trips), acceleration (postgres), results cache enabled.
-2025-01-07T00:58:34.083257Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2025-01-07T00:59:43.684903Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (8.41 GiB) for dataset taxi_trips in 1m 9s 601ms.
+2025-01-07T00:58:34.083257Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2025-01-07T00:59:43.684903Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (8.41 GiB) for dataset taxi_trips in 1m 9s 601ms.
 ```
 
 Follow the [getting started guide](https://docs.spiceai.org/getting-started) to get started with the Spice.ai runtime.

--- a/redshift/README.md
+++ b/redshift/README.md
@@ -70,29 +70,29 @@ You should see this output in your terminal window:
 2025-08-01T01:15:06.442089Z  INFO runtime::init::dataset: Dataset part initializing...
 2025-08-01T01:15:06.442117Z  INFO runtime::init::dataset: Dataset nation initializing...
 2025-08-01T01:15:07.411919Z  INFO runtime::init::dataset: Dataset region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (postgres), results cache enabled.
-2025-08-01T01:15:07.413277Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset region
+2025-08-01T01:15:07.413277Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset region
 2025-08-01T01:15:07.702387Z  INFO runtime::init::dataset: Dataset supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (postgres), results cache enabled.
 2025-08-01T01:15:07.702858Z  INFO runtime::init::dataset: Dataset part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (postgres), results cache enabled.
 2025-08-01T01:15:07.702864Z  INFO runtime::init::dataset: Dataset orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (postgres), results cache enabled.
 2025-08-01T01:15:07.703431Z  INFO runtime::init::dataset: Dataset customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (postgres), results cache enabled.
-2025-08-01T01:15:07.703558Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
-2025-08-01T01:15:07.703580Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
-2025-08-01T01:15:07.703617Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset part
+2025-08-01T01:15:07.703558Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset supplier
+2025-08-01T01:15:07.703580Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset orders
+2025-08-01T01:15:07.703617Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset part
 2025-08-01T01:15:07.703894Z  INFO runtime::init::dataset: Dataset nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (postgres), results cache enabled.
 2025-08-01T01:15:07.703941Z  INFO runtime::init::dataset: Dataset partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (postgres), results cache enabled.
 2025-08-01T01:15:07.704752Z  INFO runtime::init::dataset: Dataset lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (postgres), results cache enabled.
-2025-08-01T01:15:07.704832Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
-2025-08-01T01:15:07.704859Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
-2025-08-01T01:15:07.704871Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
-2025-08-01T01:15:07.706200Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
-2025-08-01T01:15:08.814196Z  INFO runtime::accelerated_table::refresh_task: Loaded 5 rows (1008.00 B) for dataset region in 1s 400ms.
-2025-08-01T01:15:09.264442Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (190.69 kiB) for dataset supplier in 1s 560ms.
-2025-08-01T01:15:09.608490Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (3.35 kiB) for dataset nation in 1s 903ms.
-2025-08-01T01:15:10.603145Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (277.68 kiB) for dataset customer in 2s 898ms.
-2025-08-01T01:15:12.128351Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (158.19 kiB) for dataset orders in 4s 424ms.
-2025-08-01T01:15:12.846856Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (190.84 kiB) for dataset lineitem in 5s 140ms.
-2025-08-01T01:15:13.375356Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (180.17 kiB) for dataset part in 5s 671ms.
-2025-08-01T01:15:14.029083Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (227.71 kiB) for dataset partsupp in 6s 324ms.
+2025-08-01T01:15:07.704832Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset nation
+2025-08-01T01:15:07.704859Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset partsupp
+2025-08-01T01:15:07.704871Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset customer
+2025-08-01T01:15:07.706200Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset lineitem
+2025-08-01T01:15:08.814196Z  INFO runtime_table::accelerated::refresh_task: Loaded 5 rows (1008.00 B) for dataset region in 1s 400ms.
+2025-08-01T01:15:09.264442Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (190.69 kiB) for dataset supplier in 1s 560ms.
+2025-08-01T01:15:09.608490Z  INFO runtime_table::accelerated::refresh_task: Loaded 25 rows (3.35 kiB) for dataset nation in 1s 903ms.
+2025-08-01T01:15:10.603145Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (277.68 kiB) for dataset customer in 2s 898ms.
+2025-08-01T01:15:12.128351Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (158.19 kiB) for dataset orders in 4s 424ms.
+2025-08-01T01:15:12.846856Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (190.84 kiB) for dataset lineitem in 5s 140ms.
+2025-08-01T01:15:13.375356Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (180.17 kiB) for dataset part in 5s 671ms.
+2025-08-01T01:15:14.029083Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (227.71 kiB) for dataset partsupp in 6s 324ms.
 2025-08-01T01:15:14.091465Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 
@@ -229,29 +229,29 @@ You should see this output in your terminal window:
 2025-08-01T01:15:40.308684Z  INFO runtime::init::dataset: Dataset partsupp initializing...
 2025-08-01T01:15:40.308770Z  INFO runtime::init::dataset: Dataset lineitem initializing...
 2025-08-01T01:15:40.995606Z  INFO runtime::init::dataset: Dataset orders registered (postgres:public.orders), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:40.996460Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset orders
-2025-08-01T01:15:41.374001Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (146.19 kiB) for dataset orders in 377ms.
+2025-08-01T01:15:40.996460Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset orders
+2025-08-01T01:15:41.374001Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (146.19 kiB) for dataset orders in 377ms.
 2025-08-01T01:15:41.481632Z  INFO runtime::init::dataset: Dataset region registered (postgres:public.region), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:41.482800Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset region
-2025-08-01T01:15:41.563571Z  INFO runtime::accelerated_table::refresh_task: Loaded 5 rows (14.45 kiB) for dataset region in 80ms.
+2025-08-01T01:15:41.482800Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset region
+2025-08-01T01:15:41.563571Z  INFO runtime_table::accelerated::refresh_task: Loaded 5 rows (14.45 kiB) for dataset region in 80ms.
 2025-08-01T01:15:41.798712Z  INFO runtime::init::dataset: Dataset part registered (postgres:public.part), acceleration (arrow), results cacheenabled.
-2025-08-01T01:15:41.799995Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset part
-2025-08-01T01:15:41.926069Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (161.36 kiB) for dataset part in 126ms.
+2025-08-01T01:15:41.799995Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset part
+2025-08-01T01:15:41.926069Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (161.36 kiB) for dataset part in 126ms.
 2025-08-01T01:15:42.142538Z  INFO runtime::init::dataset: Dataset nation registered (postgres:public.nation), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:42.143810Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset nation
-2025-08-01T01:15:42.219842Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (19.55 kiB) for dataset nation in 76ms.
+2025-08-01T01:15:42.143810Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset nation
+2025-08-01T01:15:42.219842Z  INFO runtime_table::accelerated::refresh_task: Loaded 25 rows (19.55 kiB) for dataset nation in 76ms.
 2025-08-01T01:15:42.480982Z  INFO runtime::init::dataset: Dataset customer registered (postgres:public.customer), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:42.482235Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset customer
-2025-08-01T01:15:42.826813Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (269.18 kiB) for dataset customer in 344ms.
+2025-08-01T01:15:42.482235Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset customer
+2025-08-01T01:15:42.826813Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (269.18 kiB) for dataset customer in 344ms.
 2025-08-01T01:15:42.886263Z  INFO runtime::init::dataset: Dataset supplier registered (postgres:public.supplier), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:42.887628Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset supplier
-2025-08-01T01:15:43.250965Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (185.00 kiB) for dataset supplier in 363ms.
+2025-08-01T01:15:42.887628Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset supplier
+2025-08-01T01:15:43.250965Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (185.00 kiB) for dataset supplier in 363ms.
 2025-08-01T01:15:43.386852Z  INFO runtime::init::dataset: Dataset partsupp registered (postgres:public.partsupp), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:43.388171Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset partsupp
+2025-08-01T01:15:43.388171Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset partsupp
 2025-08-01T01:15:43.830328Z  INFO runtime::init::dataset: Dataset lineitem registered (postgres:public.lineitem), acceleration (arrow), results cache enabled.
-2025-08-01T01:15:43.831713Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
-2025-08-01T01:15:43.898640Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (160.55 kiB) for dataset partsupp in 510ms.
-2025-08-01T01:15:44.157564Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,000 rows (171.93 kiB) for dataset lineitem in 325ms.
+2025-08-01T01:15:43.831713Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset lineitem
+2025-08-01T01:15:43.898640Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (160.55 kiB) for dataset partsupp in 510ms.
+2025-08-01T01:15:44.157564Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,000 rows (171.93 kiB) for dataset lineitem in 325ms.
 2025-08-01T01:15:44.239953Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -44,8 +44,8 @@ Spice.ai runtime starting...
 2024-08-05T14:35:55.354672Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
 2024-08-05T14:35:55.354940Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-08-05T14:35:56.584438Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2024-08-05T14:35:56.585614Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-08-05T14:36:06.654548Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 68ms.
+2024-08-05T14:35:56.585614Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-08-05T14:36:06.654548Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 68ms.
 ```
 
 Run `spice sql` to check the number of rows and the 5 earliest records sorted by `tpep_pickup_datetime`
@@ -114,8 +114,8 @@ Check if dataset has been reloaded
 
 ```bash
 2024-08-05T14:36:11.552233Z  INFO runtime: Updating accelerated dataset taxi_trips...
-2024-08-05T14:36:12.777384Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-08-05T14:36:21.990860Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,619 rows (421.58 MiB) for dataset taxi_trips in 9s 213ms.
+2024-08-05T14:36:12.777384Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-08-05T14:36:21.990860Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,619 rows (421.58 MiB) for dataset taxi_trips in 9s 213ms.
 2024-08-05T14:36:23.197896Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 
 ```

--- a/retention/README.md
+++ b/retention/README.md
@@ -40,19 +40,19 @@ Inserted new user user_1743059152063665845@example.com with username user_174305
 Run `docker logs -f spiceai-retention-demo` and Wait for the next retention check interval and see the retention policy evict data:
 
 ```console
-2025-03-27T07:08:50.616347Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 16ms.
-2025-03-27T07:08:54.291596Z  INFO runtime::accelerated_table: [retention] Evicting data for users where updated_at < 2025-03-27T07:08:24+00:00...
-2025-03-27T07:08:54.299160Z  INFO runtime::accelerated_table: [retention] Evicted 2 records for users
-2025-03-27T07:08:55.634074Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset users
-2025-03-27T07:08:55.650633Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 31ms.
-2025-03-27T07:09:00.660625Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset users
-2025-03-27T07:09:00.673057Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 20ms.
-2025-03-27T07:09:04.293654Z  INFO runtime::accelerated_table: [retention] Evicting data for users where updated_at < 2025-03-27T07:08:34+00:00...
-2025-03-27T07:09:04.302727Z  INFO runtime::accelerated_table: [retention] Evicted 2 records for users
-2025-03-27T07:09:05.689919Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset users
-2025-03-27T07:09:05.697891Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 23ms.
-2025-03-27T07:09:10.712582Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset users
-2025-03-27T07:09:10.729119Z  INFO runtime::accelerated_table::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 25ms.
+2025-03-27T07:08:50.616347Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 16ms.
+2025-03-27T07:08:54.291596Z  INFO runtime_table::accelerated::retention: [retention] Evicting data for users where updated_at < 2025-03-27T07:08:24+00:00
+2025-03-27T07:08:54.299160Z  INFO runtime_table::accelerated::retention: [retention] Evicted 2 records for users
+2025-03-27T07:08:55.634074Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset users
+2025-03-27T07:08:55.650633Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 31ms.
+2025-03-27T07:09:00.660625Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset users
+2025-03-27T07:09:00.673057Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 20ms.
+2025-03-27T07:09:04.293654Z  INFO runtime_table::accelerated::retention: [retention] Evicting data for users where updated_at < 2025-03-27T07:08:34+00:00
+2025-03-27T07:09:04.302727Z  INFO runtime_table::accelerated::retention: [retention] Evicted 2 records for users
+2025-03-27T07:09:05.689919Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset users
+2025-03-27T07:09:05.697891Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 23ms.
+2025-03-27T07:09:10.712582Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset users
+2025-03-27T07:09:10.729119Z  INFO runtime_table::accelerated::refresh_task: Loaded 1 rows (34.64 kiB) for dataset users in 25ms.
 ```
 
 In addition to viewing the logs, run queries with the Spice SQL REPL to explore the data and confirm that only recently added users are in the dataset.

--- a/s3/README.md
+++ b/s3/README.md
@@ -89,7 +89,7 @@ The following output is shown in the Spice runtime terminal:
 ```bash
 2024-11-27T23:01:32.660992Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
 2024-11-27T23:01:32.663444Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2024-11-27T23:01:41.897121Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 9s 233ms.
+2024-11-27T23:01:41.897121Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 9s 233ms.
 ```
 
 **Step 3.** Run queries against the dataset using the Spice SQL REPL.
@@ -284,7 +284,7 @@ Spice.ai runtime starting...
 2024-07-23T00:33:50.552044Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-07-23T00:35:42.716736Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://yourcompany-bucketname-datasets/taxi_trips/), acceleration (arrow, 10s refresh), results cache enabled.
 2024-07-23T00:35:42.718009Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2024-07-23T00:35:59.390722Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 672ms.
+2024-07-23T00:35:59.390722Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 672ms.
 ```
 
 **Step 8.** Run queries against the dataset using the Spice SQL REPL.

--- a/s3/README.md
+++ b/s3/README.md
@@ -88,8 +88,8 @@ The following output is shown in the Spice runtime terminal:
 
 ```bash
 2024-11-27T23:01:32.660992Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow, 10s refresh), results cache enabled.
-2024-11-27T23:01:32.663444Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-11-27T23:01:41.897121Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 9s 233ms.
+2024-11-27T23:01:32.663444Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-11-27T23:01:41.897121Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (419.31 MiB) for dataset taxi_trips in 9s 233ms.
 ```
 
 **Step 3.** Run queries against the dataset using the Spice SQL REPL.
@@ -283,8 +283,8 @@ Spice.ai runtime starting...
 2024-07-23T00:33:50.552016Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 2024-07-23T00:33:50.552044Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
 2024-07-23T00:35:42.716736Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://yourcompany-bucketname-datasets/taxi_trips/), acceleration (arrow, 10s refresh), results cache enabled.
-2024-07-23T00:35:42.718009Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-07-23T00:35:59.390722Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 672ms.
+2024-07-23T00:35:42.718009Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-07-23T00:35:59.390722Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (421.71 MiB) for dataset taxi_trips in 16s 672ms.
 ```
 
 **Step 8.** Run queries against the dataset using the Spice SQL REPL.

--- a/search/README.md
+++ b/search/README.md
@@ -88,12 +88,12 @@ You should see this output:
 2025-09-26T15:21:47.659106Z  INFO runtime::init::dataset: Dataset bluesky_posts initializing...
 2025-09-26T15:21:47.730735Z  INFO runtime::dataconnector::file: Watching changes to bluesky_posts.parquet
 2025-09-26T15:21:47.730999Z  INFO runtime::init::dataset: Dataset bluesky_posts registered (file://bluesky_posts.parquet), acceleration (duckdb:file, append), results cache enabled.
-2025-09-26T15:21:47.740354Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset bluesky_posts
-2025-09-26T15:21:57.885819Z  INFO runtime::accelerated_table::refresh_task: Dataset bluesky_posts received 38,101 records
-2025-09-26T15:21:58.507599Z  INFO runtime::accelerated_table::refresh_task: Loaded 38,101 rows (54.72 MiB) for dataset bluesky_posts in 10s 775ms.
+2025-09-26T15:21:47.740354Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset bluesky_posts
+2025-09-26T15:21:57.885819Z  INFO runtime_table::accelerated::refresh_task: Dataset bluesky_posts received 38,101 records
+2025-09-26T15:21:58.507599Z  INFO runtime_table::accelerated::refresh_task: Loaded 38,101 rows (54.72 MiB) for dataset bluesky_posts in 10s 775ms.
 2025-09-26T15:21:58.550191Z  INFO runtime: All components are loaded. Spice runtime is ready!
-2025-09-26T15:22:20.335633Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset bluesky_posts
-2025-09-26T15:22:21.960722Z  INFO runtime::accelerated_table::refresh_task: Loaded 251 rows (339.49 kiB) for dataset bluesky_posts in 1s 656ms.
+2025-09-26T15:22:20.335633Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset bluesky_posts
+2025-09-26T15:22:21.960722Z  INFO runtime_table::accelerated::refresh_task: Loaded 251 rows (339.49 kiB) for dataset bluesky_posts in 1s 656ms.
 ```
 
 _In a new terminal_, start the Spice SQL REPL:

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -192,8 +192,8 @@ The following output is shown in the Spice runtime terminal confirming new confi
 
 ```bash
 2024-07-23T00:23:29.327942Z  INFO runtime: Updating accelerated dataset lineitem...
-2024-07-23T00:23:29.657023Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset lineitem
-2024-07-23T00:23:52.413596Z  INFO runtime::accelerated_table::refresh_task: Loaded 6,001,215 rows (9.46 GiB) for dataset lineitem in 22s 756ms.
+2024-07-23T00:23:29.657023Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset lineitem
+2024-07-23T00:23:52.413596Z  INFO runtime_table::accelerated::refresh_task: Loaded 6,001,215 rows (9.46 GiB) for dataset lineitem in 22s 756ms.
 2024-07-23T00:23:52.553037Z  INFO runtime::init::dataset: Dataset lineitem registered (snowflake:snowflake_sample_data.tpch_sf1.lineitem), acceleration (arrow), results cache enabled.
 ```
 

--- a/sqlite/accelerator/README.md
+++ b/sqlite/accelerator/README.md
@@ -114,8 +114,8 @@ The following output is shown in the Spice runtime terminal confirming new confi
 ```bash
 2024-09-10T06:59:21.908667Z  INFO runtime: Unloaded dataset taxi_trips
 2024-09-10T06:59:22.524295Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (sqlite:file), results cache enabled.
-2024-09-10T06:59:22.525789Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset taxi_trips
-2024-09-10T06:59:39.244473Z  INFO runtime::accelerated_table::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 718ms.
+2024-09-10T06:59:22.525789Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2024-09-10T06:59:39.244473Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 16s 718ms.
 ```
 
 Run query to display the longest taxi trips again:

--- a/tpc-h/README.md
+++ b/tpc-h/README.md
@@ -27,29 +27,29 @@ The following output is shown in the Spice runtime terminal:
 
 ```bash
 2026-08-05T12:12:47.811362Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:47.812658Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.customer
+2026-08-05T12:12:47.812658Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.customer
 2026-08-05T12:12:49.605443Z  INFO runtime::init::dataset: Dataset tpch.lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:49.606500Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.lineitem
+2026-08-05T12:12:49.606500Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.lineitem
 2026-08-05T12:12:50.409819Z  INFO runtime::init::dataset: Dataset tpch.nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:50.410648Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.nation
-2026-08-05T12:12:50.524894Z  INFO runtime::accelerated_table::refresh_task: Loaded 150,000 rows (33.76 MiB) for dataset tpch.customer in 2s 712ms.
-2026-08-05T12:12:50.970014Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (3.35 kiB) for dataset tpch.nation in 559ms.
+2026-08-05T12:12:50.410648Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.nation
+2026-08-05T12:12:50.524894Z  INFO runtime_table::accelerated::refresh_task: Loaded 150,000 rows (33.76 MiB) for dataset tpch.customer in 2s 712ms.
+2026-08-05T12:12:50.970014Z  INFO runtime_table::accelerated::refresh_task: Loaded 25 rows (3.35 kiB) for dataset tpch.nation in 559ms.
 2026-08-05T12:12:51.591911Z  INFO runtime::init::dataset: Dataset tpch.orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:51.592095Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.orders
+2026-08-05T12:12:51.592095Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.orders
 2026-08-05T12:12:52.822669Z  INFO runtime::init::dataset: Dataset tpch.part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:52.823043Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.part
+2026-08-05T12:12:52.823043Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.part
 2026-08-05T12:12:53.982557Z  INFO runtime::init::dataset: Dataset tpch.partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:53.983000Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.partsupp
-2026-08-05T12:12:54.160528Z  INFO runtime::accelerated_table::refresh_task: Loaded 200,000 rows (35.80 MiB) for dataset tpch.part in 1s 337ms.
+2026-08-05T12:12:53.983000Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.partsupp
+2026-08-05T12:12:54.160528Z  INFO runtime_table::accelerated::refresh_task: Loaded 200,000 rows (35.80 MiB) for dataset tpch.part in 1s 337ms.
 2026-08-05T12:12:54.829053Z  INFO runtime::init::dataset: Dataset tpch.region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:54.829967Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.region
-2026-08-05T12:12:55.402071Z  INFO runtime::accelerated_table::refresh_task: Loaded 5 rows (1008.00 B) for dataset tpch.region in 572ms.
+2026-08-05T12:12:54.829967Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.region
+2026-08-05T12:12:55.402071Z  INFO runtime_table::accelerated::refresh_task: Loaded 5 rows (1008.00 B) for dataset tpch.region in 572ms.
 2026-08-05T12:12:56.036613Z  INFO runtime::init::dataset: Dataset tpch.supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb), results cache enabled.
-2026-08-05T12:12:56.036896Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.supplier
-2026-08-05T12:12:56.397026Z  INFO runtime::accelerated_table::refresh_task: Loaded 800,000 rows (141.48 MiB) for dataset tpch.partsupp in 2s 414ms.
-2026-08-05T12:12:57.340627Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (1.87 MiB) for dataset tpch.supplier in 1s 303ms.
-2026-08-05T12:13:12.771851Z  INFO runtime::accelerated_table::refresh_task: Loaded 6,001,215 rows (1.07 GiB) for dataset tpch.lineitem in 23s 165ms.
-2026-08-05T12:13:16.294713Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,500,000 rows (212.28 MiB) for dataset tpch.orders in 24s 702ms.
+2026-08-05T12:12:56.036896Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.supplier
+2026-08-05T12:12:56.397026Z  INFO runtime_table::accelerated::refresh_task: Loaded 800,000 rows (141.48 MiB) for dataset tpch.partsupp in 2s 414ms.
+2026-08-05T12:12:57.340627Z  INFO runtime_table::accelerated::refresh_task: Loaded 10,000 rows (1.87 MiB) for dataset tpch.supplier in 1s 303ms.
+2026-08-05T12:13:12.771851Z  INFO runtime_table::accelerated::refresh_task: Loaded 6,001,215 rows (1.07 GiB) for dataset tpch.lineitem in 23s 165ms.
+2026-08-05T12:13:16.294713Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,500,000 rows (212.28 MiB) for dataset tpch.orders in 24s 702ms.
 ```
 
 **Step 3.** Run queries against the dataset using the Spice SQL REPL.

--- a/views/README.md
+++ b/views/README.md
@@ -39,29 +39,29 @@ Example output:
 
 ```bash
 2025-05-18T20:17:42.674632Z  INFO runtime::init::dataset: Dataset tpch.customer registered (s3://spiceai-demo-datasets/tpch/customer/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:42.677295Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.customer
+2025-05-18T20:17:42.677295Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.customer
 2025-05-18T20:17:43.689020Z  INFO runtime::init::dataset: Dataset tpch.lineitem registered (s3://spiceai-demo-datasets/tpch/lineitem/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:43.691802Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.lineitem
+2025-05-18T20:17:43.691802Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.lineitem
 2025-05-18T20:17:44.573390Z  INFO runtime::init::dataset: Dataset tpch.nation registered (s3://spiceai-demo-datasets/tpch/nation/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:44.575014Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.nation
-2025-05-18T20:17:45.012944Z  INFO runtime::accelerated_table::refresh_task: Loaded 150,000 rows (33.72 MiB) for dataset tpch.customer in 2s 335ms.
-2025-05-18T20:17:45.465199Z  INFO runtime::accelerated_table::refresh_task: Loaded 25 rows (3.35 kiB) for dataset tpch.nation in 890ms.
+2025-05-18T20:17:44.575014Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.nation
+2025-05-18T20:17:45.012944Z  INFO runtime_table::accelerated::refresh_task: Loaded 150,000 rows (33.72 MiB) for dataset tpch.customer in 2s 335ms.
+2025-05-18T20:17:45.465199Z  INFO runtime_table::accelerated::refresh_task: Loaded 25 rows (3.35 kiB) for dataset tpch.nation in 890ms.
 2025-05-18T20:17:45.579670Z  INFO runtime::init::dataset: Dataset tpch.orders registered (s3://spiceai-demo-datasets/tpch/orders/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:45.584503Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.orders
+2025-05-18T20:17:45.584503Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.orders
 2025-05-18T20:17:46.861509Z  INFO runtime::init::dataset: Dataset tpch.part registered (s3://spiceai-demo-datasets/tpch/part/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:46.863911Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.part
+2025-05-18T20:17:46.863911Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.part
 2025-05-18T20:17:47.979505Z  INFO runtime::init::dataset: Dataset tpch.partsupp registered (s3://spiceai-demo-datasets/tpch/partsupp/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:47.981985Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.partsupp
-2025-05-18T20:17:48.661190Z  INFO runtime::accelerated_table::refresh_task: Loaded 200,000 rows (35.76 MiB) for dataset tpch.part in 1s 797ms.
+2025-05-18T20:17:47.981985Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.partsupp
+2025-05-18T20:17:48.661190Z  INFO runtime_table::accelerated::refresh_task: Loaded 200,000 rows (35.76 MiB) for dataset tpch.part in 1s 797ms.
 2025-05-18T20:17:48.947079Z  INFO runtime::init::dataset: Dataset tpch.region registered (s3://spiceai-demo-datasets/tpch/region/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:48.949633Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.region
-2025-05-18T20:17:49.863619Z  INFO runtime::accelerated_table::refresh_task: Loaded 5 rows (1008.00 B) for dataset tpch.region in 913ms.
+2025-05-18T20:17:48.949633Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.region
+2025-05-18T20:17:49.863619Z  INFO runtime_table::accelerated::refresh_task: Loaded 5 rows (1008.00 B) for dataset tpch.region in 913ms.
 2025-05-18T20:17:49.979310Z  INFO runtime::init::dataset: Dataset tpch.supplier registered (s3://spiceai-demo-datasets/tpch/supplier/), acceleration (duckdb), results cache enabled.
-2025-05-18T20:17:49.980156Z  INFO runtime::accelerated_table::refresh_task: Loading data for dataset tpch.supplier
-2025-05-18T20:17:51.387183Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (1.83 MiB) for dataset tpch.supplier in 1s 407ms.
-2025-05-18T20:17:52.873917Z  INFO runtime::accelerated_table::refresh_task: Loaded 800,000 rows (141.47 MiB) for dataset tpch.partsupp in 4s 891ms.
-2025-05-18T20:18:01.715009Z  INFO runtime::accelerated_table::refresh_task: Loaded 6,001,215 rows (1.07 GiB) for dataset tpch.lineitem in 18s 23ms.
-2025-05-18T20:18:01.862647Z  INFO runtime::accelerated_table::refresh_task: Loaded 1,500,000 rows (212.25 MiB) for dataset tpch.orders in 16s 278ms
+2025-05-18T20:17:49.980156Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset tpch.supplier
+2025-05-18T20:17:51.387183Z  INFO runtime_table::accelerated::refresh_task: Loaded 10,000 rows (1.83 MiB) for dataset tpch.supplier in 1s 407ms.
+2025-05-18T20:17:52.873917Z  INFO runtime_table::accelerated::refresh_task: Loaded 800,000 rows (141.47 MiB) for dataset tpch.partsupp in 4s 891ms.
+2025-05-18T20:18:01.715009Z  INFO runtime_table::accelerated::refresh_task: Loaded 6,001,215 rows (1.07 GiB) for dataset tpch.lineitem in 18s 23ms.
+2025-05-18T20:18:01.862647Z  INFO runtime_table::accelerated::refresh_task: Loaded 1,500,000 rows (212.25 MiB) for dataset tpch.orders in 16s 278ms
 ```
 
 ## Step 3: Create View
@@ -126,8 +126,8 @@ Example output:
 
 ```bash
 2025-05-18T20:20:11.150665Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb, 3600s refresh).
-2025-05-18T20:20:11.151971Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
-2025-05-18T20:20:12.414223Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
+2025-05-18T20:20:11.151971Z  INFO runtime_table::accelerated::refresh_task: Loading data for view supplier_order_waits
+2025-05-18T20:20:12.414223Z  INFO runtime_table::accelerated::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
 ```
 
 ## Step 4: Run Queries
@@ -281,10 +281,10 @@ Example output:
 
 ```bash
 2025-05-18T20:20:11.150665Z  INFO runtime::datafusion: View supplier_order_waits registered, acceleration (duckdb).
-2025-05-18T20:20:11.151971Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
-2025-05-18T20:20:12.414223Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
-2025-05-18T20:21:00.151971Z  INFO runtime::accelerated_table::refresh_task: Loading data for view supplier_order_waits
-2025-05-18T20:21:01.414223Z  INFO runtime::accelerated_table::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
+2025-05-18T20:20:11.151971Z  INFO runtime_table::accelerated::refresh_task: Loading data for view supplier_order_waits
+2025-05-18T20:20:12.414223Z  INFO runtime_table::accelerated::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
+2025-05-18T20:21:00.151971Z  INFO runtime_table::accelerated::refresh_task: Loading data for view supplier_order_waits
+2025-05-18T20:21:01.414223Z  INFO runtime_table::accelerated::refresh_task: Loaded 10,000 rows (481.43 kiB) for view supplier_order_waits in 1s 262ms.
 ```
 
 ## Additional Resources


### PR DESCRIPTION
## Summary

Two corrections to the same expected-output lines across the cookbook, both against v2.2.0 (current stable).

### 1. Renamed log module target (45 recipes, 208 lines) — functional break

v2.2.0 moved the accelerated-table code into a new `runtime_table` crate, renaming its tracing targets. The old `runtime::accelerated_table*` targets no longer exist anywhere in the runtime.

| Recipe shows (pre-v2.2.0) | v2.2.0 emits |
| --- | --- |
| `runtime::accelerated_table::refresh_task` | `runtime_table::accelerated::refresh_task` |
| `runtime::accelerated_table::refresh_task::changes` | `runtime_table::accelerated::refresh_task::changes` |
| `runtime::accelerated_table` (`[retention]` lines) | `runtime_table::accelerated::retention` |
| `runtime::accelerated_table` (`[refresh]` lines) | `runtime_table::accelerated` |

The bare path maps to **two different** targets depending on the message, so this is not a single find/replace — each line was mapped by the message it carries.

**This is more than stale text.** `cdc-debezium/.env`, `cdc-debezium/README.md`, and `kafka/.env` set `SPICED_LOG` to the old module path. On v2.2.0 that filter matches nothing, so the TRACE/DEBUG change-stream output those recipes tell the reader to watch for never appears.

Also drops a trailing `...` from the retention eviction lines — the runtime's format string has no ellipsis.

### 2. Stale accelerated sizes on those same lines (5 recipes)

For `s3://spiceai-demo-datasets/taxi_trips/2024/` (2,964,624 rows), v2.2.0 reports **399.38 MiB** — already what 17 other recipes show:

- `s3`: 419.31 MiB and 421.71 MiB → 399.38 MiB
- `openai_sdk`, `openai-responses-api`, `client-sdk/spicepy-sdk-sample`, `client-sdk/spice-dotnet-sdk-sample`: 399.41 MiB → 399.38 MiB

`postgres/accelerator`'s 8.41 GiB is deliberately left alone — it loads a different source (`spice.ai/spiceai/quickstart`) into the `postgres` engine.

## Verified against

spiceai/spiceai v2.2.0 (current stable, released 2026-08-24), runtime `v2.2.0+models.metal`.

## Evidence

New target and the size, from a live run of the recipe config:

```
2026-08-29T23:31:53.699496Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 10s 369ms.
```

Retention, run locally with a short `retention_period` (note: no trailing ellipsis):

```
2026-08-29T23:27:42.674403Z  INFO runtime_table::accelerated::retention: [retention] Evicting data for taxi_trips where tpep_pickup_datetime < 2026-08-29T23:27:12+00:00
2026-08-29T23:27:42.674902Z  INFO runtime_table::accelerated::retention: [retention] Evicted 0 records for taxi_trips
```

`[refresh]` line via `PATCH /v1/datasets/taxi_trips/acceleration` — bare target, not `::refresh`:

```
2026-08-29T23:27:53.958967Z  INFO runtime_table::accelerated: [refresh] Updated refresh SQL for taxi_trips to SELECT * FROM taxi_trips WHERE passenger_count = 3
```

The `SPICED_LOG` break, A/B on the same spicepod:

```
FILTER runtime::accelerated_table::refresh_task=TRACE   -> TRACE lines: 0
FILTER runtime_table::accelerated::refresh_task=TRACE   -> TRACE lines: 362
```

The old target is absent from the v2.2.0 binary entirely, while every replacement path is present.

`dremio/README.md` and `federation/README.md` already used the new path, so this brings the rest of the cookbook in line with them.