### PR TITLE
Fix http recipe: refresh the stale spice run transcript

### DIFF
--- a/http/README.md
+++ b/http/README.md
@@ -81,20 +81,24 @@ spice run
 Example output:
 
 ```console
-2025/11/09 14:51:05 INFO Checking for latest Spice runtime release...
-2025/11/09 14:51:05 INFO Spice.ai runtime starting...
-2025-11-09T22:51:05.790767Z  INFO spiced: Starting runtime v1.9.0-unstable-build.521d6438f+models.metal
-2025-11-09T22:51:05.792981Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s
-2025-11-09T22:51:05.793020Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s
-2025-11-09T22:51:05.793031Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s
-2025-11-09T22:51:06.137090Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
-2025-11-09T22:51:06.137446Z  INFO runtime::init::dataset: Dataset tvmaze initializing...
-2025-11-09T22:51:06.137756Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-11-09T22:51:06.336540Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-11-09T22:51:06.367725Z  INFO runtime::init::dataset: Dataset tvmaze registered (https://api.tvmaze.com), results cache enabled.
-2025-11-09T22:51:06.671311Z  INFO runtime::management: Connected to Spice Cloud for management and monitoring
-2025-11-09T22:51:06.774002Z  INFO runtime: All components are loaded. Spice runtime is ready!
+ INFO Spice.ai runtime starting...
+2026-09-05T21:54:00.787858Z  INFO spiced: Starting runtime v2.2.1+models.metal
+...
+2026-09-05T21:54:00.793801Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-09-05T21:54:00.793829Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-09-05T21:54:00.793839Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-09-05T21:54:00.795378Z  INFO runtime::init::task_history: Task history enabled: retention_period=28800s, retention_check_interval=900s
+2026-09-05T21:54:00.795492Z  INFO runtime::init::dataset: Loading datasets: 2 tasks dispatched, 0 skipped at accelerator init (of 2 total; localpod datasets may be chained).
+2026-09-05T21:54:00.795515Z  INFO runtime::init::dataset: Dataset tvmaze initializing...
+2026-09-05T21:54:00.795825Z  INFO runtime::init::dataset: Dataset products initializing...
+2026-09-05T21:54:00.799774Z  INFO runtime::init::dataset: Dataset products registered (https://dummyjson.com/products), results cache enabled. duration_ms=0
+2026-09-05T21:54:00.799774Z  INFO runtime::init::dataset: Dataset tvmaze registered (https://api.tvmaze.com), results cache enabled. duration_ms=0
+2026-09-05T21:54:00.901507Z  INFO runtime: All components are loaded. Spice runtime is ready!
+2026-09-05T21:54:00.994991Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-09-05T21:54:00.995358Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
 ```
+
+The elided lines report the CPU and memory budgets the runtime derives for this host, so their values differ from machine to machine.
 
 **Step 3.** Run `spice sql` in a new terminal to start an interactive SQL query session.
 
@@ -219,6 +223,7 @@ SELECT count(*) FROM products;
 ```console
 +----------+
 | count(*) |
+|   int64  |
 +----------+
 | 194      |
 +----------+
@@ -239,6 +244,7 @@ LIMIT 35;
 ```console
 +------------------+-------------------------------------------+---------+
 |   request_query  |                   title                   |  price  |
+|      varchar     |                  varchar                  | float64 |
 +------------------+-------------------------------------------+---------+
 | skip=0&limit=30  | Essence Mascara Lash Princess             | 9.99    |
 | skip=0&limit=30  | Eyeshadow Palette with Mirror             | 19.99   |


### PR DESCRIPTION
## Summary

The `http` recipe itself works — every query in it returns exactly what the README claims (see Evidence). Its `spice run` transcript, though, was captured on a v1.9.0 development build and has drifted in five separate ways:

| README showed | v2.2.1 actually prints |
| --- | --- |
| `2025/11/09 14:51:05 INFO Checking for latest Spice runtime release...` + a second dated banner line | a single ` INFO Spice.ai runtime starting...`, no date prefix (the Rust CLI rewrite dropped both) |
| `Starting runtime v1.9.0-unstable-build.521d6438f+models.metal` | `Starting runtime v2.2.1+models.metal` |
| `Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s` | `..., item ttl: 1s, hashing algorithm: XXH3, encoding: none`; the search and embeddings lines gained `, engine: Moka` |
| `Dataset tvmaze registered (...), results cache enabled.` | the same line with a trailing `duration_ms=0`, plus a `Loading datasets: 2 tasks dispatched, ...` line before it |
| `runtime::management: Connected to Spice Cloud for management and monitoring` | nothing — that line only appears when the runtime is enrolled in Spice Cloud, which a reader following this recipe is not |

The transcript also never mentioned the `products` dataset, even though `spicepod.yaml` registers it and the recipe's own pagination section queries it — so the block was stale relative to the recipe as well as to the runtime.

The replacement is a verbatim capture with the host-dependent CPU/memory budget lines elided behind a `...`, and a sentence saying so, since those values differ per machine.

Separately, this adds the data-type row that `spice sql` has printed under the column names since `v2.0` to the two result tables in the pagination section — the two whose output this run reproduced exactly.

## Verified against

spiceai/spiceai at `v2.2.1`, run locally as `spiced v2.2.1+models.metal`.

## Evidence

Everything below is from running this recipe's own directory. All three documented result values are unchanged and correct:

```console
$ spice sql
+----------+
| count(*) |
|   int64  |
+----------+
| 194      |
+----------+
Time: 1.272914375 seconds. 1 rows.
```

```console
> SELECT count(*) FROM tvmaze WHERE request_path = '/search/people'
    AND request_query IN ('q=michael', 'q=luke');
| 20       |
```

```console
> SELECT request_query, json_get_str(content,'title') AS title,
         json_get_float(content,'price') AS price FROM products LIMIT 35;
+------------------+-------------------------------------------+---------+
|   request_query  |                   title                   |  price  |
|      varchar     |                  varchar                  | float64 |
+------------------+-------------------------------------------+---------+
| skip=0&limit=30  | Essence Mascara Lash Princess             | 9.99    |
...
| skip=30&limit=30 | Potatoes                                  | 2.29    |
+------------------+-------------------------------------------+---------+
Time: 0.370123792 seconds. 35 rows.
```

The two `json_get_*` queries in the Advanced Usage section also return `Breaking Bad | Scripted | 60 | Ended` and `Game of Thrones | HBO | US` as the prose describes. Only the transcript needed changing.