### PR TITLE
Fix dynamodb/streams: ready_lag is deprecated, and the version floor is wrong

### DIFF
--- a/dynamodb/streams/README.md
+++ b/dynamodb/streams/README.md
@@ -1,6 +1,6 @@
 # DynamoDB Streams Data Connector (AWS Hosted)
 
-Works with `v1.10+`
+Works with `v2.2.0+`
 
 This recipe demonstrates how to configure a Spice dataset to stream real-time changes from an AWS-hosted DynamoDB table using DynamoDB Streams. You'll see how inserts, updates, and deletes automatically flow into Spice.
 

--- a/dynamodb/streams/spicepod.yaml
+++ b/dynamodb/streams/spicepod.yaml
@@ -10,7 +10,7 @@ datasets:
       dynamodb_aws_auth: key
       dynamodb_aws_access_key_id: ${secrets:SPICE_DYNAMODB_KEY}
       dynamodb_aws_secret_access_key: ${secrets:SPICE_DYNAMODB_SECRET}
-      ready_lag: 1h
+      dynamodb_replication_ready_lag: 1h
     acceleration:
       enabled: true
       engine: duckdb


### PR DESCRIPTION
## Summary

`dynamodb/streams/spicepod.yaml` sets `ready_lag: 1h`. As of v2.2.0 that parameter is a
deprecated alias — the runtime accepts it, warns, and the canonical name is
`dynamodb_replication_ready_lag`. Renamed it.

The recipe also declared `Works with v1.10+`, which was already wrong before this change: the
shipped Spicepod is `version: v2`, and a v1.x runtime only accepts `v1beta1`/`v1`. With the
canonical parameter name the true floor is v2.2.0, so the note now says `v2.2.0+`.

Unchanged: the `ready_lag=1h` field in the Step 5 log transcript. That is the tracing field
name in `connector.rs`, not the parameter name, and it is still emitted as `ready_lag`.

## Verified against

spiceai/spiceai at `v2.2.1`:
- `crates/data-connectors/connector-dynamodb/src/connector.rs:204-209` —
  `ParameterSpec::component("replication_ready_lag")`, with
  `ParameterSpec::runtime("ready_lag").deprecated("Renamed to 'dynamodb_replication_ready_lag'.")`
  right below it, and the dual-read at line 385 preferring the canonical name.
- `crates/spicepod/src/spec.rs` — `SpicepodVersion` at `v1.11.6` is only `V1Beta1`/`V1`;
  `v2` became valid in v2.0.0.
- `replication_ready_lag` is absent at `v2.1.5` and present at `v2.2.0`, which is where the
  rename landed.

## Evidence

Runtime v2.2.1, `spiced` started in `dynamodb/streams/` before and after the change.

Before — the recipe as shipped:

```text
WARN runtime_parameters: Parameter 'ready_lag' is deprecated for connector dynamodb: Renamed to 'dynamodb_replication_ready_lag'.
```

After — same command, no deprecation and no "Ignoring parameter" warning for the new name:

```text
(no runtime_parameters warnings)
```

Found by sweeping all 97 Spicepods in the repo through a v2.2.1 runtime and collecting every
parameter warning; this was the only deprecated parameter in the cookbook.

The Step 6/7 result tables were left alone — they need an AWS DynamoDB table to reproduce, and
guessing the Arrow types for a hand-written transcript would not be an improvement.