### PR TITLE
Fix github recipe: stop pinning github_max_comments_fetched at the cap

### DIFF
--- a/github/spicepod.yaml
+++ b/github/spicepod.yaml
@@ -27,7 +27,10 @@ datasets:
       github_query_mode: search
       github_token: ${secrets:GITHUB_TOKEN}
       github_include_comments: all
-      github_max_comments_fetched: 75 # 75 is the maximum; higher values are clamped
+      # github_max_comments_fetched defaults to 25 and is capped at 75. Leave it
+      # unset: on a repository this size, pinning the cap pushes the GraphQL
+      # query past GitHub's per-request budget, so the first refresh of this
+      # dataset takes several minutes or fails outright and has to retry.
     time_column: updated_at
     acceleration:
       enabled: true


### PR DESCRIPTION
## Summary

**The recipe said:** `github/spicepod.yaml` pins `github_max_comments_fetched: 75 # 75 is the maximum; higher values are clamped` on the `spiceai.pulls` dataset.

**What the code does:** v2.3.0 lowered the connector's default from 75 to 25, specifically "to keep the GitHub GraphQL node count well under the 500,000 node hard limit for queries that enable `include_comments` (each PR page multiplies this by up to 20 review threads)" — `DEFAULT_MAX_COMMENTS_FETCHED`, `crates/data-connectors/connector-github/src/lib.rs`. 75 is still the hard cap (`MAX_COMMENTS_FETCHED`), so the recipe pins the query at exactly the shape the new default moves away from. v2.3.0 also narrowed the pull-request page to 25 for the same reason.

**What changed:** removed the override so the runtime default applies, with a comment saying why so it does not get re-raised. This supersedes the cap-at-75 change in #580, which was correct against v2.2.x defaults.

## Verified against

spiceai/spiceai at `v2.3.0` — [`crates/data-connectors/connector-github/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/data-connectors/connector-github/src/lib.rs) (`DEFAULT_MAX_COMMENTS_FETCHED = 25`, `MAX_COMMENTS_FETCHED = 75`) and [`crates/data-connectors/connector-github/src/pull_requests.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/data-connectors/connector-github/src/pull_requests.rs) (`COMMENTS_PAGE_SIZE = 25`, `REVIEW_THREADS_PER_PR = 20`).

## Evidence

**Reproduced.** Runtime `v2.3.0+models.metal`, source `github.com/spiceai/spiceai`, same `refresh_data_window: 7d`, same `github_include_comments: all`. All three runs loaded the identical **172 rows (8.90 MiB)** — the larger comment budget buys no extra pull requests here.

### Reproduction

**Before — the recipe as shipped (`75`), full `github/spicepod.yaml`:** the first refresh fails and the dataset is unqueryable for ~11½ minutes.

```console
2026-09-11T12:04:34.390734Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.pulls
2026-09-11T12:09:42.572810Z  WARN runtime_table::accelerated::refresh_task: Failed to load data for dataset spiceai.pulls (github): Failed to fetch data from the data connector: External error: Execution error: The upstream server returned an error (HTTP 200 OK). The response could not be parsed as JSON. Technical details: EOF while parsing a value at line 1 column 0. Ensure the dataset source path and connector configuration are valid, and try again.
2026-09-11T12:09:43.859091Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.pulls
2026-09-11T12:16:05.302126Z  INFO runtime_table::accelerated::refresh_task: Loaded 172 rows (8.90 MiB) for dataset spiceai.pulls in 6m 21s 443ms.
```

While that is happening, the README's two `spiceai.pulls` queries in Step 3 do not work:

```console
$ spice sql --query "select count(*) from spiceai.pulls;"
Query Error: Acceleration not ready; loading initial data for spiceai.pulls
```

The empty 200 body is the failure mode the v2.3.0 release notes describe for an oversized pull-request page.

**Control — `75` on the `pulls` dataset alone**, to rule out contention with the recipe's five other GitHub datasets. No outright failure, but still slow:

```console
2026-09-11T12:17:44.435959Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.pulls
2026-09-11T12:23:18.711029Z  INFO runtime_table::accelerated::refresh_task: Loaded 172 rows (8.90 MiB) for dataset spiceai.pulls in 5m 34s 275ms.
```

**After — this change (override removed, default 25):**

```console
2026-09-11T12:12:58.605404Z  INFO runtime_table::accelerated::refresh_task: Loading data for dataset spiceai.pulls
2026-09-11T12:14:52.802178Z  INFO runtime_table::accelerated::refresh_task: Loaded 172 rows (8.90 MiB) for dataset spiceai.pulls in 1m 54s 196ms.
```

Both README `spiceai.pulls` queries then run against the fixed config — here is the second one and what it printed:

```console
$ spice sql --query "select number, title, state, merged_at from spiceai.pulls where state = 'MERGED' order by merged_at desc limit 5;"
+--------+-----------------------------------------------------------------------------------------------------+---------+---------------------+
| number |                                                title                                                |  state  |      merged_at      |
|  int64 |                                               varchar                                               | varchar |    timestamp[ms]    |
+--------+-----------------------------------------------------------------------------------------------------+---------+---------------------+
| 14031  | endgame: include spiceai/skills versioned release                                                   | MERGED  | 2026-09-11T05:46:52 |
| 14021  | fix(caching): partition doomed entries at the survivor cutoff so eviction converges (closes #13994) | MERGED  | 2026-09-11T05:46:52 |
| 14035  | perf(vortex): defer projection setup on filtered scans until the filter resolves                    | MERGED  | 2026-09-11T05:05:28 |
| 13996  | test(forks): guard seven fork patches that had no repo-side test                                    | MERGED  | 2026-09-10T20:46:24 |
| 14009  | Reduce Cayenne allocations during primary-key validation and filtering                              | MERGED  | 2026-09-10T20:46:24 |
+--------+-----------------------------------------------------------------------------------------------------+---------+---------------------+

Time: 0.006892375 seconds. 5 rows.
```

The `UNNEST(review_comments)` query in Step 3 also still returns a row on the default budget, so nothing the README demonstrates depends on the 75 override (body truncated here for length):

```console
$ spice sql --query "WITH review_comments AS (SELECT number, UNNEST(review_comments) AS comment FROM spiceai.pulls) SELECT comment.author, comment.created_at, comment.body FROM review_comments LIMIT 1;"
+---------------------------------+-------------------------------------+-----------------------------------+
| review_comments.comment[author] | review_comments.comment[created_at] | review_comments.comment[body]     |
|             varchar             |            timestamp[ms]            |              varchar              |
+---------------------------------+-------------------------------------+-----------------------------------+
| copilot-pull-request-reviewer   | 2026-09-11T00:53:42                 | Advertising `2026-07-28` commits… |
+---------------------------------+-------------------------------------+-----------------------------------+

Time: 0.015719417 seconds. 1 rows.
```

**Scope note:** the outright refresh failure was seen once, in the full-recipe run where five other GitHub datasets share the token — *observed, not isolated* as to cause. The 3×–6× slowdown reproduced in both `75` runs and is what this change fixes.
