### PR TITLE
Fix azure_openai and models/openai: explain the file_format WARN on the GitHub datasets

### DIFF
--- a/azure_openai/README.md
+++ b/azure_openai/README.md
@@ -63,6 +63,13 @@ models:
 spice run
 ```
 
+At startup the runtime logs `WARN runtime_parameters: Ignoring parameter
+'file_format': not supported for connector github.` — this is expected and
+harmless. The GitHub connector has no `file_format` parameter, but the chunker
+reads the dataset's `file_format` directly and uses it to pick the Markdown-aware
+splitter, which is what the setting is for here. Removing it falls back to the
+plain text splitter.
+
 Wait for the datasets to finish loading, then check their sizes in `spice sql`:
 
 ```sql

--- a/models/openai/README.md
+++ b/models/openai/README.md
@@ -77,6 +77,13 @@ Result:
 2025-01-20T16:19:49.394003Z  INFO runtime_table::accelerated::refresh_task: Loaded 93 rows (1.28 MiB) for dataset spiceai.docs in 3s 228ms.
 ```
 
+At startup the runtime logs `WARN runtime_parameters: Ignoring parameter
+'file_format': not supported for connector github.` — this is expected and
+harmless. The GitHub connector has no `file_format` parameter, but the chunker
+reads the dataset's `file_format` directly and uses it to pick the Markdown-aware
+splitter, which is what the setting is for here. Removing it falls back to the
+plain text splitter.
+
 ## SQL Search
 
 1. Execute a Basic SQL Query to perform keyword searches within the dataset:


### PR DESCRIPTION
## Summary

`azure_openai/spicepod.yaml` and `models/openai/spicepod.yaml` both set `file_format: md` on a `github:…/files/trunk` dataset. The GitHub connector has no `file_format` parameter, so on every refresh v2.3.0 logs:

```
WARN runtime_parameters: Ignoring parameter `file_format`: not supported for connector github.
```

Neither README mentions it, and "Ignoring parameter … not supported" reads like a config mistake. It isn't one — but deleting the key to silence it silently downgrades chunking quality, because the embeddings path reads `file_format` off the dataset params directly, bypassing the connector's `ParameterSpec`, and the chunker uses it to choose the Markdown splitter.

`search_github_files` already documents exactly this (#638). This adds the same note to the two recipes that have the same config and don't.

Config unchanged in both recipes — `file_format: md` is correct and should stay.

## Verified against

spiceai/spiceai at `v2.3.0`:

- [`crates/data-connectors/connector-github/src/lib.rs`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/data-connectors/connector-github/src/lib.rs) — the connector's `ParameterSpec` list (lines 801–837) has `token`, `client_id`, `private_key`, `installation_id`, `query_mode`, `endpoint`, `include_comments`, `max_comments_fetched`, `include_commits`, `workflow_logs`, `max_concurrent_requests`, `include`. No `file_format`, at any tag from `v1.11.6` through `v2.3.0`.
- [`crates/runtime/src/embeddings/connector.rs:138`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/runtime/src/embeddings/connector.rs#L138) — `dataset.params.get("file_format")`, passed to the chunker.
- [`crates/chunking/src/lib.rs:127`](https://github.com/spiceai/spiceai/blob/v2.3.0/crates/chunking/src/lib.rs#L127) — `Some("md" | ".md" | "mdx" | ".mdx") => Splitter::Markdown(...)`, everything else `Splitter::Text`.

## Evidence

### Reproduction

**Reproduced.** Ran each recipe's shipped spicepod under `spiced` v2.3.0 on base (`5d7011b`) — no edits, no secrets — and grepped the startup log. Both emit the warning; no other spicepod in the repository does:

```console
$ git rev-parse --short HEAD
5d7011b
$ grep -c "Ignoring parameter" podsweep/azure_openai.log podsweep/models__openai.log
podsweep/azure_openai.log:8
podsweep/models__openai.log:11

$ grep -h "Ignoring parameter" podsweep/*.log | sed 's/.*WARN //' | sort | uniq -c
  19 runtime_parameters: Ignoring parameter `file_format`: not supported for connector github.
$ grep -l "Ignoring parameter" podsweep/*.log
podsweep/azure_openai.log
podsweep/models__openai.log
```

(That sweep ran all 97 spicepods in the repository for 7s each; these two are the only `Ignoring parameter` hits, and there were no `deprecated` hits at all.)

**Doc said** — on base `5d7011b`, neither README mentions the warning at all:

```console
$ git rev-parse --short HEAD
5d7011b
$ grep -c "Ignoring parameter" azure_openai/README.md models/openai/README.md
azure_openai/README.md:0
models/openai/README.md:0
```

**Branch says** — the same grep on this branch, so the warning a reader sees at startup is now in the text they are reading:

```console
$ grep -c "Ignoring parameter" azure_openai/README.md models/openai/README.md
azure_openai/README.md:1
models/openai/README.md:1
```

The claim that the key still does work is **unverified by a run** — exercising the Markdown splitter needs an Azure/OpenAI embeddings key this run did not have. It rests on source inspection only: `crates/runtime/src/embeddings/connector.rs:138` reads `dataset.params.get("file_format")` and `crates/chunking/src/lib.rs:127` branches on it to `Splitter::Markdown`, both at `v2.3.0`.
