### PR TITLE
Fix Java SDK sample: crashes on JDK 24+, contradicting its 'JDK 17+' prerequisite

### DIFF
--- a/client-sdk/spice-java-sdk-sample/build.gradle
+++ b/client-sdk/spice-java-sdk-sample/build.gradle
@@ -24,8 +24,11 @@ application {
 tasks.withType(JavaExec) {
     jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
 
-    // Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+ disables by
-    // default (JEP 498). The flag was only added in JDK 23, so it is applied conditionally.
+    // Arrow allocates through Netty, and Netty switches off its own sun.misc.Unsafe path
+    // whenever the JVM reports `sun.misc.unsafe.memory.access` as anything other than
+    // `allow`, leaving Arrow with no usable allocator. JDK 24 sets that property to `warn`
+    // by default (JEP 498 phase 2 — the JDK does not itself deny the calls until phase 3,
+    // JDK 26 or later). The option only exists from JDK 23 on, so it is applied conditionally.
     if (JavaVersion.current().majorVersion.toInteger() >= 23) {
         jvmArgs '--sun-misc-unsafe-memory-access=allow'
     }

--- a/client-sdk/spice-java-sdk-sample/build.gradle
+++ b/client-sdk/spice-java-sdk-sample/build.gradle
@@ -23,4 +23,10 @@ application {
 
 tasks.withType(JavaExec) {
     jvmArgs '--add-opens=java.base/java.nio=ALL-UNNAMED'
+
+    // Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+ disables by
+    // default (JEP 498). The flag was only added in JDK 23, so it is applied conditionally.
+    if (JavaVersion.current().majorVersion.toInteger() >= 23) {
+        jvmArgs '--sun-misc-unsafe-memory-access=allow'
+    }
 }

--- a/client-sdk/spice-java-sdk-sample/pom.xml
+++ b/client-sdk/spice-java-sdk-sample/pom.xml
@@ -19,11 +19,15 @@
      <maven.compiler.source>17</maven.compiler.source>
      <maven.compiler.target>17</maven.compiler.target>
      <exec.mainClass>ai.spice.example.App</exec.mainClass>
-     <!-- Apache Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+
-          disables by default (JEP 498). Without the flag the sample dies in SpiceClient's
-          constructor with UnsupportedOperationException. The flag was only added in JDK 23,
-          so the default below repeats the add-opens argument (harmless) and the jdk23-plus
-          profile swaps in the real flag. -->
+     <!-- Apache Arrow allocates through Netty, and Netty switches off its own
+          sun.misc.Unsafe path whenever the JVM reports `sun.misc.unsafe.memory.access` as
+          anything other than `allow`. That leaves Arrow with no usable allocator, and the
+          sample dies in SpiceClient's constructor with UnsupportedOperationException. JDK 24
+          sets that property to `warn` by default (JEP 498 phase 2 — the JDK does not itself
+          deny the calls until phase 3, JDK 26 or later), so passing `allow` is what keeps
+          Netty's Unsafe path available. The option only exists from JDK 23 on, so the default
+          below repeats the add-opens argument (harmless) and the jdk23-plus profile swaps in
+          the real flag. -->
      <arrow.unsafe.arg>--add-opens=java.base/java.nio=ALL-UNNAMED</arrow.unsafe.arg>
   </properties>
   <build>
@@ -33,7 +37,9 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.3</version>
         <configuration>
-          <executable>java</executable>
+          <!-- Maven's own JVM, so the jdk23-plus activation below and the JVM actually
+               launched here can never be different Java versions. -->
+          <executable>${java.home}/bin/java</executable>
           <arguments>
             <argument>--add-opens=java.base/java.nio=ALL-UNNAMED</argument>
             <argument>${arrow.unsafe.arg}</argument>

--- a/client-sdk/spice-java-sdk-sample/pom.xml
+++ b/client-sdk/spice-java-sdk-sample/pom.xml
@@ -19,6 +19,12 @@
      <maven.compiler.source>17</maven.compiler.source>
      <maven.compiler.target>17</maven.compiler.target>
      <exec.mainClass>ai.spice.example.App</exec.mainClass>
+     <!-- Apache Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+
+          disables by default (JEP 498). Without the flag the sample dies in SpiceClient's
+          constructor with UnsupportedOperationException. The flag was only added in JDK 23,
+          so the default below repeats the add-opens argument (harmless) and the jdk23-plus
+          profile swaps in the real flag. -->
+     <arrow.unsafe.arg>--add-opens=java.base/java.nio=ALL-UNNAMED</arrow.unsafe.arg>
   </properties>
   <build>
     <plugins>
@@ -30,6 +36,7 @@
           <executable>java</executable>
           <arguments>
             <argument>--add-opens=java.base/java.nio=ALL-UNNAMED</argument>
+            <argument>${arrow.unsafe.arg}</argument>
             <argument>-classpath</argument>
             <classpath/>
             <argument>${exec.mainClass}</argument>
@@ -38,4 +45,15 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>jdk23-plus</id>
+      <activation>
+        <jdk>[23,)</jdk>
+      </activation>
+      <properties>
+        <arrow.unsafe.arg>--sun-misc-unsafe-memory-access=allow</arrow.unsafe.arg>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
## Summary

`client-sdk/spice-java-sdk-sample` lists **JDK 17+** as its prerequisite. It does not run on JDK 24 or newer.

Apache Arrow's Netty allocator (pulled in by `ai.spice:spiceai`) reaches for `sun.misc.Unsafe` memory access, which JDK 24 disables by default under [JEP 498](https://openjdk.org/jeps/498). Both documented run paths — `mvn clean compile exec:exec` and `./gradlew run` — die before the first query:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.apache.arrow.memory.netty.DefaultAllocationManagerFactory.<clinit>(DefaultAllocationManagerFactory.java:26)
	...
	at ai.spice.SpiceClient.<init>(SpiceClient.java:224)
	at ai.spice.SpiceClientBuilder.build(SpiceClientBuilder.java:176)
	at ai.spice.example.App.main(App.java:34)
Caused by: java.lang.UnsupportedOperationException
	at io.netty.buffer.EmptyByteBuf.memoryAddress(EmptyByteBuf.java:961)
	...
	at org.apache.arrow.memory.netty.NettyAllocationManager.<clinit>(NettyAllocationManager.java:54)
```

JDK 25 is the current LTS, so this is not a corner case.

The fix is to pass `--sun-misc-unsafe-memory-access=allow`. That flag only exists on JDK 23+ (`Unrecognized option` on 17 and 21, which stops the JVM from starting), so it is applied conditionally:

- **Maven** — a `jdk23-plus` profile (`<jdk>[23,)</jdk>`) swaps the `arrow.unsafe.arg` property from a harmless repeat of the existing `--add-opens` argument to the real flag.
- **Gradle** — `if (JavaVersion.current().majorVersion.toInteger() >= 23)`.

Nothing changes on JDK 17/21, so the README's "JDK 17+" becomes true again instead of having to be narrowed to "17 or 21". No sample code changed.

## Verified against

Spice runtime `v2.2.1` (current stable), `ai.spice:spiceai` 0.6.0 as pinned, Maven 3.9.16, Gradle 9.7.1, Temurin/Homebrew JDK 17.0.20.1 / 21.0.12.1 / 25.0.4.1 / 26.0.2.1.

## Evidence

All runs against a live `spiced v2.2.1+models.metal` with this sample's spicepod (`taxi_trips`, arrow acceleration).

**Before** — `mvn clean compile exec:exec`:

| JDK | Result |
| --- | --- |
| 17 | rows printed |
| 21 | rows printed |
| 25 | `ExceptionInInitializerError` / `UnsupportedOperationException` |
| 26 | `ExceptionInInitializerError` / `UnsupportedOperationException` |

`./gradlew run` fails identically on 26:

```console
$ ./gradlew -q run
Exception in thread "main" java.lang.ExceptionInInitializerError
Caused by: java.lang.UnsupportedOperationException
* What went wrong:
Execution failed for task ':run' ...
```

**After** — every JDK produces rows on both paths.

```console
======== JDK 17 ========      ======== JDK 21 ========
VendorID	tpep_pickup_datetime	fare_amount
2	2024-01-13T13:28:44	32.4
...
======== JDK 25 ========      ======== JDK 26 ========
VendorID	tpep_pickup_datetime	fare_amount
2	2024-01-26T14:51:59	16.3
...
```

```console
======== gradle on JDK 17 / 21 / 25 / 26 ========
VendorID	tpep_pickup_datetime	fare_amount
1	2024-01-03T10:42:24	12.1
...
```

And the flag really is absent before 23, which is why it is gated rather than added unconditionally:

```console
$ jdk21/bin/java --sun-misc-unsafe-memory-access=allow -version
Unrecognized option: --sun-misc-unsafe-memory-access=allow
Error: Could not create the Java Virtual Machine.
```

## Note for reviewers

`clients/java` and `clients/scala` hit the same Arrow/Netty wall (they use `flight-sql-jdbc-driver` 19.0.0 directly). Those are separate recipes; I'm filing them separately rather than widening this PR.

## Review gate

Attests the review-feedback fix in `ee51331`, not the original commit.

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed
- `/security-review`: no findings — `${java.home}` is supplied by the JVM running Maven, not by user input, so binding the executable to it introduces no injection surface; no secret-shaped literals in the diff
- `/simplify`: n/a — one `<executable>` path plus comment rewords. `xml.etree` parses both poms; no JDK on this host to run the samples