### PR TITLE
Fix llama recipe: HuggingFace token param is `huggingface_token`, not `hf_token`

### DIFF
--- a/llama/README.md
+++ b/llama/README.md
@@ -94,10 +94,11 @@ For more information, see the [Spice HuggingFace documentation](https://docs.spi
 
 ## Hardware Acceleration
 
-`spice install` (and `curl https://install.spiceai.org | /bin/bash`) auto-detects the
-local hardware accelerator and installs the matching runtime build — Metal on Apple
-silicon, CUDA on Linux when a supported GPU is present — so no extra step is needed.
-Confirm which build is installed with:
+`curl https://install.spiceai.org | /bin/bash` installs the `spice` CLI only. The
+runtime itself is fetched the first time you run `spice run` or `spice install`, and
+*that* step auto-detects the local hardware accelerator and installs the matching
+build — Metal on Apple silicon, CUDA on Linux when a supported GPU is present — so no
+extra step is needed. Confirm which build is installed with:
 
 ```sh
 spice version
@@ -112,8 +113,14 @@ A `+models.metal` or `+models.cuda_<cc>` suffix on the runtime version means the
 accelerated build is in use. To install a CUDA build explicitly on Linux:
 
 ```sh
-spice install cuda
+spice install cuda --force
 ```
+
+`--force` is required here rather than optional: by this point in the recipe `spice
+run` has already installed a runtime, and `spice install` skips the download whenever
+the installed version matches the latest release tag — a check that does not consider
+which flavor you asked for. Without `--force` the command reports the runtime as
+already installed and leaves the non-CUDA build in place.
 
 Building from source is only necessary to run an unreleased revision; see
 [Building Spice](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building).

--- a/llama/README.md
+++ b/llama/README.md
@@ -26,17 +26,18 @@ For more information, see the [Spice HuggingFace documentation](https://docs.spi
 
 2. **Configure the spicepod with the Llama model:**
 
-   Edit the `spicepod.yml` file to include the Llama model configuration:
+   Edit the `spicepod.yaml` file to include the Llama model configuration:
 
    ```yaml
    models:
      - name: llama3
        from: huggingface:huggingface.co/meta-llama/Llama-3.2-3B-Instruct
        params:
-         hf_token: ${ secrets:SPICE_HUGGINGFACE_API_KEY }
+         huggingface_token: ${ secrets:SPICE_HUGGINGFACE_API_KEY }
    ```
 
-   An example `spicepod.yml` is also provided in the recipe directory.
+   An example `spicepod.yml` is also provided in the recipe directory (both
+   `spicepod.yaml` and `spicepod.yml` are loaded).
 
 3. **Update `.env` with the HuggingFace variable:**
 
@@ -91,36 +92,28 @@ For more information, see the [Spice HuggingFace documentation](https://docs.spi
    Time: 16.09s (first token 0.53s). Tokens: 197. Prompt: 64. Completion: 133 (8.55/s).
    ```
 
-## Optional: Enable Hardware Acceleration
+## Hardware Acceleration
 
-If you have the required hardware (NVIDIA GPU or Apple M-series processor), you can build and run Spice with hardware acceleration.
-
-See [Building Spice](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building) for general instructions to build Spice from source.
-
-### For NVIDIA GPU (CUDA)
-
-1. **Install CUDA Toolkit:**
-
-Follow the [CUDA Toolkit installation guide](https://developer.nvidia.com/cuda-downloads) to install the appropriate version for your system.
-
-2. **Build Spice with CUDA support:**
+`spice install` (and `curl https://install.spiceai.org | /bin/bash`) auto-detects the
+local hardware accelerator and installs the matching runtime build — Metal on Apple
+silicon, CUDA on Linux when a supported GPU is present — so no extra step is needed.
+Confirm which build is installed with:
 
 ```sh
-git clone git@github.com:spiceai/spiceai.git
-cd spiceai
-make install-cuda
+spice version
 ```
-
-### For Apple M-series (Metal)
-
-1. **Ensure you have the latest macOS updates:**
-
-   Make sure your macOS is up to date to leverage the latest Metal support.
-
-2. **Build Spice with Metal support:**
 
 ```sh
-git clone git@github.com:spiceai/spiceai.git
-cd spiceai
-make install-metal
+CLI version:     v2.2.1
+Runtime version: v2.2.1+models.metal
 ```
+
+A `+models.metal` or `+models.cuda_<cc>` suffix on the runtime version means the
+accelerated build is in use. To install a CUDA build explicitly on Linux:
+
+```sh
+spice install cuda
+```
+
+Building from source is only necessary to run an unreleased revision; see
+[Building Spice](https://github.com/spiceai/spiceai/blob/trunk/CONTRIBUTING.md#building).

--- a/llama/spicepod.yml
+++ b/llama/spicepod.yml
@@ -6,4 +6,4 @@ models:
   - name: llama3
     from: huggingface:huggingface.co/meta-llama/Llama-3.2-3B-Instruct
     params:
-      hf_token: ${ secrets:SPICE_HUGGINGFACE_API_KEY }
+      huggingface_token: ${ secrets:SPICE_HUGGINGFACE_API_KEY }

--- a/text-to-sql/spicepod.yaml
+++ b/text-to-sql/spicepod.yaml
@@ -19,4 +19,4 @@ models:
   # - name: local
   #   from: huggingface:huggingface.co/meta-llama/Llama-3.2-3B-Instruct
   #   params:
-  #     hf_token: ${ secrets:SPICE_HF_TOKEN }
+  #     huggingface_token: ${ secrets:SPICE_HF_TOKEN }


### PR DESCRIPTION
## Summary

The recipe's only configuration parameter is silently discarded by the runtime, so the recipe cannot work as written.

`llama/spicepod.yml` and Step 2 of the README set:

```yaml
params:
  hf_token: ${ secrets:SPICE_HUGGINGFACE_API_KEY }
```

`hf_token` is the **embeddings** key. For a **chat** model the runtime reads the token from `params.get("token")`, and model params are provider-prefixed, so the spicepod key is `huggingface_token`. Since the v2.2.0 typed-params work the runtime says so out loud and drops the value:

```
WARN runtime_parameters_typed: Ignoring parameter `hf_token`: not supported for model huggingface.
```

With the token dropped, the gated `meta-llama/Llama-3.2-3B-Instruct` download fails and no model loads:

```
WARN runtime::init::model: Failed to load LLM: llama3. Failed to initialize LLM model: Failed to load
the model. An error occurred: Could not access `tokenizer.json` for `meta-llama/Llama-3.2-3B-Instruct`
(revision `main`) on Hugging Face (HTTP 401). ... status code 401
```

Note the runtime's "Did you mean" hint does **not** fire for `hf_token` (it does for `hf_huggingface_token`), so a reader gets no correction — the token just goes nowhere.

Two more fixes in the same recipe:

- **Step 2 named the wrong file.** Step 1 runs `spice init llama-spicepod`, which writes `spicepod.yaml`; Step 2 said to edit `spicepod.yml`, which does not exist in the new directory. (The recipe directory itself ships `spicepod.yml`, which the runtime does load — that's noted rather than renamed.)
- **The hardware-acceleration section was obsolete.** It told readers to clone `spiceai/spiceai` and run `make install-metal` / `make install-cuda`. Releases now publish prebuilt accelerated runtimes (`spiced_metal_darwin_aarch64`, `spiced_cuda_{80,86,87,89,90}_linux_x86_64`) and `spice install` auto-detects the accelerator, so an ordinary install already gets it. Replaced with how to confirm the installed build and the `spice install cuda` escape hatch.

`text-to-sql/spicepod.yaml` carries the same wrong key in its commented-out local-model block; that one line is fixed here too since it is the identical defect.

## Verified against

spiceai/spiceai at `v2.2.1`:

- [`crates/runtime/src/model/params/huggingface.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime/src/model/params/huggingface.rs) — `#[params(prefix = "huggingface", ...)]` with `pub token: Option<SecretString>` (a component param, hence the `huggingface_` prefix), while [`crates/runtime/src/embeddings/params/huggingface.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/crates/runtime/src/embeddings/params/huggingface.rs) has `#[param(runtime, autoload_secret)] pub hf_token` — unprefixed. That asymmetry is what the recipe tripped over.
- `crates/runtime/src/model/chat.rs` has read `params.get("token")` for HuggingFace chat models since v1.x (checked at `v1.11.6`, `v2.0.0`, `v2.1.5`), so `hf_token` never reached the chat model — v2.2.0 only made the loss visible.
- [`bin/spice/src/commands/install.rs`](https://github.com/spiceai/spiceai/blob/v2.2.1/bin/spice/src/commands/install.rs) / `bin/spice/src/github/release.rs` — default flavor "auto-detects hardware accelerator (Metal on macOS, CUDA on Linux if available)".

## Evidence

Runtime `v2.2.1+models.metal`. Three identical spicepods differing only in the key name:

```console
$ # params: hf_token: dummy-token-value
WARN runtime_parameters_typed: Ignoring parameter `hf_token`: not supported for model huggingface.

$ # params: huggingface_token: dummy-token-value
(no warning — accepted)

$ # params: hf_huggingface_token: dummy-token-value
WARN runtime_parameters_typed: Ignoring parameter `hf_huggingface_token`: not supported for model huggingface. Did you mean `huggingface_token`?
```

`spice init` output:

```console
$ spice init initest && ls -a initest
.  ..  spicepod.yaml
```

Release assets for `v2.2.1` include `spiced_metal_darwin_aarch64.tar.gz` and `spiced_cuda_{80,86,87,89,90}_linux_x86_64.tar.gz`; a plain install on Apple silicon yields:

```console
$ spice version
CLI version:     v2.2.1
Runtime version: v2.2.1+models.metal
```

The end-to-end chat step still needs HuggingFace access to a gated model, so the chat transcripts are unchanged and were not re-run.