### PR TITLE
Fix spice.js SDK sample README: cloud path and a fabricated output line

### DIFF
--- a/client-sdk/spice.js-sdk-sample/README.md
+++ b/client-sdk/spice.js-sdk-sample/README.md
@@ -47,7 +47,16 @@ Set your API key for the commands in this README:
 export SPICE_API_KEY="your_api_key"
 ```
 
-The cloud snippet keeps an inline API key placeholder by design. Replace the API key placeholder in `index_cloud.mjs` with `${SPICE_API_KEY}`, then run:
+`index.js` reads `SPICE_API_KEY` (from the environment or a `.env` file) and connects to
+Spice.ai Cloud instead of the local runtime when it is set - no code edit needed:
+
+```bash
+npm start
+```
+
+`index_cloud.mjs` is a minimal cloud-only snippet and keeps an inline API key placeholder
+by design. Replace the API key placeholder in `index_cloud.mjs` with `${SPICE_API_KEY}`,
+then run:
 
 ```bash
 node index_cloud.mjs
@@ -66,7 +75,7 @@ Spice.js initialized
 NYC Taxi Trips Data Analysis
 
 Connected to: Local Spice Runtime
-Tip: Use `index_cloud.mjs` with your cloud API key for Spice.ai Cloud
+Tip: Set SPICE_API_KEY in .env to use Spice.ai Cloud
 
 Querying taxi_trips dataset...
 

--- a/client-sdk/spice.js-sdk-sample/README.md
+++ b/client-sdk/spice.js-sdk-sample/README.md
@@ -55,8 +55,8 @@ npm start
 ```
 
 `index_cloud.mjs` is a minimal cloud-only snippet and keeps an inline API key placeholder
-by design. Replace the API key placeholder in `index_cloud.mjs` with `${SPICE_API_KEY}`,
-then run:
+by design. It does not read the environment, so replace its `API_KEY` placeholder with the
+key itself rather than with `${SPICE_API_KEY}`, then run:
 
 ```bash
 node index_cloud.mjs


### PR DESCRIPTION
## Summary

Two README-vs-code mismatches in `client-sdk/spice.js-sdk-sample`:

**1. The documented cloud path is the harder of the two that exist.** `index.js` already reads `SPICE_API_KEY` and switches to Spice.ai Cloud on its own:

```js
const API_KEY = process.env.SPICE_API_KEY;
const usingCloud = !!API_KEY;
```

but the README's "Run with Spice.ai Cloud" section tells the reader to `export SPICE_API_KEY` and then hand-edit `index_cloud.mjs` — never mentioning that the export alone is enough for `npm start`. The section now documents both: `npm start` for the full sample, `index_cloud.mjs` for the minimal cloud-only snippet.

**2. The Example Output block contains a line the program never prints.** It shows:

```text
Tip: Use `index_cloud.mjs` with your cloud API key for Spice.ai Cloud
```

`index.js` prints:

```js
console.log("💡 Tip: Set SPICE_API_KEY in .env to use Spice.ai Cloud\n");
```

Corrected to match (the surrounding transcript is emoji-stripped, so this line is too).

No code changes.

## Verified against

Spice runtime `v2.2.1` (current stable), Node.js 25.9.0, `@spiceai/spice` 3.2.0 as resolved by the sample's `package.json`.

## Evidence

Local run against a live `spiced v2.2.1+models.metal` with this sample's spicepod — note the tip line:

```console
$ npm start
🌶️  Spice.js initialized
   Platform: Node.js v25.9.0 darwin arm64
   Transport: Arrow Flight → HTTP
   Endpoint: http://127.0.0.1:8090
   Flight URL: 127.0.0.1:50051
🚕 NYC Taxi Trips Data Analysis

📡 Connected to: Local Spice Runtime 🏠
💡 Tip: Set SPICE_API_KEY in .env to use Spice.ai Cloud
```

Same command with only `SPICE_API_KEY` set — no file edited — takes the cloud branch:

```console
$ SPICE_API_KEY=<key> npm start
🌶️  Spice.js initialized
   Platform: Node.js v25.9.0 darwin arm64
   Transport: Arrow Flight → HTTP
   Endpoint: Spice Cloud (data.spiceai.io)
   Flight URL: flight.spiceai.io:443 (TLS)
   Auth: API Key configured
🚕 NYC Taxi Trips Data Analysis

📡 Connected to: Spice.ai Cloud ☁️
```

The rest of the Example Output transcript reproduced exactly, so it is left alone.

## Review gate

Attests the review-feedback fix in `549f9ba`, not the original commit.

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed
- `/security-review`: no findings — the change is README prose and adds no code path; the added lines carry no secret-shaped literals, and it removes an instruction that would have had readers write a non-expanding `${SPICE_API_KEY}` in place of a key
- `/simplify`: n/a — a two-line prose change