### PR TITLE
Fix CDC recipes: replace phantom bootstrap log lines

### DIFF
--- a/dynamodb/streams/README.md
+++ b/dynamodb/streams/README.md
@@ -67,8 +67,7 @@ You should see the dataset initialize and begin streaming:
 
 ```bash
 INFO runtime::init::dataset: Dataset orders_stream registered (dynamodb:orders), acceleration (duckdb:file, changes), results cache enabled.
-INFO runtime::dataconnector::dynamodb: No existing lag found for DynamoDB Streams table, starting initialization
-INFO runtime::dataconnector::dynamodb: DynamoDB Streams table initialization complete, starting to process changes from the Stream
+INFO connector_dynamodb::connector: No existing checkpoint found for DynamoDB Streams table, starting initialization. Table will be marked as Ready once lag threshold is reached dataset=orders_stream ready_lag=1h
 INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/mongodb/change-streams/README.md
+++ b/mongodb/change-streams/README.md
@@ -79,8 +79,8 @@ You should see the dataset bootstrap and then transition to live streaming:
 ```
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset orders initializing...
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset orders registered (mongodb:orders), acceleration (duckdb:file, changes).
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::mongodb: Bootstrapping MongoDB collection orders, records=3
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::mongodb: Bootstrap complete for orders. Streaming live changes.
+2025-01-13T12:00:00Z  INFO connector_mongodb::changes: MongoDB Change Stream started; bootstrapping accelerator from collection snapshot dataset=orders collection=orders
+2025-01-13T12:00:00Z  INFO connector_mongodb::changes: MongoDB collection snapshot complete; resuming Change Stream events from captured token dataset=orders collection=orders
 2025-01-13T12:00:00Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 

--- a/postgres/cdc/README.md
+++ b/postgres/cdc/README.md
@@ -75,8 +75,8 @@ You should see the dataset bootstrap from a consistent snapshot and then transit
 ```
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset orders initializing...
 2025-01-13T12:00:00Z  INFO runtime::init::dataset: Dataset orders registered (postgres:orders), acceleration (duckdb:file, changes).
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::postgres: Bootstrapping PostgreSQL table orders, records=3
-2025-01-13T12:00:00Z  INFO runtime::dataconnector::postgres: Bootstrap complete for orders. Streaming WAL changes from slot spice_orders.
+2025-01-13T12:00:00Z  INFO data_components::postgres_replication::slot: Created new replication slot slot=spice_orders publication=spice_orders_pub consistent_lsn=0/1A2B3C48 snapshot=0/1A2B3C48
+2025-01-13T12:00:00Z  INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=orders rows=3 expected=Some(3)
 2025-01-13T12:00:00Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
 


### PR DESCRIPTION
## Summary

`postgres/cdc`, `mongodb/change-streams` and `dynamodb/streams` each show a "you should see this" startup block containing log lines the runtime never emits. Both halves are wrong — the module target *and* the message text — so a reader following the recipe waits for output that cannot appear and has no way to tell whether CDC actually started.

The `runtime::dataconnector::postgres` / `::mongodb` / `::dynamodb` targets do not exist in v2.2.0 at all.

| Recipe | Claimed (does not exist) | v2.2.0 actually emits |
| --- | --- | --- |
| `postgres/cdc` | `runtime::dataconnector::postgres: Bootstrapping PostgreSQL table orders, records=3` | `data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=… rows=… expected=…` |
| `postgres/cdc` | `…: Bootstrap complete for orders. Streaming WAL changes from slot spice_orders.` | `data_components::postgres_replication::slot: Created new replication slot slot=… publication=… consistent_lsn=… snapshot=…` |
| `mongodb/change-streams` | `runtime::dataconnector::mongodb: Bootstrapping MongoDB collection orders, records=3` | `connector_mongodb::changes: MongoDB Change Stream started; bootstrapping accelerator from collection snapshot dataset=… collection=…` |
| `mongodb/change-streams` | `…: Bootstrap complete for orders. Streaming live changes.` | `connector_mongodb::changes: MongoDB collection snapshot complete; resuming Change Stream events from captured token dataset=… collection=…` |
| `dynamodb/streams` | `runtime::dataconnector::dynamodb: No existing lag found for DynamoDB Streams table, starting initialization` | `connector_dynamodb::connector: No existing checkpoint found for DynamoDB Streams table, starting initialization. Table will be marked as Ready once lag threshold is reached dataset=… ready_lag=…` |
| `dynamodb/streams` | `…: DynamoDB Streams table initialization complete, starting to process changes from the Stream` | **no counterpart** — line removed rather than invented |

Field values are filled in from each recipe's own config: `postgres/cdc` sets `pg_replication_slot: spice_orders` (publication is derived as `<slot>_pub` by `publication_name_for_slot`), and `dynamodb/streams` sets `ready_lag: 1h` on dataset `orders_stream`.

## Verified against

spiceai/spiceai at `v2.2.0` (current stable):

- `crates/data_components/src/postgres_replication/bootstrap.rs:286` — `"initial snapshot bootstrap complete"` with fields `dataset`, `rows`, `expected`
- `crates/data_components/src/postgres_replication/slot.rs:453` — `"Created new replication slot"` with fields `slot`, `publication`, `consistent_lsn`, `snapshot`
- `crates/data_components/src/postgres_replication/config.rs:455` — `publication_name_for_slot` → `{slot}_pub`
- `crates/data-connectors/connector-mongodb/src/changes.rs:197,253`
- `crates/data-connectors/connector-dynamodb/src/connector.rs:655`

## Evidence

None of the claimed messages appear anywhere in the v2.2.0 source tree:

```
Bootstrapping PostgreSQL table     : 0
Bootstrap complete for             : 0
Streaming WAL changes from slot    : 0
Bootstrapping MongoDB collection   : 0
No existing lag found for DynamoDB : 0
```

while each replacement message is present in the shipped release binary, as are the new module targets (`connector_mongodb::changes`, `connector_dynamodb::connector`, `data_components::postgres_replication::{slot,bootstrap}`).

The sibling `catalogs/postgres-cdc` recipe — added for v2.2.0 and captured from a real run — already shows this exact format, e.g.:

```
INFO data_components::postgres_replication::bootstrap: initial snapshot bootstrap complete dataset=__catalog_accel_pg__public__customer rows=150000 expected=Some(150000)
```

so this brings the three older CDC recipes in line with it.

Static/source review only — these three recipes need Docker plus a live Postgres/MongoDB/DynamoDB, which this run could not start. The LSN and snapshot values in the `postgres/cdc` block remain illustrative placeholders, as they are environment-specific.