### PR TITLE
Fix databricks recipe: spice datasets gained an ERROR column in v2.2.0

### DIFF
--- a/databricks/README.md
+++ b/databricks/README.md
@@ -154,8 +154,8 @@ To improve the query performance, the Databricks dataset can be accelerated.
    ```shell
    >>> spice datasets
 
-   NAME     FROM                                       REPLICATION ACCELERATION STATUS
-   my_table databricks:spice_data.public.awesome_table false       true         Ready
+    NAME      FROM                                        REPLICATION  ACCELERATION  STATUS  ERROR
+    my_table  databricks:spice_data.public.awesome_table  false        true          Ready
    ```
 
 3. Rerun the query


### PR DESCRIPTION
## Summary

The `databricks` recipe is the only recipe that documents `spice datasets` output, and its table is now wrong on v2.2.0: the CLI prints a sixth **ERROR** column (added alongside the v2.2.0 change where "a non-accelerated dataset now shows the `Error` state when its source is unavailable"). The recipe also uses single-space column separators where the CLI renders two.

```diff
-   NAME     FROM                                       REPLICATION ACCELERATION STATUS
-   my_table databricks:spice_data.public.awesome_table false       true         Ready
+    NAME      FROM                                        REPLICATION  ACCELERATION  STATUS  ERROR
+    my_table  databricks:spice_data.public.awesome_table  false        true          Ready
```

## Verified against

spiceai/spiceai v2.2.0 (current stable), runtime `v2.2.0+models.metal`.

## Evidence

Live `spice datasets` against a v2.2.0 runtime:

```
 NAME        FROM                                         REPLICATION  ACCELERATION  STATUS  ERROR
 taxi_trips  s3://spiceai-demo-datasets/taxi_trips/2024/  false        true          Ready
```

The replacement rows were produced with the same column-width rule the CLI uses (each column padded to its widest cell, two spaces between columns), validated by reproducing the live output above byte-for-byte before applying it to the recipe's own row.

The recipe itself needs Databricks credentials, so only the CLI table was reproduced here — the `my_table` / `databricks:spice_data.public.awesome_table` values are carried over unchanged from the existing block.

While checking this recipe I also confirmed its bare `mode: delta_lake` / `mode: spark_connect` params are still correct — `mode` is registered as `ParameterSpec::runtime("mode")` (`crates/data-connectors/connector-databricks/src/lib.rs:174`), so it is intentionally unprefixed.