### PR TITLE
Fix 11 recipes: stale v1 `spice sql` REPL banner in expected output

### DIFF
--- a/acceleration/constraints/README.md
+++ b/acceleration/constraints/README.md
@@ -47,9 +47,13 @@ Run queries using the Spice SQL REPL to explore the data and ensure the constrai
 `spice sql`
 
 ```bash
-Welcome to the interactive Spice.ai SQL Query Utility! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> show tables;
 +---------------+--------------+--------------+------------+
 | table_catalog | table_schema | table_name   | table_type |

--- a/catalogs/databricks/README.md
+++ b/catalogs/databricks/README.md
@@ -150,7 +150,13 @@ SELECT 1 AS id;
 
 ```shell
 >> spice sql
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
+
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> select * from db_uc.<SCHEMA_NAME>.test_table_no_v2checkpoint;
 +----+
 | id |

--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -92,9 +92,13 @@ For more information on using `spice sql`, see the [CLI reference](https://docs.
 
 ```console
 $ spice sql
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> select * from my_first_table;
 +---------+----------------------------------------------------+---------------------+---------+
 | user_id | message                                            | timestamp           | metric  |

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -71,9 +71,13 @@ Spice can read data straight from a Databricks instance. This recipe will create
 
    ```shell
    >>> spice sql
-   Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+   Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-   show tables; -- list available tables
+   Examples:
+     show tables;              -- list available tables
+     describe <table_name>;    -- show column types
+     nql <question>            -- natural language to SQL (requires a model)
+
    sql> show tables;
    +---------------+--------------+---------------+------------+
    | table_catalog | table_schema | table_name    | table_type |
@@ -232,9 +236,13 @@ Note: A dataset can be accelerated when configured by specifying yes (y) to `loc
 
    ```shell
    >>> spice sql
-   Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+   Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-   show tables; -- list available tables
+   Examples:
+     show tables;              -- list available tables
+     describe <table_name>;    -- show column types
+     nql <question>            -- natural language to SQL (requires a model)
+
    sql> show tables;
    +---------------+--------------+---------------+------------+
    | table_catalog | table_schema | table_name    | table_type |
@@ -307,9 +315,13 @@ Note: A dataset can be accelerated when configured by specifying yes (y) to `loc
 
    ```shell
    >>> spice sql
-   Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+   Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-   show tables; -- list available tables
+   Examples:
+     show tables;              -- list available tables
+     describe <table_name>;    -- show column types
+     nql <question>            -- natural language to SQL (requires a model)
+
    sql> show tables;
    +---------------+--------------+--------------+------------+
    | table_catalog | table_schema | table_name   | table_type |
@@ -384,9 +396,13 @@ Create a Databricks service principal by following the [Databricks documentation
 
    ```shell
    >>> spice sql
-   Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+   Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-   show tables; -- list available tables
+   Examples:
+     show tables;              -- list available tables
+     describe <table_name>;    -- show column types
+     nql <question>            -- natural language to SQL (requires a model)
+
    sql> show tables;
    +---------------+--------------+---------------+------------+
    | table_catalog | table_schema | table_name    | table_type |

--- a/delta-lake/README.md
+++ b/delta-lake/README.md
@@ -57,9 +57,13 @@ Spice supports reading data directly from Delta Lake tables. This recipe will cr
 
    ```shell
    >>> spice sql
-    Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+    Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-    show tables; -- list available tables
+    Examples:
+      show tables;              -- list available tables
+      describe <table_name>;    -- show column types
+      nql <question>            -- natural language to SQL (requires a model)
+
     sql> show tables;
     +---------------+--------------+------------------+------------+
     | table_catalog | table_schema | table_name       | table_type |

--- a/mssql/README.md
+++ b/mssql/README.md
@@ -52,9 +52,13 @@ instances are accessible from within Spice to demonstrate that you can query acr
 4. In another shell, fire up the Spice SQL REPL using `spice sql`
 
    ```shell
-   Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+   Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-   show tables; -- list available tables
+   Examples:
+     show tables;              -- list available tables
+     describe <table_name>;    -- show column types
+     nql <question>            -- natural language to SQL (requires a model)
+
    ```
 
 ## Example Queries

--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -55,9 +55,13 @@ spice sql
 ```
 
 ```shell
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 ```
 
 ```sql

--- a/retention/README.md
+++ b/retention/README.md
@@ -60,9 +60,13 @@ In addition to viewing the logs, run queries with the Spice SQL REPL to explore 
 `docker exec -it spiceai-retention-demo spiced --repl`
 
 ```console
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> show tables;
 +---------------+--------------+--------------+------------+
 | table_catalog | table_schema | table_name   | table_type |

--- a/sales-bi/README.md
+++ b/sales-bi/README.md
@@ -105,9 +105,13 @@ In addition to Apache Superset, run queries using the Spice SQL REPL to explore 
 `docker exec -it spiceai-sales-bi-demo spiced --repl`
 
 ```bash
-Welcome to the interactive Spice.ai SQL Query Utility! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> show tables;
 +---------------+--------------+--------------------------------+------------+
 | table_catalog | table_schema | table_name                     | table_type |

--- a/spark/README.md
+++ b/spark/README.md
@@ -118,9 +118,13 @@ spice sql
 ```
 
 ```
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 ```
 
 ```shell

--- a/tls/README.md
+++ b/tls/README.md
@@ -176,9 +176,13 @@ SELECT * FROM customer_addresses LIMIT 5;
 ```
 
 ```bash
-Welcome to the Spice.ai SQL REPL! Type 'help' for help.
+Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.
 
-show tables; -- list available tables
+Examples:
+  show tables;              -- list available tables
+  describe <table_name>;    -- show column types
+  nql <question>            -- natural language to SQL (requires a model)
+
 sql> SELECT * FROM customer_addresses LIMIT 5;
 +----+------------+------------+----------------------------+----------------------+--------------------+--------------+---------------+--------------+--------------+
 | id | first_name | last_name  | email                      | res_address          | work_address       | country      | state         | phone_1      | phone_2      |


### PR DESCRIPTION
## Summary

Eleven recipes show a `spice sql` transcript that opens with the **v1** REPL banner:

```
Welcome to the Spice.ai SQL REPL! Type 'help' for help.

show tables; -- list available tables
```

Two of them (`acceleration/constraints`, `sales-bi`) show an even older pre-v1 line:
`Welcome to the interactive Spice.ai SQL Query Utility! Type 'help' for help.`

Neither string is emitted by any Spice release a reader can install today. The REPL banner is now six lines and the `show tables` hint moved inside an `Examples:` block:

```
Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.

Examples:
  show tables;              -- list available tables
  describe <table_name>;    -- show column types
  nql <question>            -- natural language to SQL (requires a model)
```

This replaces the stale banner (and the now-redundant stray hint line) in every affected transcript, preserving each block's existing indentation. Nothing but the banner changed — the query output in these transcripts is untouched.

Recipes: `acceleration/constraints`, `catalogs/databricks`, `clickhouse`, `databricks` (4 transcripts), `delta-lake`, `mssql`, `refresh-data-window`, `retention`, `sales-bi`, `spark`, `tls`.

## Verified against

spiceai/spiceai at `v2.2.1` — the banner is printed by [`crates/repl/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/repl/src/lib.rs) (`println!("Welcome to the Spice.ai SQL REPL! Type \`help\` or \`?\` for commands.\n")` followed by the three `Examples:` lines). Neither old string appears anywhere in the runtime or CLI except in the `spice sql --help` example text.

Both `spice sql` and `spiced --repl` share this code path, so the fix applies to `retention` and `sales-bi`, which invoke the REPL via `docker exec ... spiced --repl`.

## Evidence

Runtime `v2.2.1+models.metal`, run locally:

```console
$ spice sql
Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.

Examples:
  show tables;              -- list available tables
  describe <table_name>;    -- show column types
  nql <question>            -- natural language to SQL (requires a model)

sql>
```

```console
$ spiced --repl
Welcome to the Spice.ai SQL REPL! Type `help` or `?` for commands.

Examples:
  show tables;              -- list available tables
  describe <table_name>;    -- show column types
  nql <question>            -- natural language to SQL (requires a model)

+---------------+--------------+--------------+------------+
| table_catalog | table_schema |  table_name  | table_type |
|    varchar    |    varchar   |    varchar   |   varchar  |
+---------------+--------------+--------------+------------+
| spice         | runtime      | task_history | BASE TABLE |
| spice         | public       | taxi_trips   | BASE TABLE |
+---------------+--------------+--------------+------------+
```

Note: the table transcripts in several of these recipes also predate the v2 typed-header row (the `varchar` line above). That is a separate, larger sweep and is deliberately left out of this PR so the banner fix stays reviewable.