### PR TITLE
Fix refresh-data-window and snowflake: stale hot-reload log line (and wrong accelerated size)

### DIFF
--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -113,10 +113,10 @@ datasets:
 Check if dataset has been reloaded
 
 ```bash
-2024-08-05T14:36:11.552233Z  INFO runtime: Updating accelerated dataset taxi_trips...
-2024-08-05T14:36:12.777384Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2024-08-05T14:36:21.990860Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,619 rows (421.58 MiB) for dataset taxi_trips in 9s 213ms.
-2024-08-05T14:36:23.197896Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
+2026-09-08T12:08:56.214710Z  INFO runtime::init::dataset: Accelerated Dataset taxi_trips updating...
+2026-09-08T12:08:57.391829Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
+2026-09-08T12:09:00.250563Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,619 rows (399.38 MiB) for dataset taxi_trips in 2s 858ms.
+2026-09-08T12:09:01.170846Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
 
 ```
 

--- a/refresh-data-window/README.md
+++ b/refresh-data-window/README.md
@@ -116,7 +116,7 @@ Check if dataset has been reloaded
 2026-09-08T12:08:56.214710Z  INFO runtime::init::dataset: Accelerated Dataset taxi_trips updating...
 2026-09-08T12:08:57.391829Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
 2026-09-08T12:09:00.250563Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,619 rows (399.38 MiB) for dataset taxi_trips in 2s 858ms.
-2026-09-08T12:09:01.170846Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
+2026-09-08T12:09:01.170846Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled. duration_ms=0
 
 ```
 

--- a/snowflake/README.md
+++ b/snowflake/README.md
@@ -191,7 +191,7 @@ Note: we use `refresh_sql` parameter in this example to specify exact data we re
 The following output is shown in the Spice runtime terminal confirming new configuration is applied.
 
 ```bash
-2024-07-23T00:23:29.327942Z  INFO runtime: Updating accelerated dataset lineitem...
+2024-07-23T00:23:29.327942Z  INFO runtime::init::dataset: Accelerated Dataset lineitem updating...
 2024-07-23T00:23:29.657023Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset lineitem
 2024-07-23T00:23:52.413596Z  INFO runtime_table::accelerated::refresh_task: Loaded 6,001,215 rows (9.46 GiB) for dataset lineitem in 22s 756ms.
 2024-07-23T00:23:52.553037Z  INFO runtime::init::dataset: Dataset lineitem registered (snowflake:snowflake_sample_data.tpch_sf1.lineitem), acceleration (arrow), results cache enabled.


### PR DESCRIPTION
## Summary

Both recipes show a `spicepod.yaml` hot-reload transcript that opens with:

```
INFO runtime: Updating accelerated dataset <name>...
```

No Spice release emits that. The runtime logs it from `runtime::init::dataset` with the words reordered:

```
INFO runtime::init::dataset: Accelerated Dataset <name> updating...
```

(`arrow/README.md` already carries the correct form, so this is the tail of that sweep.)

`refresh-data-window` additionally reported the reloaded `taxi_trips` as **421.58 MiB**. A v2.2.1 run reports **399.38 MiB** — the same figure the recipe's own Step 3 block already shows for the pre-eviction load, so the old number contradicted the recipe itself. Timestamps in that block are re-based on the run below so it reads as one session.

Everything else in `refresh-data-window` was confirmed correct by running it: 2,964,624 rows before, 2,964,619 after, the same five 2002/2009 rows evicted, and `2023-12-31T23:39:17` as the new earliest record.

## Verified against

spiceai/spiceai at `v2.2.1` — [`crates/runtime/src/init/dataset.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime/src/init/dataset.rs): `tracing::info!("Accelerated Dataset {} updating...", &ds.name)`. Grepping the tree for `Updating accelerated dataset` returns nothing.

## Evidence

`refresh-data-window` run end to end on runtime `v2.2.1+models.metal`. Initial load:

```
INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled. duration_ms=2
INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 72ms.
```

After adding `refresh_data_window: 35040h`:

```
INFO runtime::init::dataset: Accelerated Dataset taxi_trips updating...
INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
INFO runtime_table::accelerated::refresh_task: Loaded 2,964,619 rows (399.38 MiB) for dataset taxi_trips in 2s 858ms.
INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled. duration_ms=0
```

```console
sql> select count(1) from taxi_trips;
+-----------------+
| count(Int64(1)) |
|      int64      |
+-----------------+
| 2964619         |
+-----------------+
```

The `snowflake` change is the message text only — static, since the recipe needs a Snowflake account.