### PR TITLE
Fix serializable-transactions: DELETE is refused on a write-back dataset in v2.3.0

### DIFF
--- a/serializable-transactions/README.md
+++ b/serializable-transactions/README.md
@@ -61,8 +61,10 @@ docker exec spice-bank psql -U postgres -d spice_demo -c "SHOW wal_level;"
 
 ## Step 2. Create and seed the accounts
 
-Two tables, each with a primary key (required so `UPDATE`/`DELETE` replicate and so
-write-back can address rows by key). Alice starts with 1000 in checking, 0 in savings.
+Two tables, each with a single-column primary key — required so `UPDATE` replicates and
+so write-back can address rows by key. (A `DELETE` through Spice is refused on a
+write-back dataset; see [What write-back refuses](#what-write-back-refuses).) Alice
+starts with 1000 in checking, 0 in savings.
 
 ```bash
 docker exec -i spice-bank psql -U postgres -d spice_demo <<'EOF'
@@ -232,6 +234,38 @@ SELECT pg_drop_replication_slot('spice_savings');
 - For `write_mode: write_back`, the commit records the touched primary keys in a marker
   table **in the same commit transaction**; a per-table worker then reconciles them to
   PostgreSQL idempotently (delete-by-key, then insert the current rows).
+
+## What write-back refuses
+
+> **Version note:** Both refusals below were added in `v2.3.0`. On `v2.2.x` these
+> statements were accepted, and a `DELETE` could diverge the accelerator from
+> PostgreSQL without recording anything for delivery.
+
+`write_mode: write_back` only accepts writes it can record for delivery to PostgreSQL,
+so two shapes are refused outright rather than silently diverging from the source:
+
+- **Writes outside a transaction.** An `INSERT` or `UPDATE` that is not inside a
+  `BEGIN … COMMIT` body is refused. Every write in this recipe is submitted as one
+  `BEGIN; … COMMIT;` request, which is why they succeed.
+- **`DELETE` in any form, and `TRUNCATE`.** A delete cannot be recorded for delivery,
+  so it is refused:
+
+  ```console
+  Failed to delete from dataset 'checking': DELETE is not supported while
+  'acceleration.write_mode: write_back' is enabled, because a delete cannot be
+  recorded for delivery to the federated source.
+  ```
+
+  To remove rows at the source, stop writing to the dataset and wait for its
+  `dataset_acceleration_write_back_pending_keys` metric to reach zero *while write-back
+  is still enabled* — the delivery worker is what drains it, and taking the dataset out
+  of write-back stops that worker and clears the gauge without delivering anything. Once
+  it reads zero, take the dataset out of write-back, delete at the source, and let the
+  change stream refresh the accelerator.
+
+The runtime also refuses a write-back configuration it cannot uphold, which is why each
+dataset here sets `mode: file`, declares a single-column `primary_key`, and sets no
+retention.
 
 ## Additional Resources
 


### PR DESCRIPTION
## Summary

Step 2 of the recipe said the tables need a primary key "required so `UPDATE`/`DELETE` replicate and so write-back can address rows by key".

v2.3.0 refuses a `DELETE` on any `write_mode: write_back` dataset outright — a delete cannot be recorded for delivery to the federated source, so rather than let the accelerator diverge from PostgreSQL the runtime rejects the statement. `TRUNCATE`, and any write outside a `BEGIN … COMMIT` body, are refused for the same reason. Both refusals are new in v2.3.0; on v2.2.x these statements were accepted.

**What changed:**

- Corrected the Step 2 parenthetical: the primary key is what lets `UPDATE` replicate and lets write-back address rows by key, and it must be single-column.
- Added a "What write-back refuses" section covering both refusals, quoting the runtime's own error and its documented recovery path for deleting at the source, with a version note that this is `v2.3.0+` behavior.
- Noted why the recipe's own datasets are already compliant — `mode: file`, a single-column `primary_key`, no retention settings, and every write submitted as one `BEGIN; … COMMIT;` request.

The recipe's config and every SQL example already satisfy the new rules, so the walkthrough itself still runs as written. Only the `DELETE` claim was wrong.

## Verified against

spiceai/spiceai at `v2.3.0`:

- [`crates/runtime-table/src/accelerated/write/write_back.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime-table/src/accelerated/write/write_back.rs) — module doc: "Writes outside a transaction, and `DELETE` in any form, are refused"; `delete_not_supported` carries the quoted message, and `delete_on_a_write_back_dataset_is_refused` / `an_update_outside_a_transaction_is_refused` assert both.
- [`crates/runtime-table/src/accelerated/mod.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime-table/src/accelerated/mod.rs) — `TRUNCATE is not supported for write_back or dual_write accelerated tables`.

Version boundary: `git grep -c delete_not_supported v2.2.1 -- 'crates/*'` and the same for `write_requires_transaction` return nothing, so both helpers land in v2.3.0. `write_back` itself is present at v2.2.0, so the recipe's `Works with v2.2+` floor stays correct.

## Evidence

Static review only — this recipe needs Docker and a PostgreSQL instance with logical replication, which this environment does not have. The finding rests on the v2.3.0 source above, including the upstream unit tests that assert each refusal, plus the release notes' own Breaking Changes entry ("Write-back datasets reject `DELETE` and `TRUNCATE` when you issue those statements").