### PR TITLE
Fix search recipes: document /v1/search matches as an array

### DIFF
--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -137,7 +137,9 @@ Result:
   "results": [
     {
       "matches": {
-        "content": ".\n\n## Definitions\n\n- Metric: is a measurement used to track the state and behavior of a system component. Metrics represent the current status ..."
+        "content": [
+          ".\n\n## Definitions\n\n- Metric: is a measurement used to track the state and behavior of a system component. Metrics represent the current status ..."
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/dev/metrics.md"
@@ -150,7 +152,9 @@ Result:
     },
     {
       "matches": {
-        "content": "6\n\n## Core Connector Data Types\n\nCore Connector Data Types depend on the specific connector, but in general can be abstracted as (non-exhaustive) types like: ..."
+        "content": [
+          "6\n\n## Core Connector Data Types\n\nCore Connector Data Types depend on the specific connector, but in general can be abstracted as (non-exhaustive) types like: ..."
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/criteria/definitions.md"

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -132,7 +132,9 @@ Result
   "results": [
     {
       "matches": {
-        "content": "# Metrics Naming\n\n## TL;DR\n\n**Metric Naming Guide**: Prioritize Developer Experience (DX) with intuitive, ..."
+        "content": [
+          "# Metrics Naming\n\n## TL;DR\n\n**Metric Naming Guide**: Prioritize Developer Experience (DX) with intuitive, ..."
+        ]
       },
       "_score": 0.7941223368131454,
       "dataset": "spiceai.docs",
@@ -142,7 +144,9 @@ Result
     },
     {
       "matches": {
-        "content": "# Criteria Definitions\n\n## RC\n\nAcronym for \"Release Candidate\". Identifies a version that is eligible for ..."
+        "content": [
+          "# Criteria Definitions\n\n## RC\n\nAcronym for \"Release Candidate\". Identifies a version that is eligible for ..."
+        ]
       },
       "_score": 0.7145749783070606,
       "dataset": "spiceai.docs",

--- a/search_github_files/README.md
+++ b/search_github_files/README.md
@@ -77,7 +77,9 @@ Result:
   "results": [
     {
       "matches": {
-        "content": "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        "content": [
+          "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/EXTENSIBILITY.md"
@@ -90,7 +92,9 @@ Result:
     },
     {
       "matches": {
-        "content": ".\n\n**API Guidelines**: The [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) are followed for all public interfaces."
+        "content": [
+          ".\n\n**API Guidelines**: The [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/about.html) are followed for all public interfaces."
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/dev/style_guide.md"
@@ -129,7 +133,9 @@ Result:
   "results": [
     {
       "matches": {
-        "content": "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        "content": [
+          "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/EXTENSIBILITY.md",
@@ -143,7 +149,9 @@ Result:
     },
     {
       "matches": {
-        "content": " ] All of the model's error messages follow the [error handling guidelines](../../dev/error_handling.md)\n\n### Documentation\n\n- [ ] All documentation meets alpha criteria.\n- [ ] Documentation includes any exceptions made for Beta quality.\n"
+        "content": [
+          " ] All of the model's error messages follow the [error handling guidelines](../../dev/error_handling.md)\n\n### Documentation\n\n- [ ] All documentation meets alpha criteria.\n- [ ] Documentation includes any exceptions made for Beta quality.\n"
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/criteria/models/beta.md",
@@ -212,7 +220,9 @@ Result:
   "results": [
     {
       "matches": {
-        "content": "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        "content": [
+          "\n| Component           | Description                                                                                                                                                                                  | Definition Link                                            |"
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/EXTENSIBILITY.md"
@@ -225,7 +235,9 @@ Result:
     },
     {
       "matches": {
-        "content": " ] All of the model's error messages follow the [error handling guidelines](../../dev/error_handling.md)\n\n### Documentation\n\n- [ ] All documentation meets alpha criteria.\n- [ ] Documentation includes any exceptions made for Beta quality.\n"
+        "content": [
+          " ] All of the model's error messages follow the [error handling guidelines](../../dev/error_handling.md)\n\n### Documentation\n\n- [ ] All documentation meets alpha criteria.\n- [ ] Documentation includes any exceptions made for Beta quality.\n"
+        ]
       },
       "data": {
         "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/criteria/models/beta.md"

--- a/vectors/s3/README.md
+++ b/vectors/s3/README.md
@@ -241,7 +241,9 @@ Response:
   "results": [
     {
       "matches": {
-        "body": "## 📝 Summary\r\n- Update duckdb-rs to point at spiceai duckdb fork: https://github.com/spiceai/duckdb-rs/pull/20\r\n- DuckDB v1.3.2 + [index resolution fix](https://github.com/spiceai/duckdb/compare/v1.3.2...v1.3.2-index-resolution)\r\n"
+        "body": [
+          "## 📝 Summary\r\n- Update duckdb-rs to point at spiceai duckdb fork: https://github.com/spiceai/duckdb-rs/pull/20\r\n- DuckDB v1.3.2 + [index resolution fix](https://github.com/spiceai/duckdb/compare/v1.3.2...v1.3.2-index-resolution)\r\n"
+        ]
       },
       "data": {
         "url": "https://github.com/spiceai/spiceai/pull/6496",
@@ -255,7 +257,9 @@ Response:
     },
     {
       "matches": {
-        "body": "## 📝 Summary\r\n\r\n<!-- What does this PR change? Why is it necessary? Keep it concise. -->\r\n\r\n## 🔗 Related\r\n\r\n<!-- Link to relevant issues, discussions, or other PRs. Use \"Closes #123\" to auto-close issues. Omit if none. -->\r\n\r\n## 🚨 Breaking Changes\r\n\r\n<!-- Describe breaking changes if any, or delete this section. -->\r\n<!-- If breaking, make sure the \"breaking change\" label is added. -->\r\n\r\n## 📚 Docs\r\n\r\n<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->\r\n\r\n## 👀 Notes for Reviewers\r\n\r\n<!-- Any areas needing special attention or questions for reviewers? Omitၓ Omit if none. -->\r\n"
+        "body": [
+          "## 📝 Summary\r\n\r\n<!-- What does this PR change? Why is it necessary? Keep it concise. -->\r\n\r\n## 🔗 Related\r\n\r\n<!-- Link to relevant issues, discussions, or other PRs. Use \"Closes #123\" to auto-close issues. Omit if none. -->\r\n\r\n## 🚨 Breaking Changes\r\n\r\n<!-- Describe breaking changes if any, or delete this section. -->\r\n<!-- If breaking, make sure the \"breaking change\" label is added. -->\r\n\r\n## 📚 Docs\r\n\r\n<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->\r\n\r\n## 👀 Notes for Reviewers\r\n\r\n<!-- Any areas needing special attention or questions for reviewers? Omitၓ Omit if none. -->\r\n"
+        ]
       },
       "data": {
         "url": "https://github.com/spiceai/spiceai/pull/6494",
@@ -269,7 +273,9 @@ Response:
     },
     {
       "matches": {
-        "body": "## 📝 Summary\r\n\r\n<!-- What does this PR change? Why is it necessary? Keep it concise. -->\r\n\r\n## 🔗 Related\r\n\r\n<!-- Link to relevant issues, discussions, or other PRs. Use \"Closes #123\" to auto-close issues. Omit if none. -->\r\n\r\n## 🚨 Breaking Changes\r\n\r\n<!-- Describe breaking changes if any, or delete this section. -->\r\n<!-- If breaking, make sure the \"breaking change\" label is added. -->\r\n\r\n## 📚 Docs\r\n\r\n<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->\r\n\r\n## 👀 Notes for Reviewers\r\n\r\n<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->\r\n"
+        "body": [
+          "## 📝 Summary\r\n\r\n<!-- What does this PR change? Why is it necessary? Keep it concise. -->\r\n\r\n## 🔗 Related\r\n\r\n<!-- Link to relevant issues, discussions, or other PRs. Use \"Closes #123\" to auto-close issues. Omit if none. -->\r\n\r\n## 🚨 Breaking Changes\r\n\r\n<!-- Describe breaking changes if any, or delete this section. -->\r\n<!-- If breaking, make sure the \"breaking change\" label is added. -->\r\n\r\n## 📚 Docs\r\n\r\n<!-- Note any required updates to docs, recipes, or guides. Omit if not applicable. -->\r\n\r\n## 👀 Notes for Reviewers\r\n\r\n<!-- Any areas needing special attention or questions for reviewers? Omit if none. -->\r\n"
+        ]
       },
       "data": {
         "url": "https://github.com/spiceai/spiceai/pull/6520",
@@ -283,7 +289,9 @@ Response:
     },
     {
       "matches": {
-        "body": "## Summary\r\nAdds a new `availability_monitor` configuration option to individual datasets to control whether the dataset availability monitor checks that specific dataset. This provides granular control over which datasets are monitored, preventing unnecessary remote calls that could wake up expensive warehouses.\r\n\r\n- Closes #5676\r\n\r\n## Usage\r\nUsers can now disable availability monitoring for specific datasets that might cause expensive warehouse wake-ups:\r\n\r\n```yaml\r\ndatasets:\r\n  - from: snowflake\r\n    name: expensive_table\r\n    availability_monitor: disabled\r\n  \r\n  - from: file://local_data.csv\r\n    name: local_data\r\n    availability_monitor: default\r\n```\r\n"
+        "body": [
+          "## Summary\r\nAdds a new `availability_monitor` configuration option to individual datasets to control whether the dataset availability monitor checks that specific dataset. This provides granular control over which datasets are monitored, preventing unnecessary remote calls that could wake up expensive warehouses.\r\n\r\n- Closes #5676\r\n\r\n## Usage\r\nUsers can now disable availability monitoring for specific datasets that might cause expensive warehouse wake-ups:\r\n\r\n```yaml\r\ndatasets:\r\n  - from: snowflake\r\n    name: expensive_table\r\n    availability_monitor: disabled\r\n  \r\n  - from: file://local_data.csv\r\n    name: local_data\r\n    availability_monitor: default\r\n```\r\n"
+        ]
       },
       "data": {
         "url": "https://github.com/spiceai/spiceai/pull/6482",
@@ -388,7 +396,9 @@ curl --request POST \
   "results": [
     {
       "matches": {
-        "content": "\n```sql\n-- Normal query - single department access\nINSERT INTO query_audit_logs (user_id, query_text, database_name, schema_name, rows_affected, ..."
+        "content": [
+          "\n```sql\n-- Normal query - single department access\nINSERT INTO query_audit_logs (user_id, query_text, database_name, schema_name, rows_affected, ..."
+        ]
       },
       "primary_key": {
         "path": "guides/security-analyzer/README.md"
@@ -398,7 +408,9 @@ curl --request POST \
     },
     {
       "matches": {
-        "content": "\n```shell\ndrop table <CATALOG_NAME>.<SCHEMA_NAME>.test_table_no_v2checkpoint;\n```\n\n**Verify table removal in Spice**: Observe that the table has beem removed in spice runtime log\n\n```shell\n2025-01-18T00:59:49.121835Z  INFO data_components::unity_catalog::provider: Refreshed schema <CATALOG_NAME>.<SCHEMA_NAME>. Tables removed: test_table_no_v2checkpoint.\n```\n\n## Step 8. Use Databricks Service Principal\n\nCreate a Databricks service ..."
+        "content": [
+          "\n```shell\ndrop table <CATALOG_NAME>.<SCHEMA_NAME>.test_table_no_v2checkpoint;\n```\n\n**Verify table removal in Spice**: Observe that the table has beem removed in spice runtime log\n\n```shell\n2025-01-18T00:59:49.121835Z  INFO data_components::unity_catalog::provider: Refreshed schema <CATALOG_NAME>.<SCHEMA_NAME>. Tables removed: test_table_no_v2checkpoint.\n```\n\n## Step 8. Use Databricks Service Principal\n\nCreate a Databricks service ..."
+        ]
       },
       "primary_key": {
         "path": "catalogs/databricks/README.md"


### PR DESCRIPTION
## Summary

Four recipes document the `POST /v1/search` response with `matches` holding a bare string:

```json
"matches": {
  "content": "# Metrics Naming\n\n## TL;DR\n..."
}
```

The runtime returns a list. `Match.matches` is `HashMap<String, Vec<Value>>` — a single column can contribute more than one highlight to a row (a chunked column commonly does) — so the value is always a JSON array, even when it holds one element:

```json
"matches": {
  "content": ["# Metrics Naming\n\n## TL;DR\n..."]
}
```

This changes `azure_openai`, `models/openai`, `vectors/s3` and `search_github_files` (16 blocks). Only the shape changes — every highlight string, score, and data value is left exactly as it was. The `full-text-search` recipe already documented the array form, which is what made the inconsistency visible.

## Verified against

spiceai/spiceai at `v2.2.1` — [`crates/runtime-search/src/types.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime-search/src/types.rs):

```rust
pub struct Match {
    /// The matches for this result
    matches: HashMap<String, Vec<Value>>,
    ...
}
```

`git show` on the `v2.0.0`, `v2.1.0`, `v2.2.0` and `v2.2.1` tags gives the same declaration, so this shape is not new in `v2.2.1` — the samples have been wrong for every `v2.x` reader.

## Evidence

Runtime output from a local `spiced v2.2.1+models.metal` (a `file:` dataset with an `all-MiniLM-L6-v2` embedding on one text column, no chunking — the simplest case, which still returns an array):

```console
$ curl -s -X POST http://localhost:8090/v1/search -H 'Content-Type: application/json' \
    -d '{"text":"animals","additional_columns":["title"],"limit":1}'
{
    "results": [
        {
            "matches": {
                "description": [
                    "A Touching Reflection of a Crocodile And a Dog who must Chase a Hunter in An Abandoned Fun House"
                ]
            },
            "data": { "title": "STRICTLY SCARFACE" },
            "_score": 0.7381305772506472,
            "dataset": "spice.public.films"
        }
    ],
    "duration_ms": 173
}
```

Note for reviewers: the upstream OpenAPI example in [`crates/runtime/src/http/v1/search.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime/src/http/v1/search.rs) still shows the scalar form too, which is likely where these samples came from. That one is worth a separate fix in `spiceai/spiceai`.