### PR TITLE
Fix spicepy SDK sample: 'uv run main_cloud.py' has no dependencies

### DIFF
--- a/client-sdk/spicepy-sdk-sample/main_cloud.py
+++ b/client-sdk/spicepy-sdk-sample/main_cloud.py
@@ -1,4 +1,14 @@
-# Install with: pip install git+https://github.com/spiceai/spicepy
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#     "spicepy",
+#     "adbc-driver-flightsql",
+#     "adbc-driver-manager",
+# ]
+#
+# [tool.uv.sources]
+# spicepy = { git = "https://github.com/spiceai/spicepy", rev = "v3.1.0" }
+# ///
 from spicepy import Client
 
 client = Client(


### PR DESCRIPTION
## Summary

`client-sdk/spicepy-sdk-sample` runs both of its scripts through `uv`:

> ```bash
> uv run sample.py
> ```
> …
> The cloud snippet keeps an inline API key placeholder by design. Replace the API key placeholder in `main_cloud.py` with `${SPICE_API_KEY}`, then run:
>
> ```bash
> uv run main_cloud.py
> ```

`sample.py` declares its dependencies in a PEP 723 `# /// script` block, so `uv run sample.py` works. `main_cloud.py` has no such block, and the sample ships no `pyproject.toml` — so `uv run main_cloud.py` builds an ephemeral environment with nothing installed and dies on the first import, before the reader's API key is ever used.

This adds the same script-metadata block to `main_cloud.py`, replacing a stale `# Install with: pip install git+…` comment that described a different (pip) workflow than the README's.

`main_cloud.py`'s own code is unchanged.

## Verified against

Spice runtime `v2.2.1` (current stable); `uv` 0.12.10; `spicepy` at the `v3.1.0` rev the sample already pins in `sample.py`.

## Evidence

Before, on a clean checkout of `trunk`:

```console
$ uv run main_cloud.py
Traceback (most recent call last):
  File ".../main_cloud.py", line 2, in <module>
    from spicepy import Client
ModuleNotFoundError: No module named 'spicepy'
```

After this change:

```console
$ uv run main_cloud.py
Installed 15 packages in 84ms
Traceback (most recent call last):
  ...
  File ".../spicepy/_client.py", line 224, in _authenticate
    self._flight_client.authenticate_basic_token("", self._api_key),
pyarrow._flight.FlightUnauthenticatedError: Flight returned unauthenticated error, with message: invalid API key
```

The script now resolves its dependencies, imports, and reaches Spice.ai Cloud — failing only on the deliberate `'API_KEY'` placeholder, which is exactly the point where the reader substitutes their own key.

`uv run sample.py` is unaffected and still works against a live local `spiced v2.2.1+models.metal`:

```console
$ uv run sample.py
=== Using query ===
VendorID: 2, tpep_pickup_datetime: 2024-01-31 07:47:27, fare_amount: 9.3
...
=== Using query with params ===
VendorID: 1, tpep_pickup_datetime: 2024-01-07 21:01:36, fare_amount: 12.1
...
```