### PR TITLE
Fix two README lines: a link that swallows the next word, and a stale 'current stable'

### DIFF
--- a/mongodb/connector/README.md
+++ b/mongodb/connector/README.md
@@ -6,7 +6,7 @@ This recipe will use a demo instance of MongoDB with a generated dataset. Follow
 
 ## Prerequisites
 
-- [Docker](https://docs.docker.com/get-docker/)is installed
+- [Docker](https://docs.docker.com/get-docker/) is installed
 - Spice is installed (see the [Getting Started](https://docs.spiceai.org/getting-started) documentation).
 
 ## Steps

--- a/websearch/README.md
+++ b/websearch/README.md
@@ -2,7 +2,7 @@
 
 Deprecated in `v2.0+`. Works with `v1.0+`
 
-> **Note:** This recipe relies on the built-in `websearch` tool with the Perplexity engine. Perplexity support — both the model provider and the `websearch` tool — was removed in Spice `v2.0`, so this recipe only runs against `v1.x` releases (e.g. the current stable `v1.11.6`).
+> **Note:** This recipe relies on the built-in `websearch` tool with the Perplexity engine. Perplexity support — both the model provider and the `websearch` tool — was removed in Spice `v2.0`, so this recipe only runs against `v1.x` releases — the last of which is `v1.11.6`.
 
 This recipe demonstrates how to configure and use Perplexity web search within Spice AI.
 


### PR DESCRIPTION
## Summary

Two unrelated one-line README inaccuracies, found by mechanical sweeps over the whole repository.

**`mongodb/connector/README.md:9`** — the Docker prerequisite has no space between the link and the following word, so Markdown renders it as *"Dockeris installed"*. It is the only occurrence in the repository.

**`websearch/README.md:5`** — the deprecation note says this recipe runs only on `v1.x` *"(e.g. the current stable `v1.11.6`)"*. Current stable is `v2.3.0`; `v1.11.6` is the last `v1.x` release, which is what the sentence is trying to say. Reworded, no change to the recipe's substance — the removal of Perplexity support in v2.0 is correct and unchanged.

## Verified against

Current stable: `gh release view -R spiceai/spiceai` → `v2.3.0`, published 2026-09-09, `isPrerelease: false`.

## Evidence

### Reproduction

**Reproduced.** Both are text-level claims, settled by the files on base (`5d7011b`) and by the release list.

```console
$ git rev-parse --short HEAD
5d7011b
$ grep -rnE '\)[A-Za-z]' --include="*.md" . | grep -E 'https?://[^)]*\)[A-Za-z]'
mongodb/connector/README.md:9:- [Docker](https://docs.docker.com/get-docker/)is installed
```

On this branch the same sweep finds nothing:

```console
$ grep -rnE '\)[A-Za-z]' --include="*.md" . | grep -E 'https?://[^)]*\)[A-Za-z]' | wc -l
0
```

**Doc said** (websearch/README.md:5 on base) — "the current stable `v1.11.6`".
**Code says** — the release API, read today:

```console
$ gh release view -R spiceai/spiceai --json tagName,isPrerelease,publishedAt
{"isPrerelease":false,"publishedAt":"2026-09-09T21:53:58Z","tagName":"v2.3.0"}
```

**Branch says** — "`v1.x` releases — the last of which is `v1.11.6`."

Neither recipe was run: `mongodb/connector` needs Docker (**not run — no Docker in this environment**) and `websearch` needs a Perplexity token and a v1.x runtime (**not run — the feature is removed from stable**). Neither change touches anything a run would exercise.
