### PR TITLE
Fix clients/java and clients/scala: both crash on JDK 24+

### DIFF
--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -6,7 +6,7 @@ This guide demonstrates how to use Java to query Spice via the Apache Arrow Flig
 
 ## Requirements
 
-- JDK 17
+- JDK 17 or newer
 - [Maven](https://maven.apache.org/) installed
 - [Spice CLI](https://docs.spiceai.org/getting-started) installed and Spice OSS runtime available
 

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -11,11 +11,15 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <!-- Apache Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+
-             disables by default (JEP 498). Without the flag the client dies opening the Flight
-             SQL connection with UnsupportedOperationException. The flag was only added in JDK
-             23, so the default below repeats the add-opens argument (harmless) and the
-             jdk23-plus profile swaps in the real flag. -->
+        <!-- Apache Arrow allocates through Netty, and Netty switches off its own
+             sun.misc.Unsafe path whenever the JVM reports `sun.misc.unsafe.memory.access` as
+             anything other than `allow`. That leaves Arrow with no usable allocator, and the
+             client dies opening the Flight SQL connection with UnsupportedOperationException.
+             JDK 24 sets that property to `warn` by default (JEP 498 phase 2 — the JDK does not
+             itself deny the calls until phase 3, JDK 26 or later), so passing `allow` is what
+             keeps Netty's Unsafe path available. The option only exists from JDK 23 on, so the
+             default below repeats the add-opens argument (harmless) and the jdk23-plus profile
+             swaps in the real flag. -->
         <arrow.unsafe.arg>--add-opens=java.base/java.nio=ALL-UNNAMED</arrow.unsafe.arg>
     </properties>
 
@@ -54,7 +58,9 @@
         <artifactId>exec-maven-plugin</artifactId>
         <version>3.6.3</version>
         <configuration>
-            <executable>java</executable>
+            <!-- Maven's own JVM, so the jdk23-plus activation below and the JVM actually
+                 launched here can never be different Java versions. -->
+            <executable>${java.home}/bin/java</executable>
             <arguments>
             <argument>--add-opens=java.base/java.nio=ALL-UNNAMED</argument>
             <argument>${arrow.unsafe.arg}</argument>

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -11,6 +11,12 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <!-- Apache Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+
+             disables by default (JEP 498). Without the flag the client dies opening the Flight
+             SQL connection with UnsupportedOperationException. The flag was only added in JDK
+             23, so the default below repeats the add-opens argument (harmless) and the
+             jdk23-plus profile swaps in the real flag. -->
+        <arrow.unsafe.arg>--add-opens=java.base/java.nio=ALL-UNNAMED</arrow.unsafe.arg>
     </properties>
 
     <dependencies>
@@ -51,6 +57,7 @@
             <executable>java</executable>
             <arguments>
             <argument>--add-opens=java.base/java.nio=ALL-UNNAMED</argument>
+            <argument>${arrow.unsafe.arg}</argument>
             <argument>-classpath</argument>
             <classpath/>
             <argument>MessagingServiceApp</argument>
@@ -59,4 +66,15 @@
         </plugin>
     </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>jdk23-plus</id>
+            <activation>
+                <jdk>[23,)</jdk>
+            </activation>
+            <properties>
+                <arrow.unsafe.arg>--sun-misc-unsafe-memory-access=allow</arrow.unsafe.arg>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/clients/scala/README.md
+++ b/clients/scala/README.md
@@ -6,7 +6,7 @@ This guide demonstrates how to use Scala to query Spice via the Apache Arrow Fli
 
 ## Requirements
 
-- JDK 17
+- JDK 17 or newer
 - [sbt](https://www.scala-sbt.org/) installed
 - [Spice CLI](https://docs.spiceai.org/getting-started) installed and Spice OSS runtime available
 

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -15,8 +15,11 @@ libraryDependencies ++= Seq(
 run / javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
 run / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED"
 
-// Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+ disables by
-// default (JEP 498). The flag was only added in JDK 23, so it is applied conditionally.
+// Arrow allocates through Netty, and Netty switches off its own sun.misc.Unsafe path
+// whenever the JVM reports `sun.misc.unsafe.memory.access` as anything other than `allow`,
+// leaving Arrow with no usable allocator. JDK 24 sets that property to `warn` by default
+// (JEP 498 phase 2 — the JDK does not itself deny the calls until phase 3, JDK 26 or later).
+// The option only exists from JDK 23 on, so it is applied conditionally.
 run / javaOptions ++= {
   val jdk = System.getProperty("java.specification.version").toInt
   if (jdk >= 23) Seq("--sun-misc-unsafe-memory-access=allow") else Seq.empty

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -14,4 +14,11 @@ libraryDependencies ++= Seq(
 
 run / javaOptions += "--add-opens=java.base/java.nio=ALL-UNNAMED"
 run / javaOptions += "--add-opens=java.base/java.lang=ALL-UNNAMED"
+
+// Arrow's Netty allocator uses sun.misc.Unsafe memory access, which JDK 24+ disables by
+// default (JEP 498). The flag was only added in JDK 23, so it is applied conditionally.
+run / javaOptions ++= {
+  val jdk = System.getProperty("java.specification.version").toInt
+  if (jdk >= 23) Seq("--sun-misc-unsafe-memory-access=allow") else Seq.empty
+}
 run / fork := true


### PR DESCRIPTION
## Summary

`clients/java` and `clients/scala` both query Spice through Apache Arrow's `flight-sql-jdbc-driver` 19.0.0. Its Netty allocator reaches for `sun.misc.Unsafe` memory access, which JDK 24 disables by default under [JEP 498](https://openjdk.org/jeps/498) — so on JDK 25 (the current LTS) and JDK 26 both recipes fail before the first query.

`clients/java`, `mvn exec:exec`:

```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at org.apache.arrow.driver.jdbc.shaded.org.apache.arrow.memory.netty.DefaultAllocationManagerFactory.<clinit>(...)
Caused by: java.lang.UnsupportedOperationException
	at io.netty.buffer.EmptyByteBuf.memoryAddress(EmptyByteBuf.java:961)
	at org.apache.arrow.memory.netty.NettyAllocationManager.<clinit>(NettyAllocationManager.java:54)
```

`clients/scala`, `sbt run`:

```
[error] Exception in thread "main" java.lang.NoClassDefFoundError: Could not initialize class org.apache.arrow.driver.jdbc.shaded.org.apache.arrow.memory.RootAllocator
[error] Caused by: java.lang.ExceptionInInitializerError
[error] 	at org.skife.jdbi.v2.DBI.open(DBI.java:211)
[error] 	at MessagingServiceApp$.main(DemoApp.scala:72)
```

The fix is `--sun-misc-unsafe-memory-access=allow`. That flag was only added in JDK 23 — on 17 and 21 it is an `Unrecognized option` that stops the JVM from starting — so both builds apply it conditionally:

- `clients/java/pom.xml` — a `jdk23-plus` profile (`<jdk>[23,)</jdk>`) swaps the `arrow.unsafe.arg` property from a harmless repeat of the existing `--add-opens` argument to the real flag.
- `clients/scala/build.sbt` — `run / javaOptions ++=` guarded on `java.specification.version >= 23`.

With that, both recipes work on 17 through 26, so the requirement widens from `JDK 17` to `JDK 17 or newer`. No sample code changed.

## Verified against

Spice runtime `v2.2.1` (current stable), Maven 3.9.16, sbt 1.10.11, Homebrew JDK 17.0.20.1 / 21.0.12.1 / 25.0.4.1 / 26.0.2.1.

## Evidence

Both recipes run against a live `spiced v2.2.1+models.metal` with their own spicepods (`addons` from the bundled CSV).

**Before** — `clients/scala`, `sbt -batch run`:

| JDK | Result |
| --- | --- |
| 17 | rows printed |
| 21 | rows printed |
| 25 | `NoClassDefFoundError: ... RootAllocator` |
| 26 | `NoClassDefFoundError: ... RootAllocator` |

`clients/java` fails on 25 and 26 the same way.

**After** — every JDK on both recipes prints exactly the README's expected output.

`clients/java`:

```console
======== JDK 17 / 21 / 25 / 26 ========
Add-ons by account and service:
addon1
addon2
addon6

Add-ons by add-on type:
addon1
addon2
addon4
addon6
addon8
addon10
```

`clients/scala`:

```console
======== sbt run on JDK 17 / 21 / 25 / 26 ========
[info] Add-ons by account and service:
[info] addon6
[info] addon2
[info] addon1
[info] Add-ons by add-on type:
[info] addon1
[info] addon2
[info] addon4
[info] addon6
[info] addon8
[info] addon10
```

Why the flag is gated rather than added unconditionally:

```console
$ jdk21/bin/java --sun-misc-unsafe-memory-access=allow -version
Unrecognized option: --sun-misc-unsafe-memory-access=allow
Error: Could not create the Java Virtual Machine.
```

Two recipes in one PR because it is one root cause and one fix; `client-sdk/spice-java-sdk-sample` hits the same wall through `ai.spice:spiceai` and is fixed separately.

## Review gate

Attests the review-feedback fix in `fedf35d`, not the original commit.

- Adversarial review: **skipped** — `codex` exited 1: "Your workspace is out of credits."; `grok` not installed
- `/security-review`: no findings — `${java.home}` comes from the JVM running Maven rather than user input, so the executable binding adds no injection surface; no secret-shaped literals in the diff
- `/simplify`: n/a — one `<executable>` path plus comment rewords. `xml.etree` parses `clients/java/pom.xml`; no JDK on this host to run the clients