### PR TITLE
Fix authorization recipe: OSS runtime silently loads nothing, and stale v1 transcripts

### DIFF
--- a/authorization/README.md
+++ b/authorization/README.md
@@ -67,8 +67,11 @@ spice run
 
 > **On the OSS runtime this looks like a success but is not.** The Spicepod is
 > rejected, no datasets load, and the runtime still logs `All components are
-> loaded. Spice runtime is ready!` - so check for this line, otherwise every
-> query below fails with `table 'spice.public.customers' not found`:
+> loaded. Spice runtime is ready!` - that line is printed either way, so it does
+> **not** confirm the recipe is working. The warning below is the failure signal:
+> if `spice run` prints it, stop here and install the Enterprise distribution,
+> because every query below will fail with
+> `table 'spice.public.customers' not found`:
 >
 > ```text
 > WARN spiced: Starting in pods watcher mode without a valid spicepod.yaml. The runtime will load

--- a/authorization/README.md
+++ b/authorization/README.md
@@ -21,7 +21,10 @@ Multi-tenancy isolates by **organization**; RLS isolates by **user**.
 
 ## Requirements
 
-- Spice.ai runtime (Enterprise) - [Install Spice.ai](https://docs.spiceai.org/installation)
+- Spice.ai runtime, **Enterprise distribution** - the OSS runtime has no
+  `oidc` or `authorization` configuration and rejects this Spicepod (see
+  [Step 2](#step-2-run-spice)).
+  [Get Spice.ai Enterprise](https://docs.spice.ai/docs/enterprise)
 - `python3` (standard library) to serve the JWKS
 - `node` - only to regenerate the demo tokens
 
@@ -62,6 +65,17 @@ In a second terminal:
 spice run
 ```
 
+> **On the OSS runtime this looks like a success but is not.** The Spicepod is
+> rejected, no datasets load, and the runtime still logs `All components are
+> loaded. Spice runtime is ready!` - so check for this line, otherwise every
+> query below fails with `table 'spice.public.customers' not found`:
+>
+> ```text
+> WARN spiced: Starting in pods watcher mode without a valid spicepod.yaml. The runtime will load
+> components once a valid spicepod.yaml is provided: Unable to load spicepod ...: Failed to parse
+> spicepod.yaml: unknown field `oidc`, expected `api-key` or `api_key`
+> ```
+
 ## Step 3: Load the demo tokens
 
 In a third terminal:
@@ -82,13 +96,14 @@ echo 'select id, tenant_id, email, ssn from customers order by id;' \
 ```
 
 ```text
-+----+-----------+---------+-------------+
-| id | tenant_id | email   | ssn         |
-+----+-----------+---------+-------------+
-| 1  | acme      | ***@*** | ***-**-**** |
-| 2  | acme      | ***@*** | ***-**-**** |
-| 5  | acme      | ***@*** | ***-**-**** |
-+----+-----------+---------+-------------+
++-------+-----------+---------+-------------+
+|   id  | tenant_id |  email  |     ssn     |
+| int64 |  varchar  | varchar |   varchar   |
++-------+-----------+---------+-------------+
+| 1     | acme      | ***@*** | ***-**-**** |
+| 2     | acme      | ***@*** | ***-**-**** |
+| 5     | acme      | ***@*** | ***-**-**** |
++-------+-----------+---------+-------------+
 ```
 
 The same query as a Globex analyst returns Globex rows only - tenant isolation
@@ -100,12 +115,13 @@ echo 'select id, tenant_id, email, ssn from customers order by id;' \
 ```
 
 ```text
-+----+-----------+---------+-------------+
-| id | tenant_id | email   | ssn         |
-+----+-----------+---------+-------------+
-| 3  | globex    | ***@*** | ***-**-**** |
-| 4  | globex    | ***@*** | ***-**-**** |
-+----+-----------+---------+-------------+
++-------+-----------+---------+-------------+
+|   id  | tenant_id |  email  |     ssn     |
+| int64 |  varchar  | varchar |   varchar   |
++-------+-----------+---------+-------------+
+| 3     | globex    | ***@*** | ***-**-**** |
+| 4     | globex    | ***@*** | ***-**-**** |
++-------+-----------+---------+-------------+
 ```
 
 ## Step 5: Row-level security by ownership
@@ -118,12 +134,13 @@ echo 'select id, tenant_id, owner, name, amount from deals order by id;' \
 ```
 
 ```text
-+----+-----------+------------+--------------+--------+
-| id | tenant_id | owner      | name         | amount |
-+----+-----------+------------+--------------+--------+
-| 1  | acme      | alice@acme | Acme Renewal | 50000  |
-| 2  | acme      | alice@acme | Acme Upsell  | 20000  |
-+----+-----------+------------+--------------+--------+
++-------+-----------+------------+--------------+--------+
+|   id  | tenant_id |    owner   |     name     | amount |
+| int64 |  varchar  |   varchar  |    varchar   |  int64 |
++-------+-----------+------------+--------------+--------+
+| 1     | acme      | alice@acme | Acme Renewal | 50000  |
+| 2     | acme      | alice@acme | Acme Upsell  | 20000  |
++-------+-----------+------------+--------------+--------+
 ```
 
 Dana is in the **same tenant** as Alice (`acme`), but sees only the row she
@@ -135,11 +152,12 @@ echo 'select id, tenant_id, owner, name, amount from deals order by id;' \
 ```
 
 ```text
-+----+-----------+-----------+----------------+--------+
-| id | tenant_id | owner     | name           | amount |
-+----+-----------+-----------+----------------+--------+
-| 3  | acme      | dana@acme | Acme Expansion | 75000  |
-+----+-----------+-----------+----------------+--------+
++-------+-----------+-----------+----------------+--------+
+|   id  | tenant_id |   owner   |      name      | amount |
+| int64 |  varchar  |  varchar  |     varchar    |  int64 |
++-------+-----------+-----------+----------------+--------+
+| 3     | acme      | dana@acme | Acme Expansion | 75000  |
++-------+-----------+-----------+----------------+--------+
 ```
 
 `morgan` holds the `admin` role, which is exempt from the ownership filter and
@@ -152,14 +170,15 @@ echo 'select id, tenant_id, owner, name, amount from deals order by id;' \
 ```
 
 ```text
-+----+-----------+------------+-----------------+--------+
-| id | tenant_id | owner      | name            | amount |
-+----+-----------+------------+-----------------+--------+
-| 1  | acme      | alice@acme | Acme Renewal    | 50000  |
-| 2  | acme      | alice@acme | Acme Upsell     | 20000  |
-| 3  | acme      | dana@acme  | Acme Expansion  | 75000  |
-| 5  | acme      | hebe@acme  | Acme Onboarding | 30000  |
-+----+-----------+------------+-----------------+--------+
++-------+-----------+------------+-----------------+--------+
+|   id  | tenant_id |    owner   |       name      | amount |
+| int64 |  varchar  |   varchar  |     varchar     |  int64 |
++-------+-----------+------------+-----------------+--------+
+| 1     | acme      | alice@acme | Acme Renewal    | 50000  |
+| 2     | acme      | alice@acme | Acme Upsell     | 20000  |
+| 3     | acme      | dana@acme  | Acme Expansion  | 75000  |
+| 5     | acme      | hebe@acme  | Acme Onboarding | 30000  |
++-------+-----------+------------+-----------------+--------+
 ```
 
 ## Step 6: Role-conditional PII
@@ -173,13 +192,14 @@ echo 'select id, tenant_id, email, ssn from customers order by id;' \
 ```
 
 ```text
-+----+-----------+--------------------+-------------+
-| id | tenant_id | email              | ssn         |
-+----+-----------+--------------------+-------------+
-| 1  | acme      | alice@acme.example | 111-11-1111 |
-| 2  | acme      | aaron@acme.example | 222-22-2222 |
-| 5  | acme      | amy@acme.example   | 555-55-5555 |
-+----+-----------+--------------------+-------------+
++-------+-----------+--------------------+-------------+
+|   id  | tenant_id |        email       |     ssn     |
+| int64 |  varchar  |       varchar      |   varchar   |
++-------+-----------+--------------------+-------------+
+| 1     | acme      | alice@acme.example | 111-11-1111 |
+| 2     | acme      | aaron@acme.example | 222-22-2222 |
+| 5     | acme      | amy@acme.example   | 555-55-5555 |
++-------+-----------+--------------------+-------------+
 ```
 
 ## Step 7: RBAC
@@ -202,12 +222,13 @@ echo 'select * from salaries order by id;' | spice sql --api-key "$TOKEN_HEBE"
 ```
 
 ```text
-+----+-----------+----------------+--------+
-| id | tenant_id | employee       | amount |
-+----+-----------+----------------+--------+
-| 1  | acme      | Alice Anderson | 120000 |
-| 2  | acme      | Aaron Ackerman | 115000 |
-+----+-----------+----------------+--------+
++-------+-----------+----------------+--------+
+|   id  | tenant_id |    employee    | amount |
+| int64 |  varchar  |     varchar    |  int64 |
++-------+-----------+----------------+--------+
+| 1     | acme      | Alice Anderson | 120000 |
+| 2     | acme      | Aaron Ackerman | 115000 |
++-------+-----------+----------------+--------+
 ```
 
 


### PR DESCRIPTION
## Summary

Two problems in the `authorization` recipe, both confirmed by running it.

**1. The Requirements link installs a runtime that cannot run this recipe — and fails silently.**

The recipe is correctly labelled an Enterprise feature at the top, but Requirements said:

> - Spice.ai runtime (Enterprise) - [Install Spice.ai](https://docs.spiceai.org/installation)

That link is the OSS install page. The OSS runtime has no `runtime.auth.oidc` and no
`runtime.authorization`, and `Runtime` is `#[serde(deny_unknown_fields)]`, so the Spicepod is
rejected. It does **not** stop — it warns, loads **zero** datasets, and then reports
`All components are loaded. Spice runtime is ready!` and starts listening on 50051/8090.
A reader following the README sees a healthy-looking Step 2 and then an unexplained
missing-table error at Step 4.

Fixed by pointing the prerequisite at the Enterprise page and documenting the OSS
failure mode inline at Step 2, quoting the actual warning.

**2. All seven expected-output tables used the pre-v2 untyped header.**

Since v2.0 the SQL REPL renders results through `format_batches_with_types`, so real output
carries a data-type row under centered column names. Every table in the recipe showed the
pre-v2 left-aligned, untyped form.

## Verified against

spiceai/spiceai at `v2.2.1`:
- `crates/spicepod/src/component/runtime.rs` — `Runtime` is `deny_unknown_fields`; `Auth` has
  only `api_key` (no `oidc`), and there is no `authorization` field.
- `crates/repl/src/pretty.rs` — `format_batches_with_types` is unconditional in non-expanded mode.

Runtime: `spice` / `spiced` v2.2.1 (`v2.2.1+models.metal`) on macOS arm64.

## Evidence

`spice run` in `authorization/`, with `serve-jwks.py` already serving discovery + JWKS
(verified: `curl http://127.0.0.1:9999/.well-known/openid-configuration` returns the document):

```text
WARN spiced: Starting in pods watcher mode without a valid spicepod.yaml. The runtime will load
components once a valid spicepod.yaml is provided: Unable to load spicepod <path>: Failed to parse
spicepod.yaml: unknown field `oidc`, expected `api-key` or `api_key`
...
INFO runtime: All components are loaded. Spice runtime is ready!
INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
```

Then the recipe's own Step 3 + Step 4, verbatim:

```console
$ set -a; . ./tokens.env; set +a
$ echo 'show tables;' | spice sql --api-key "$TOKEN_ALICE"
No results.

$ echo 'select id, tenant_id, email, ssn from customers order by id;' | spice sql --api-key "$TOKEN_ALICE"
Query Error: table 'spice.public.customers' not found
```

For the transcripts: the policy-filtered result sets can't be produced without the Enterprise
runtime, so each one was reproduced on v2.2.1 by registering the recipe's own three CSVs and
substituting each Cedar `@row_filter` as the equivalent `WHERE` clause, and the `@mask_email` /
`@mask_ssn` values as the string literals the policies specify. Every one of the seven tables in
the README is now byte-identical to real runtime output (`diff` clean). Masked columns are typed
`varchar` regardless of how the mask is implemented internally — the REPL renders `Utf8`,
`LargeUtf8` and `Utf8View` all as `varchar` (verified with `arrow_cast`).

Unchanged: the Step 7 denial message, which only the Enterprise runtime can emit.

Also checked and correct, no change needed: the demo JWTs are not expired (`exp` 4102444800 =
2100-01-01), `serve-jwks.py` serves both documents on 9999 as documented, `generate-tokens.js`
runs with no external dependencies and mints a key when the gitignored `.pem` is absent, the
row sets in every step match the shipped CSVs, `spice sql --api-key` exists in v2.2.1, and all
three external links resolve (200).

## Review gate

Attests the review-thread fix in `fc2b1c6` (the Step 2 callout wording) — not the original recipe audit in this PR.

- Adversarial review: `codex` — **declared skip**. Engine dispatched against `origin/trunk...fc2b1c6` (scope: `authorization/README.md`) and exited 1 without a review: `Your workspace is out of credits. Ask your workspace owner to refill in order to continue.` The `grok` fallback is not installed on this host, so no cross-model pass was available. Receipt: `.git/spice-review-gate/adversarial-review.txt`.
- `/security-review`: **declared skip** — the change is Markdown prose in a recipe README. No code, no new surface, no secrets, logging, or error paths touched.
- `/simplify`: n/a — single-paragraph prose edit, 5 insertions / 2 deletions.
