### PR TITLE
Fix caching/accelerator: the recipe config grows without bound on v2.3.0

### DIFF
--- a/caching/accelerator/README.md
+++ b/caching/accelerator/README.md
@@ -99,6 +99,8 @@ datasets:
         caching_ttl: 10s
         caching_stale_while_revalidate_ttl: 10s
         caching_stale_if_error: enabled
+        caching_max_size: 256MiB
+        caching_max_items: 10000
 ```
 
 ### Key Configuration Options
@@ -110,6 +112,37 @@ datasets:
 | `caching_ttl`                        | `10s`     | Cache entries are considered fresh for 10 seconds              |
 | `caching_stale_while_revalidate_ttl` | `10s`     | Serve stale data for 10 seconds while refreshing in background |
 | `caching_stale_if_error`             | `enabled` | Return cached data if the upstream server returns an error     |
+| `caching_max_size`                   | `256MiB`  | Byte budget for the stored cache (`v2.3.0+`)                   |
+| `caching_max_items`                  | `10000`   | Row budget for the stored cache (`v2.3.0+`)                    |
+
+### What Bounds the Cache
+
+`caching_ttl` and `caching_stale_while_revalidate_ttl` bound how long an entry is
+*served*, not how long it is *stored*. With `caching_stale_if_error: enabled` an
+expired entry is deliberately kept, because it is the copy served when the origin
+fails — so those two TTLs evict nothing, and the accelerator grows with every
+distinct request it serves.
+
+`caching_max_size` and `caching_max_items` (`v2.3.0+`) are what bound it. Eviction is
+entry-granular: a cached response can span several rows, so the runtime ranks entries
+by their oldest page and removes all of an entry's rows together. Without a budget,
+`v2.3.0+` warns at startup:
+
+```console
+WARN runtime_table::accelerated::caching_eviction: Dataset 'time' sets `caching_stale_if_error: enabled` with no `caching_max_size` or `caching_max_items`, so no cached entry is ever evicted and the acceleration will grow without bound - expired entries are deliberately kept as fallback for a failing origin. Set a budget to bound it.
+```
+
+A time-based bound is a separate mechanism, and the runtime warns separately when
+none is running. To add one, either set `caching_stale_if_error: disabled` — which
+evicts at `caching_ttl` + `caching_stale_while_revalidate_ttl`, giving up the
+stale-if-error fallback this recipe demonstrates — or declare a retention policy with
+all four of `retention_check_enabled: true`, `retention_period`,
+`retention_check_interval`, and the dataset's `time_column`. A policy missing any one
+of those starts nothing.
+
+> **Note:** This recipe's DuckDB accelerator is in-memory (no `mode: file`), so the
+> cache starts empty on every `spice run`. Add `mode: file` under `acceleration` to
+> persist it across restarts.
 
 ## Experimenting with Caching Behavior
 

--- a/caching/accelerator/spicepod.yaml
+++ b/caching/accelerator/spicepod.yaml
@@ -23,4 +23,9 @@ datasets:
         caching_ttl: 10s
         caching_stale_while_revalidate_ttl: 10s
         caching_stale_if_error: enabled
+        # `caching_stale_if_error: enabled` deliberately keeps expired entries as the
+        # fallback for a failing origin, so nothing above bounds what the accelerator
+        # stores. These two budgets do (both require v2.3.0+).
+        caching_max_size: 256MiB
+        caching_max_items: 10000
 


### PR DESCRIPTION
## Summary

v2.3.0 added `caching_max_size` and `caching_max_items` to bound what a `refresh_mode: caching` accelerator stores, and made the runtime warn at startup when nothing bounds one.

This recipe sets `caching_stale_if_error: enabled` with no budget — which is precisely the unbounded case, since an expired entry is deliberately kept as the fallback for a failing origin. So the recipe's flagship config now warns twice on every `spice run`, and its config table still implies `caching_ttl: 10s` bounds the cache when it only bounds how long an entry is served *fresh*.

**What changed:**

- Added `caching_max_size: 256MiB` and `caching_max_items: 10000` to `spicepod.yaml` and to the README's config block, marked `v2.3.0+` in the options table.
- Added a "What Bounds the Cache" section: TTLs bound serving, not storage; the two budgets bound storage; a time-based bound is a separate mechanism whose remedies are `caching_stale_if_error: disabled` or a full four-key retention policy.
- Noted that this recipe's DuckDB accelerator is in-memory, so the cache starts empty on every `spice run`. The README already said "Clear the cache by restarting Spice" while the Overview advertised disk persistence the recipe never configures.

## Verified against

spiceai/spiceai at `v2.3.0`:

- [`crates/runtime-table/src/accelerated/caching_eviction.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime-table/src/accelerated/caching_eviction.rs) — `warn_about_unenforceable`, and the `stale_if_error_without_a_budget_is_the_unbounded_case` test.
- [`crates/runtime-acceleration/src/acceleration.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime-acceleration/src/acceleration.rs) — `caching_max_size` / `caching_max_items` parsing. The doc comment states `None` is no byte budget: "what remains is expiry by `caching_ttl` — and with `caching_stale_if_error: enabled` not even that".
- [`crates/runtime/src/datafusion/caching_retention.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/datafusion/caching_retention.rs) — the separate time-based bound and its `Unbounded` case.

## Evidence

Ran the recipe on v2.3.0 (`spiced v2.3.0+models.metal`) against a local server on `:7400`.

**Before** — two warnings on the unmodified recipe:

```console
WARN runtime::datafusion: Dataset 'time' sets `caching_stale_if_error: enabled` and has no retention policy running, so no cached entry is ever evicted and the accelerator grows with every distinct request it serves. ...
WARN runtime_table::accelerated::caching_eviction: Dataset 'time' sets `caching_stale_if_error: enabled` with no `caching_max_size` or `caching_max_items`, so no cached entry is ever evicted and the acceleration will grow without bound — expired entries are deliberately kept as fallback for a failing origin. Set a budget to bound it.
```

**After** — the `caching_eviction` warning is gone and the recipe's query still works:

```console
2026-09-10T12:10:12Z  INFO runtime::init::dataset: Dataset time registered (http://localhost:7400), acceleration (duckdb, caching).
2026-09-10T12:10:12Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

```console
+--------------+----------------------------------+---------------------+
| request_path |              content             |     _fetched_at     |
|    varchar   |              varchar             |    timestamp[ns]    |
+--------------+----------------------------------+---------------------+
| /time        | 2026-09-10T12:10:26.319372+00:00 | 2026-09-10T12:10:26 |
+--------------+----------------------------------+---------------------+
```

The `runtime::datafusion` retention warning is left in place and documented rather than silenced: its remedies (dropping stale-if-error, or a retention policy) would each change what the recipe demonstrates. The eight-column `describe time` table in the README was re-checked against the live schema and is accurate.