### PR TITLE
Fix graphql recipe: refresh the v1.5.0-era spice run transcript

### DIFF
--- a/graphql/README.md
+++ b/graphql/README.md
@@ -71,19 +71,31 @@ spice run
 Example output:
 
 ```console
-2025/07/07 11:32:50 INFO Checking for latest Spice runtime release...
-2025/07/07 11:32:50 INFO Spice.ai runtime starting...
-2025-07-07T18:32:50.373735Z  INFO spiced: Starting runtime v1.5.0-unstable-build.2187f22e7+models
-2025-07-07T18:32:50.374154Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2025-07-07T18:32:50.374183Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
-2025-07-07T18:32:50.761270Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2025-07-07T18:32:50.761704Z  INFO runtime::init::dataset: Dataset stargazers initializing...
-2025-07-07T18:32:50.761790Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2025-07-07T18:32:52.129189Z  INFO runtime::init::dataset: Dataset stargazers registered (graphql:https://api.github.com/graphql), acceleration (arrow), results cache enabled.
-2025-07-07T18:32:52.130877Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset stargazers
-2025-07-07T18:33:14.858107Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,478 rows (2.59 MiB) for dataset stargazers in 22s 727ms.
-2025-07-07T18:33:14.930166Z  INFO runtime: All components are loaded. Spice runtime is ready!
+ INFO Spice.ai runtime starting...
+2026-09-09T12:17:19.539074Z  INFO spiced: Starting runtime v2.2.1+models.metal
+2026-09-09T12:17:19.541962Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
+2026-09-09T12:17:19.541988Z  INFO runtime::init::caching: Initialized search results cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-09-09T12:17:19.541998Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
+2026-09-09T12:17:19.543875Z  INFO runtime::secrets_preflight: Secrets: all 1 secret reference(s) resolved.
+2026-09-09T12:17:19.544699Z  INFO runtime::init::dataset: Dataset stargazers initializing...
+2026-09-09T12:17:19.743259Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
+2026-09-09T12:17:19.743556Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+2026-09-09T12:17:23.168435Z  INFO runtime::init::dataset: Dataset stargazers registered (graphql:https://api.github.com/graphql), acceleration (arrow), results cache enabled. duration_ms=4
+2026-09-09T12:17:23.170112Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset stargazers
+2026-09-09T12:17:34.037609Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 301 records (200.33 kiB uncompressed) in 10s, 18.44 kiB/s
+2026-09-09T12:17:44.977917Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 801 records (535.35 kiB uncompressed) in 21s, 24.55 kiB/s
+2026-09-09T12:17:49.547223Z  INFO runtime::init::dataset: Dataset load summary (after 30s): 2/2 ready, 0 unhealthy, 0 still initializing.
+2026-09-09T12:17:55.464375Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 1,201 records (801.57 kiB uncompressed) in 32s, 24.82 kiB/s
+2026-09-09T12:18:05.663061Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 1,601 records (1.04 MiB uncompressed) in 42s, 25.14 kiB/s
+2026-09-09T12:18:16.571801Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 2,101 records (1.37 MiB uncompressed) in 53s, 26.26 kiB/s
+2026-09-09T12:18:28.345213Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 2,601 records (1.70 MiB uncompressed) in 65s, 26.66 kiB/s
+2026-09-09T12:18:36.363019Z  INFO runtime_table::accelerated::refresh_task: Loaded 3,079 rows (2.01 MiB) for dataset stargazers in 1m 13s 192ms.
+2026-09-09T12:18:36.389381Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
+
+The `pageInfo` block in the query lets the connector follow GitHub's cursor
+pagination, so the first load walks the full stargazer list 100 at a time and
+takes about a minute. The row count grows as the repository gains stars.
 
 **Step 3.** Run `spice sql` in a new terminal to start an interactive SQL query session against the Spice runtime.
 
@@ -98,20 +110,21 @@ select * from stargazers limit 10;
 Example output:
 
 ```console
-+----------------------+---------------------------------------------------------------------------------+
-| starredAt            | node                                                                            |
-+----------------------+---------------------------------------------------------------------------------+
-| 2021-08-13T10:40:54Z | {id: MDQ6VXNlcjIyOTIwOQ==, name: Andrew Armstrong, login: Plasma}               |
-| 2021-09-07T06:18:49Z | {id: MDQ6VXNlcjg3OTQ0NQ==, name: Phillip LeBlanc, login: phillipleblanc}        |
-| 2021-09-07T19:57:24Z | {id: MDQ6VXNlcjcwNzIw, name: Thomas Dohmke, login: ashtom}                      |
-| 2021-09-07T20:06:11Z | {id: MDQ6VXNlcjEzODk4ODM=, name: Lane Harris, login: haardvark}                 |
-| 2021-09-07T20:16:06Z | {id: MDQ6VXNlcjgzMjM0, name: Txus, login: txus}                                 |
-| 2021-09-07T20:16:13Z | {id: MDQ6VXNlcjY4OTI4NDM4, name: Iblameandrew, login: andres-ulloa-de-la-torre} |
-| 2021-09-07T20:26:53Z | {id: MDQ6VXNlcjE2Mjk1Mjgz, name: Yaron Schneider, login: yaron2}                |
-| 2021-09-07T20:28:28Z | {id: MDQ6VXNlcjY4Njg5NjY=, name: , login: nightlyworker}                        |
-| 2021-09-07T21:10:56Z | {id: MDQ6VXNlcjMxNDU3, name: Nate Todd, login: ntodd}                           |
-| 2021-09-07T21:15:22Z | {id: MDQ6VXNlcjMwNjUyNA==, name: Felix Chan, login: felixchan}                  |
-+----------------------+---------------------------------------------------------------------------------+
++----------------------+--------------------------------------------------------------------------+
+|       starredAt      |                                   node                                   |
+|        varchar       |                                  struct                                  |
++----------------------+--------------------------------------------------------------------------+
+| 2021-08-13T10:40:54Z | {id: MDQ6VXNlcjIyOTIwOQ==, name: Andrew Armstrong, login: Plasma}        |
+| 2021-09-07T06:18:49Z | {id: MDQ6VXNlcjg3OTQ0NQ==, name: Phillip LeBlanc, login: phillipleblanc} |
+| 2021-09-07T19:57:24Z | {id: MDQ6VXNlcjcwNzIw, name: Thomas Dohmke, login: ashtom}               |
+| 2021-09-07T20:06:11Z | {id: MDQ6VXNlcjEzODk4ODM=, name: Lane Harris, login: haardvark}          |
+| 2021-09-07T20:16:06Z | {id: MDQ6VXNlcjgzMjM0, name: Txus, login: txus}                          |
+| 2021-09-07T20:16:13Z | {id: MDQ6VXNlcjY4OTI4NDM4, name: godelcomplete, login: iblameandrew}     |
+| 2021-09-07T20:26:53Z | {id: MDQ6VXNlcjE2Mjk1Mjgz, name: Yaron Schneider, login: yaron2}         |
+| 2021-09-07T20:28:28Z | {id: MDQ6VXNlcjY4Njg5NjY=, name: , login: nightlyworker}                 |
+| 2021-09-07T21:10:56Z | {id: MDQ6VXNlcjMxNDU3, name: Nate Todd, login: ntodd}                    |
+| 2021-09-07T21:15:22Z | {id: MDQ6VXNlcjMwNjUyNA==, name: Felix Chan, login: felixchan}           |
++----------------------+--------------------------------------------------------------------------+
 
-Time: 0.00609725 seconds. 10 rows.
+Time: 0.004832417 seconds. 10 rows.
 ```


### PR DESCRIPTION
## Summary

The recipe's `spice run` transcript was captured against `v1.5.0-unstable-build.2187f22e7+models` and has drifted in five ways. A reader on current stable sees a materially different startup, and the load looks like it hung.

| README (v1.5.0) | v2.2.1 |
| --- | --- |
| `2025/07/07 11:32:50 INFO Checking for latest Spice runtime release...` | not printed — that line is `spice install`'s |
| `2025/07/07 11:32:50 INFO Spice.ai runtime starting...` | ` INFO Spice.ai runtime starting...` (no Go-style date prefix) |
| two `Initialized … cache` lines | three — `embeddings cache` was added |
| — | `runtime::secrets_preflight: Secrets: all 1 secret reference(s) resolved.` |
| — | per-batch `Dataset stargazers received N records (… uncompressed) in Ns, X kiB/s` lines, and `Dataset load summary (after 30s)` |
| `Dataset stargazers registered (…), acceleration (arrow), results cache enabled.` | same, now with ` duration_ms=4` |
| `Loaded 2,478 rows (2.59 MiB) … in 22s 727ms.` | `Loaded 3,079 rows (2.01 MiB) … in 1m 13s 192ms.` |

The `select * from stargazers limit 10;` output also predates the v2 typed SQL header (the `varchar` / `struct` type row under the column names).

Also added a sentence explaining that the `pageInfo` block makes the connector follow GitHub's cursor pagination, so the first load walks the whole stargazer list 100 at a time and takes about a minute — without that, the run looks stalled. The row count grows with the repository's stars, so it is called out as approximate rather than pinned.

One data row changed because the account was renamed (`name: Iblameandrew, login: andres-ulloa-de-la-torre` → `name: godelcomplete, login: iblameandrew`) — public profile data from the repository's own stargazer list, as before.

## Verified against

spiceai/spiceai at `v2.2.1` — `bin/spice/src/commands/install.rs:94` (the `Checking for latest…` line is `spice install`'s), `bin/spice/src/runtime_launcher.rs:137-150` (`spice run` reaches it only when the runtime is missing).

## Evidence

Ran the recipe's shipped `spicepod.yaml` unmodified against a local `spiced v2.2.1+models.metal`, with `GH_TOKEN` set to a default-scope GitHub token (no extra scopes needed):

```
 INFO Spice.ai runtime starting...
2026-09-09T12:17:19.539074Z  INFO spiced: Starting runtime v2.2.1+models.metal
2026-09-09T12:17:19.541998Z  INFO runtime::init::caching: Initialized embeddings cache; max size: 128.00 MiB, item ttl: 1s, engine: Moka
2026-09-09T12:17:19.543875Z  INFO runtime::secrets_preflight: Secrets: all 1 secret reference(s) resolved.
2026-09-09T12:17:34.037609Z  INFO runtime_table::accelerated::refresh_task: Dataset stargazers received 301 records (200.33 kiB uncompressed) in 10s, 18.44 kiB/s
...
2026-09-09T12:18:36.363019Z  INFO runtime_table::accelerated::refresh_task: Loaded 3,079 rows (2.01 MiB) for dataset stargazers in 1m 13s 192ms.
2026-09-09T12:18:36.389381Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

Then `select * from stargazers limit 10;` through `spice sql` — that output is pasted verbatim into the diff. Every transcript line in this PR comes from that run. All six links in the README return 200.