### PR TITLE
Fix mcp-server: a startup log line the runtime never prints, and a jira block that was never shipped

### DIFF
--- a/mcp-server/.env.example
+++ b/mcp-server/.env.example
@@ -3,7 +3,7 @@
 # Used by both the GitHub dataset connector and the GitHub MCP server (via env: in spicepod.yaml).
 GITHUB_PERSONAL_ACCESS_TOKEN=ghp_...
 
-# Optional: Jira and Confluence (uncomment tools.jira in spicepod.yaml to use)
+# Optional: Jira and Confluence (add a tools.jira block to spicepod.yaml to use)
 # JIRA_URL=https://your-org.atlassian.net
 # JIRA_USERNAME=your@email.com
 # JIRA_API_TOKEN=...

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -38,7 +38,7 @@ Your AI assistant gets one connection point that gives it:
 
 > **Tool naming (Spice `v2.2+`):** Proxied tools are exposed as `<tool-name>__<upstream-tool-name>`, joined by a **double underscore** — `github__search_code`, not `github/search_code`. MCP clients such as Claude and Cursor reject tool names outside `^[a-zA-Z0-9_-]{1,64}$`, and the previous `/` separator made every proxied tool unusable in those clients ([spiceai/spiceai#10894](https://github.com/spiceai/spiceai/issues/10894)). The `<tool-name>` half is the `name` given in the `tools` section of `spicepod.yaml`, so renaming the tool renames every tool it proxies. On `v2.1.x` and earlier, substitute `/` for `__` throughout this recipe.
 
-> **Want to add Jira?** Uncomment the `jira` tool block in `spicepod.yaml` and add your Jira credentials to `.env`. See [Adding Jira](#optional-adding-jira) below.
+> **Want to add Jira?** Add a `jira` tool block to `spicepod.yaml` and add your Jira credentials to `.env`. See [Adding Jira](#optional-adding-jira) below.
 
 ## Prerequisites
 
@@ -78,12 +78,20 @@ spice run
 Spice loads GitHub data into memory and launches the GitHub MCP server subprocess. Expect the initial load to take 20–60 seconds.
 
 ```console
-2025-05-21T10:00:01Z  INFO runtime: Spice runtime is ready
-2025-05-21T10:00:01Z  INFO runtime::init::dataset: Dataset github_issues registered (github:...), acceleration (arrow)
-2025-05-21T10:00:01Z  INFO runtime::init::dataset: Dataset github_pulls registered (github:...), acceleration (arrow)
-2025-05-21T10:00:01Z  INFO runtime::init::dataset: Dataset github_commits registered (github:...), acceleration (arrow)
-2025-05-21T10:00:01Z  INFO runtime::init::tool: Tool github registered (mcp:npx)
+2026-09-12T12:04:46.677499Z  INFO spiced: Starting runtime v2.3.0+models.metal
+2026-09-12T12:04:46.999770Z  INFO runtime::http::routes: Enabled API key authentication on HTTP routes
+2026-09-12T12:04:47.000953Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
+GitHub MCP Server running on stdio
+2026-09-12T12:04:48.422999Z  INFO runtime::init::dataset: Dataset github_issues registered (github:github.com/spiceai/cookbook/issues), acceleration (arrow, 300s refresh), results cache enabled. duration_ms=4
+2026-09-12T12:04:49.065134Z  INFO runtime_table::accelerated::refresh_task: Loaded 4 rows (1.53 MiB) for dataset github_issues in 640ms.
+2026-09-12T12:04:50.436538Z  INFO runtime::init::dataset: Dataset github_pulls registered (github:github.com/spiceai/cookbook/pulls), acceleration (arrow, 300s refresh), results cache enabled. duration_ms=0
+2026-09-12T12:04:50.660468Z  INFO runtime::init::dataset: Dataset github_commits registered (github:github.com/spiceai/cookbook/commits), acceleration (arrow), results cache enabled. duration_ms=6
+2026-09-12T12:05:08.156863Z  INFO runtime_table::accelerated::refresh_task: Loaded 500 rows (1.51 MiB) for dataset github_commits in 17s 494ms.
+2026-09-12T12:05:09.750891Z  INFO runtime_table::accelerated::refresh_task: Loaded 69 rows (7.37 MiB) for dataset github_pulls in 19s 312ms.
+2026-09-12T12:05:09.757459Z  INFO runtime: All components are loaded. Spice runtime is ready!
 ```
+
+The GitHub MCP server subprocess announces itself on stdout (`GitHub MCP Server running on stdio`); tool loading itself is logged at `DEBUG`, so no `Tool github registered` line appears at the default log level.
 
 **Step 4.** Confirm the unified tool catalog is available (in a new terminal):
 
@@ -128,7 +136,9 @@ claude mcp list
 ```
 
 ```
-spice: http://localhost:8090/v1/mcp (http)
+Checking MCP server health…
+
+spice: http://localhost:8090/v1/mcp (HTTP) - ✔ Connected
 ```
 
 Claude Code will now have access to the full Spice tool catalog — `sql`, `github__*`, `list_datasets`, and the rest — in every conversation.
@@ -203,7 +213,7 @@ JIRA_USERNAME=your@email.com
 JIRA_API_TOKEN=...
 ```
 
-Uncomment the `jira` tool block in `spicepod.yaml`:
+Add a `jira` tool block to the `tools` section of `spicepod.yaml`:
 
 ```yaml
   - name: jira


### PR DESCRIPTION
## Summary

Ran the recipe end-to-end against Spice **v2.3.0** with a real GitHub token. It works — the datasets load, `/v1/tools` returns the unified catalog, `/v1/tools/sql` and `github__search_code` both answer, and `/v1/mcp` speaks MCP. Three things the README says, however, are not true:

1. **A log line the runtime never prints.** Step 3's expected output ends with
   `INFO runtime::init::tool: Tool github registered (mcp:npx)`. No such line exists at any level: tool loading logs at `DEBUG` (`tracing::debug!("Loading tool [{}] from {}...")`), and nothing in `runtime::init::tool` emits at `INFO` except `Exposed tool as SQL function`, which needs `as_sql: true`. A reader who waits for that line waits forever. The visible sign that the subprocess started is the MCP server's own stdout line, `GitHub MCP Server running on stdio`.

   The rest of the block was stale too — it put `Spice runtime is ready` *first* (it is the last line), used the pre-v2 wording, and omitted the `Loaded N rows` lines that account for the "20–60 seconds" the prose warns about. Replaced with the real transcript.

2. **`claude mcp list` output.** The README shows a bare `spice: http://localhost:8090/v1/mcp (http)`. Claude Code now runs a health check and prints the transport in caps with a connection status.

3. **A `jira` tool block that was never shipped.** Three places — the intro note, the "Optional: Adding Jira" section, and `.env.example` — tell the reader to *uncomment* `tools.jira` in `spicepod.yaml`. That file has no jira block, commented or otherwise (59 lines, unchanged since it was added in #400). The README already supplies the YAML, so the instruction is now "add a `jira` tool block". The alternative fix — shipping the block commented-out in `spicepod.yaml` — would also work; happy to switch if reviewers prefer that.

## Verified against

spiceai/spiceai at `v2.3.0` — [`crates/runtime/src/init/tool.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/init/tool.rs) (line 37 `tracing::debug!`, line 133 the only `info!` in the module).

## Evidence

### Reproduction

**Reproduced.** Full `spice run` output at INFO from this recipe on v2.3.0 — note the absence of any `Tool ... registered` line, and that `runtime is ready` is last:

```console
2026-09-12T12:04:46.677499Z  INFO spiced: Starting runtime v2.3.0+models.metal
2026-09-12T12:04:47.000953Z  INFO runtime::http: Spice Runtime HTTP listening on 127.0.0.1:8090
GitHub MCP Server running on stdio
2026-09-12T12:04:48.422999Z  INFO runtime::init::dataset: Dataset github_issues registered (github:github.com/spiceai/cookbook/issues), acceleration (arrow, 300s refresh), results cache enabled. duration_ms=4
2026-09-12T12:05:08.156863Z  INFO runtime_table::accelerated::refresh_task: Loaded 500 rows (1.51 MiB) for dataset github_commits in 17s 494ms.
2026-09-12T12:05:09.750891Z  INFO runtime_table::accelerated::refresh_task: Loaded 69 rows (7.37 MiB) for dataset github_pulls in 19s 312ms.
2026-09-12T12:05:09.757459Z  INFO runtime: All components are loaded. Spice runtime is ready!
```

```console
$ grep -ic "tool" spice-run.log
0
```

**Doc said** (README.md:85) `INFO runtime::init::tool: Tool github registered (mcp:npx)`
**Code says** (`crates/runtime/src/init/tool.rs:37` @ v2.3.0) `tracing::debug!("Loading tool [{}] from {}...", tool.name, tool.from);`

`claude mcp list`, before/after — run against this recipe's live endpoint:

```console
$ claude mcp add --transport http spice http://localhost:8090/v1/mcp --header "X-API-KEY: foo"
Added HTTP MCP server spice with URL: http://localhost:8090/v1/mcp to local config
$ claude mcp list
Checking MCP server health…

spice: http://localhost:8090/v1/mcp (HTTP) - ✔ Connected
```

The jira claim is an existence check, settled by the file:

```console
$ grep -ci jira mcp-server/spicepod.yaml
0
```

Everything else in the recipe reproduced as written and is unchanged: `/v1/tools` returned all 10 built-ins plus 26 `github__*` tools, `/v1/tools/sql` answered all three example queries, `github__search_code` returned 25 hits for `java repo:spiceai/cookbook`, an unauthenticated `/v1/tools` returned `401`, and `/v1/mcp` returned `"serverInfo":{"name":"Spice.ai Open Source","version":"2.3.0"}`.
