### PR TITLE
Fix S3 vector chunking, Azure sample limits, and MCP examples

### DIFF
--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -4,6 +4,8 @@ Works with `v1.0+`
 
 This recipe demonstrates how to use Azure OpenAI models for vector-based search and chat functionalities with structured (taxi trips) and unstructured GitHub data.
 
+To reduce GitHub API requests and Azure embedding usage, the sample accelerates at most **10 closed issues** and **16 Markdown files** from `docs/dev/`. The `refresh_sql` limits in `spicepod.yaml` bound the embedded rows, and the file connector's `include` pattern restricts downloads to developer documentation. Increase these limits or broaden the pattern only when your API quotas allow it.
+
 ## Prerequisites
 
 - Ensure you have the Spice CLI installed. Follow the [Getting Started](https://docs.spiceai.org/getting-started) guide if you haven't done so yet.
@@ -61,27 +63,17 @@ models:
 spice run
 ```
 
-Result:
+Wait for the datasets to finish loading, then check their sizes in `spice sql`:
 
-```shell
-2024/12/12 14:10:00 INFO Checking for latest Spice runtime release...
-2024/12/12 14:10:00 INFO Spice.ai runtime starting...
-2024-12-12T22:10:00.770177Z  INFO runtime::flight: Spice Runtime Flight listening on 127.0.0.1:50051
-2024-12-12T22:10:00.770385Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
-2024-12-12T22:10:01.248755Z  INFO runtime::init::embedding: Embedding Model embeddings-model ready
-2024-12-12T22:10:01.248915Z  INFO runtime::init::dataset: Dataset spiceai.files initializing...
-2024-12-12T22:10:01.248921Z  INFO runtime::init::dataset: Dataset taxi_trips initializing...
-2024-12-12T22:10:01.248962Z  INFO runtime::init::model: Loading model [chat-model] from azure:gpt-4o-mini...
-2024-12-12T22:10:01.448894Z  INFO runtime::init::caching: Initialized sql results cache; max size: 128.00 MiB, item ttl: 1s, hashing algorithm: XXH3, encoding: none
-2024-12-12T22:10:01.640572Z  INFO runtime::init::dataset: Dataset spiceai.files registered (github:github.com/spiceai/spiceai/files/trunk), acceleration (arrow), results cache enabled.
-2024-12-12T22:10:01.641876Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.files
-2024-12-12T22:10:01.920208Z  INFO runtime::init::model: Model [chat-model] deployed, ready for inferencing
-2024-12-12T22:10:02.221149Z  INFO runtime::init::dataset: Dataset taxi_trips registered (s3://spiceai-demo-datasets/taxi_trips/2024/), acceleration (arrow), results cache enabled.
-2024-12-12T22:10:02.222425Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset taxi_trips
-2024-12-12T22:10:06.212606Z  INFO runtime_table::accelerated::refresh_task: Loaded 74 rows (1.06 MiB) for dataset spiceai.files in 4s 570ms.
-2024-12-12T22:10:10.896203Z  INFO runtime_table::accelerated::refresh_task: Loaded 2,964,624 rows (399.38 MiB) for dataset taxi_trips in 8s 673ms.
-
+```sql
+SELECT 'issues' AS dataset, COUNT(*) AS row_count FROM spiceai.issues
+UNION ALL
+SELECT 'files' AS dataset, COUNT(*) AS row_count FROM spiceai.files;
 ```
+
+The issue and file counts are capped at 10 and 16 respectively. Fewer rows are
+possible if the repository has fewer matching issues or files. Search results
+and scores depend on the contents of this sample.
 
 ## SQL Search
 
@@ -98,22 +90,26 @@ SELECT path
 FROM spiceai.files
 WHERE
     LOWER(content) LIKE '%errors%'
-    AND NOT contains(path, 'docs/release_notes');
+    AND NOT contains(path, 'docs/release_notes')
+ORDER BY path;
 ```
 
-Result:
+Example result:
 
-```shell
-+------------------------------+
-| path                         |
-+------------------------------+
-| docs/criteria/definitions.md |
-| docs/dev/error_handling.md   |
-| docs/dev/metrics.md          |
-| docs/dev/style_guide.md      |
-+------------------------------+
-
-Time: 0.018795833 seconds. 4 rows.
+```text
++--------------------------------+
+| path                           |
+|            varchar             |
++--------------------------------+
+| docs/dev/cloud-login.md        |
+| docs/dev/cloud-multi-org.md    |
+| docs/dev/cosmosdb.md           |
+| docs/dev/error_handling.md     |
+| docs/dev/fork_patches.md       |
+| docs/dev/metrics.md            |
+| docs/dev/refresh_pipelining.md |
+| docs/dev/style_guide.md        |
++--------------------------------+
 ```
 
 ## Utilizing Vector-Based Search
@@ -130,7 +126,7 @@ Time: 0.018795833 seconds. 4 rows.
     }"
 ```
 
-Result:
+Example response:
 
 ```json
 {
@@ -138,7 +134,7 @@ Result:
     {
       "matches": {
         "content": [
-          ".\n\n## Definitions\n\n- Metric: is a measurement used to track the state and behavior of a system component. Metrics represent the current status ..."
+          "# Metrics Naming\n\n## TL;DR\n\n**Metric Naming Guide**: Prioritize Developer Experience (DX) with intuitive, readable names that follow consistent conventions. Start with a domain prefix, use snake_case, avoid plurals in names (except counters), include units where relevant, and use labels for variations. Align with Prometheus and OpenTelemetry standards, and adhere to UCUM for units.\n\n"
         ]
       },
       "data": {
@@ -147,26 +143,26 @@ Result:
       "primary_key": {
         "path": "docs/dev/metrics.md"
       },
-      "_score": 0.7269563689871208,
+      "_score": 0.8277048428639362,
       "dataset": "spiceai.files"
     },
     {
       "matches": {
         "content": [
-          "6\n\n## Core Connector Data Types\n\nCore Connector Data Types depend on the specific connector, but in general can be abstracted as (non-exhaustive) types like: ..."
+          "## Guidelines\n\nThese guidelines were created based on the First Principle of Developer Experience First and Align to Industry Standard. No direct industry standards exist, but \"best practices\" are available. Loosely inspired by error handling material from:\n\n* [Error Messages in Windows 7](https://learn.microsoft.com/en-us/windows/win32/uxguide/mess-error)\n* [Cypress](https://docs.cypress.io/app/references/error-messages)\n\nRelated reading:\n\n* [Microcopy: A complete guide](https://www.microcopybook.com/)\n\n"
         ]
       },
       "data": {
-        "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/criteria/definitions.md"
+        "download_url": "https://raw.githubusercontent.com/spiceai/spiceai/trunk/docs/dev/error_handling.md"
       },
       "primary_key": {
-        "path": "docs/criteria/definitions.md"
+        "path": "docs/dev/error_handling.md"
       },
-      "_score": 0.6737559856782607,
+      "_score": 0.6896097040436964,
       "dataset": "spiceai.files"
     }
   ],
-  "duration_ms": 1043
+  "duration_ms": 381
 }
 ```
 
@@ -178,44 +174,9 @@ Vector-based search could also be performed using `spice search` CLI command:
 spice search
 ```
 
-Result:
-
-```shell
-search> OTEL metrics naming
- Rank  Key                                        Match                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      Score   Dataset
- 1     docs/dev/metrics.md                        .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.7456  spice.spiceai.files
-
-                                                  ## Definitions
- 2     docs/release_notes/beta/v0.19.3-beta.md    5                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.6989  spice.spiceai.files
-                                                  - Upgrade OTEL to v0.26 and make seconds based metrics reported precisely by @sgrebnov in https://github.com/spiceai/spiceai/pull/3203
-                                                  - use `text_embedding_inference::Infer` for more complete embedding solution by @Jeadie in https://github.com/spiceai/spiceai/pull/3199
- 3     docs/release_notes/rc/v1.0.0-rc.1.md                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  0.6730  spice.spiceai.files
-                                                  | **Before**                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  | **v1.0-rc.1**                                                           |
-                                                  | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
- 4     docs/release_notes/v1.8.1.md               .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.6684  spice.spiceai.files
-
-                                                  - **Acceleration Snapshot Metrics**: The following metrics are now available for Acceleration Snapshots:
- 5     docs/release_notes/v1.1/v1.1.1.md          # Spice v1.1.1 (Apr 7, 2025)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               0.6561  spice.spiceai.files
-
-                                                  Spice v1.1.1 introduces several key updates, including a new Component Metrics System, improved Delta Data Connector performance, improved MCP tool descriptions, and expanded runtime results caching options. This release also adds detailed MySQL connection pool metrics for better observability. Component Metrics are Prometheus-compatible and accessible via the metrics endpoint.
- 6     docs/criteria/accelerators/stable.md        end-to-end [Throughput Test](../definitions.md) is performed on the accelerator using the TPC-DS dataset at scale factor 1 in all [Access Modes](../definitions.md).                                                                                                                                                                                                                                                                                                                                                                                                                                                                      0.6550  spice.spiceai.files
-                                                    - [ ] End-to-end tests should perform [Throughput Tests](../definitions.md) at the required [parallel query count](../definitions.md)
-                                                    - [ ] [Throughput Metric](../definitions.md) is calculated and reported as a metric with a parallel query count of 1 to serve as a baseline metric.
- 7     docs/release_notes/v1.9.0.md               ocation' as primary key for document tables by [@Jeadie](https://github.com/Jeadie) in [#7567](https://github.com/spiceai/spiceai/pull/7567)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               0.6530  spice.spiceai.files
-                                                  - Extend query-related metrics by [@krinart](https://github.com/krinart) in [#7571](https://github.com/spiceai/spiceai/pull/7571)
-                                                  - Enabling acceleration refresh metrics by using `runtime.metrics` config by [@krinart](https://github.com/krinart) in [#7583](https://github.com/spiceai/spiceai/pull/7583)
- 8     docs/criteria/models/beta.md               # Spice.ai OSS Models - Beta Release Criteria                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              0.6495  spice.spiceai.files
-
-                                                  This document defines the set of criteria that is required before a model is considered to be of Beta quality.
- 9     docs/release_notes/v1.7/v1.7.1.md          .                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.6488  spice.spiceai.files
-
-                                                  Example usage:
- 10    docs/release_notes/alpha/v0.14.0-alpha.md  2                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          0.6488  spice.spiceai.files
-                                                  - Rename metrics column `labels` to `properties` and make it nullable by @ewgenius in https://github.com/spiceai/spiceai/pull/1686
-                                                  - Fix federation_optimizer_rule schema error for `tpch_q7`, `tpch_q8`, `tpch_q9`, `tpch_q14` by @sgrebnov in https://github.com/spiceai/spiceai/pull/1683
-
-Time: 0.650 seconds. 10 results.
-```
+At the search prompt, enter `TEL metrics naming`. Results come from the sampled
+developer documentation; release notes and other documentation directories are
+outside this recipe's `include` pattern.
 
 ## Vector Search on multiple columns
 

--- a/azure_openai/spicepod.yaml
+++ b/azure_openai/spicepod.yaml
@@ -49,9 +49,11 @@ datasets:
   - from: github:github.com/spiceai/spiceai/issues
     name: spiceai.issues
     params:
+      github_query_mode: search
       github_token: ${secrets:GITHUB_TOKEN}
     acceleration:
       enabled: true
+      refresh_sql: SELECT * FROM spiceai.issues WHERE state = 'CLOSED' LIMIT 10
     columns:
       - name: body
         embeddings:
@@ -71,10 +73,11 @@ datasets:
     description: Spice.ai project documentation (github.com/spiceai/spiceai)
     params:
       github_token: ${secrets:GITHUB_TOKEN}
-      include: "docs/**/*.md"
+      include: "docs/dev/*.md"
       file_format: md
     acceleration:
       enabled: true
+      refresh_sql: SELECT * FROM spiceai.files LIMIT 16
     columns:
       - name: content
         embeddings:

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -143,6 +143,10 @@ Once connected, ask your AI assistant questions like:
 
 ### SQL against the accelerated data (direct API)
 
+The `/v1/tools/sql` endpoint returns a JSON string containing the serialized row
+array. Pipe the response through `jq 'fromjson'` to decode it into a JSON array.
+The examples below show the raw response; row counts depend on the GitHub data.
+
 Count issues by state:
 
 ```bash
@@ -153,10 +157,10 @@ curl -s -XPOST http://127.0.0.1:8090/v1/tools/sql \
 ```
 
 ```json
-[{"type":"text","text":"[{\"state\":\"OPEN\",\"n\":1},{\"state\":\"CLOSED\",\"n\":1}]"}]
+"[{\"state\":\"OPEN\",\"n\":1},{\"state\":\"CLOSED\",\"n\":1}]"
 ```
 
-Top contributors by commits:
+Top contributors by commits (example response shown for two contributors):
 
 ```bash
 curl -s -XPOST http://127.0.0.1:8090/v1/tools/sql \
@@ -166,7 +170,7 @@ curl -s -XPOST http://127.0.0.1:8090/v1/tools/sql \
 ```
 
 ```json
-[{"type":"text","text":"[{\"author_name\":\"Sergei Grebnov\",\"commits\":74},{\"author_name\":\"Luke Kim\",\"commits\":45},..."}]
+"[{\"author_name\":\"Sergei Grebnov\",\"commits\":74},{\"author_name\":\"Luke Kim\",\"commits\":45}]"
 ```
 
 PRs merged in the last 7 days:

--- a/vectors/s3/README.md
+++ b/vectors/s3/README.md
@@ -28,7 +28,7 @@ s3_vectors_param: &s3_vectors_param
 
 ## Configuration
 
-Use the `spicepod.yaml` in this recipe directory. It pulls recent GitHub PRs, accelerates data for the last 7 days, embeds the `body` column, and stores vectors in S3 Vectors. The `row_id` uses `id` as the primary key for vector upsert. On ingestion, Spice embeds each PR's `body` using OpenAI and upserts to S3 Vectors with `id` as key, handling updates/deletions automatically.
+Use the `spicepod.yaml` in this recipe directory. It pulls recent GitHub PRs, accelerates data for the last 7 days, chunks and embeds the `body` column, and stores vectors in S3 Vectors. Chunking keeps large PR bodies, such as dependency update descriptions, within the embedding model's input limit. The `row_id` uses `id` to associate each chunk with its source PR; search results retain the PR's metadata.
 
 ## Run Spice
 
@@ -90,31 +90,11 @@ Examine execution:
 EXPLAIN SELECT url, title, _score FROM vector_search(pulls, 'bugs in DuckDB', 4) ORDER BY _score DESC LIMIT 4;
 ```
 
-Plan (the 1536-element query vector is elided as `[...]` for readability):
-
-```sql
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-|   plan_type   |                                                                  plan                                                                  |
-|    varchar    |                                                                varchar                                                                 |
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-| logical_plan  | Sort: vector_search(pulls, Utf8("bugs in DuckDB"), Int64(4))._score DESC NULLS FIRST, fetch=4                                           |
-|               |   Projection: vector_search(...).url, vector_search(...).title, vector_search(...)._score                                               |
-|               |     TableScan: vector_search(pulls, Utf8("bugs in DuckDB"), Int64(4)) projection=[_score, title, url]                                   |
-| physical_plan | SortExec: TopK(fetch=4), expr=[_score@2 DESC], preserve_partitioning=[false]                                                            |
-|               |   ProjectionExec: expr=[url@2 as url, title@1 as title, _score@3 as _score]                                                             |
-|               |     SortExec: TopK(fetch=4), expr=[_score@3 DESC NULLS LAST, id@0 ASC], preserve_partitioning=[false]                                   |
-|               |       ProjectionExec: expr=[id@1 as id, title@2 as title, url@3 as url,                                                                 |
-|               |                            1 - cosine_distance([...], body_embedding@0) as _score]                                                      |
-|               |         BytesProcessedExec                                                                                                              |
-|               |           DataSourceExec: partitions=1, partition_sizes=[18]                                                                            |
-+---------------+--------------------------------------------------------------------------------------------------------------------------------------------------------+
-```
-
-Because this dataset sets `acceleration: enabled: true`, the embeddings are materialized
-locally alongside the rows, and the similarity search is evaluated there — the plan scores
-rows with `cosine_distance` over the local `body_embedding` column. S3 Vectors is still the
-durable index: Spice creates it, writes every embedding through to it on ingestion, and
-serves reads from it when the vectors are not available locally.
+With acceleration enabled, the embeddings are materialized locally alongside the
+rows. The plan scores each body chunk with `cosine_distance`, groups by the PR's
+`id` to retain its best-matching chunk, and orders the resulting PRs by `_score`.
+S3 Vectors stores the embeddings durably; Spice writes the chunks to it during
+ingestion and can use the remote index when vectors are not available locally.
 
 Confirm the vectors reached S3:
 
@@ -136,6 +116,10 @@ columns:
       - from: my_embedding_model
         row_id:
           - id
+        chunking:
+          enabled: true
+          target_chunk_size: 512
+          trim_whitespace: true
   - name: title
     metadata:
       vectors: filterable
@@ -310,7 +294,9 @@ Response:
 
 ## Chunking
 
-The Spice runtime can manage chunking, embedding and reaggregating chunks of datasets with large content. Spice loaded `spiceai.cookbook_readme`: all cookbook READMEs. Search, both HTTP and SQL can be queried as before.
+Both PR bodies and cookbook README content use chunking. Spice embeds the chunks
+and returns matching source rows through the same HTTP and SQL search APIs. Use
+`_match` to inspect the matching chunk within a README:
 
 ```SQL
 SELECT

--- a/vectors/s3/spicepod.yaml
+++ b/vectors/s3/spicepod.yaml
@@ -51,6 +51,10 @@ datasets:
           - from: my_embedding_model
             row_id:
               - id
+            chunking:
+              enabled: true
+              target_chunk_size: 512
+              trim_whitespace: true
       - name: title
         metadata:
           vectors: filterable


### PR DESCRIPTION
## WHAT

Make the S3 vectors and Azure OpenAI recipes practical to run with large GitHub content and limited API quotas, and correct the MCP SQL response examples.

## WHY

Large PR bodies can exceed the embedding input limit, broad GitHub ingestion causes throttling, and the documented SQL response shape does not match the API.

## HOW

- Enable PR-body chunking for S3 vectors and align the configuration and query-plan explanation.
- Limit Azure ingestion to 10 closed issues and 16 developer-documentation files, and update the examples for that sample.
- Show `/v1/tools/sql` responses as JSON strings containing row arrays, with `jq 'fromjson'` decoding.

Validated with the local Enterprise 2.3 release build: S3 index writes and SQL/HTTP searches passed with chunking; the final Azure configuration loaded 10 issues, 16 files, and the full taxi dataset and passed search/chat checks; both MCP response examples and their decoding match live API output. The Azure limits reduce API usage but do not guarantee that small-tier quotas never throttle requests.
